### PR TITLE
fix: typo and rename "expire" -> "expire_secs"

### DIFF
--- a/proto/greptime/v1/meta/lock.proto
+++ b/proto/greptime/v1/meta/lock.proto
@@ -20,8 +20,8 @@ message LockRequest {
   bytes name = 2;
 
   // If the expiration time is exceeded and currently holds the lock, the lock is
-  // aytomatically released. The unit is second.
-  int64 expire = 3;
+  // automatically released.
+  int64 expire_secs = 3;
 }
 
 message LockResponse {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly change:
1. fix typo.
2. rename "expire" -> "expire_secs".


## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/961