### PR TITLE
feat: add gRPC reflection service

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
+
 fn main() {
+    let out_dir = PathBuf::from(
+        std::env::var("OUT_DIR")
+            .expect("cargo built-in env value 'OUT_DIR' must be set during compilation"),
+    );
+
     tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("greptime_grpc_desc.bin"))
         .compile(
             &[
                 "proto/greptime/v1/database.proto",

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -14,4 +14,6 @@
 
 tonic::include_proto!("greptime.v1");
 
+pub const GREPTIME_GRPC_DESC: &[u8] = tonic::include_file_descriptor_set!("greptime_grpc_desc");
+
 pub mod meta;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

Add gRPC server reflection, suitable for debugging and illustrating purpose.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
