### PR TITLE
fix: set header for meta structs

### DIFF
--- a/src/v1/meta.rs
+++ b/src/v1/meta.rs
@@ -130,13 +130,20 @@ impl HeartbeatResponse {
         false
     }
 }
-
 macro_rules! gen_set_header {
     ($req: ty) => {
         impl $req {
             #[inline]
             pub fn set_header(&mut self, (cluster_id, member_id): (u64, u64)) {
-                self.header = Some(RequestHeader::new((cluster_id, member_id)));
+                match self.header.as_mut() {
+                    Some(header) => {
+                        header.cluster_id = cluster_id;
+                        header.member_id = member_id;
+                    }
+                    None => {
+                        self.header = Some(RequestHeader::new((cluster_id, member_id)));
+                    }
+                }
             }
         }
     };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

I had a problem with greptimedb:
When I set the header in the code, it will be overwritten in the meta client.

This pr mainly fix this problem.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
