### PR TITLE
chore: add `gen_set_header` for `BatchDeleteRequest`

### DIFF
--- a/src/v1/meta.rs
+++ b/src/v1/meta.rs
@@ -149,6 +149,7 @@ gen_set_header!(DeleteRequest);
 gen_set_header!(PutRequest);
 gen_set_header!(BatchGetRequest);
 gen_set_header!(BatchPutRequest);
+gen_set_header!(BatchDeleteRequest);
 gen_set_header!(CompareAndPutRequest);
 gen_set_header!(DeleteRangeRequest);
 gen_set_header!(MoveValueRequest);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `gen_set_header` for `BatchDeleteRequest` 😂

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
