### PR TITLE
chore: rename RegionServer to Region

### DIFF
--- a/c++/greptime/v1/region/server.grpc.pb.cc
+++ b/c++/greptime/v1/region/server.grpc.pb.cc
@@ -23,49 +23,49 @@ namespace greptime {
 namespace v1 {
 namespace region {
 
-static const char* RegionServer_method_names[] = {
-  "/greptime.v1.region.RegionServer/Handle",
+static const char* Region_method_names[] = {
+  "/greptime.v1.region.Region/Handle",
 };
 
-std::unique_ptr< RegionServer::Stub> RegionServer::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
+std::unique_ptr< Region::Stub> Region::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
   (void)options;
-  std::unique_ptr< RegionServer::Stub> stub(new RegionServer::Stub(channel, options));
+  std::unique_ptr< Region::Stub> stub(new Region::Stub(channel, options));
   return stub;
 }
 
-RegionServer::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
-  : channel_(channel), rpcmethod_Handle_(RegionServer_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+Region::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
+  : channel_(channel), rpcmethod_Handle_(Region_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::Status RegionServer::Stub::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::greptime::v1::region::RegionResponse* response) {
+::grpc::Status Region::Stub::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::greptime::v1::region::RegionResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::greptime::v1::region::RegionRequest, ::greptime::v1::region::RegionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_Handle_, context, request, response);
 }
 
-void RegionServer::Stub::async::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, std::function<void(::grpc::Status)> f) {
+void Region::Stub::async::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, std::function<void(::grpc::Status)> f) {
   ::grpc::internal::CallbackUnaryCall< ::greptime::v1::region::RegionRequest, ::greptime::v1::region::RegionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Handle_, context, request, response, std::move(f));
 }
 
-void RegionServer::Stub::async::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+void Region::Stub::async::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientUnaryReactor* reactor) {
   ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_Handle_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>* RegionServer::Stub::PrepareAsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>* Region::Stub::PrepareAsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::greptime::v1::region::RegionResponse, ::greptime::v1::region::RegionRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_Handle_, context, request);
 }
 
-::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>* RegionServer::Stub::AsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>* Region::Stub::AsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncHandleRaw(context, request, cq);
   result->StartCall();
   return result;
 }
 
-RegionServer::Service::Service() {
+Region::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      RegionServer_method_names[0],
+      Region_method_names[0],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< RegionServer::Service, ::greptime::v1::region::RegionRequest, ::greptime::v1::region::RegionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
-          [](RegionServer::Service* service,
+      new ::grpc::internal::RpcMethodHandler< Region::Service, ::greptime::v1::region::RegionRequest, ::greptime::v1::region::RegionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](Region::Service* service,
              ::grpc::ServerContext* ctx,
              const ::greptime::v1::region::RegionRequest* req,
              ::greptime::v1::region::RegionResponse* resp) {
@@ -73,10 +73,10 @@ RegionServer::Service::Service() {
              }, this)));
 }
 
-RegionServer::Service::~Service() {
+Region::Service::~Service() {
 }
 
-::grpc::Status RegionServer::Service::Handle(::grpc::ServerContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response) {
+::grpc::Status Region::Service::Handle(::grpc::ServerContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/c++/greptime/v1/region/server.grpc.pb.cc
+++ b/c++/greptime/v1/region/server.grpc.pb.cc
@@ -25,6 +25,7 @@ namespace region {
 
 static const char* Region_method_names[] = {
   "/greptime.v1.region.Region/Handle",
+  "/greptime.v1.region.Region/HandleRequests",
 };
 
 std::unique_ptr< Region::Stub> Region::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -35,6 +36,7 @@ std::unique_ptr< Region::Stub> Region::NewStub(const std::shared_ptr< ::grpc::Ch
 
 Region::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
   : channel_(channel), rpcmethod_Handle_(Region_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_HandleRequests_(Region_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::CLIENT_STREAMING, channel)
   {}
 
 ::grpc::Status Region::Stub::Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::greptime::v1::region::RegionResponse* response) {
@@ -60,6 +62,22 @@ void Region::Stub::async::Handle(::grpc::ClientContext* context, const ::greptim
   return result;
 }
 
+::grpc::ClientWriter< ::greptime::v1::region::RegionRequest>* Region::Stub::HandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response) {
+  return ::grpc::internal::ClientWriterFactory< ::greptime::v1::region::RegionRequest>::Create(channel_.get(), rpcmethod_HandleRequests_, context, response);
+}
+
+void Region::Stub::async::HandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientWriteReactor< ::greptime::v1::region::RegionRequest>* reactor) {
+  ::grpc::internal::ClientCallbackWriterFactory< ::greptime::v1::region::RegionRequest>::Create(stub_->channel_.get(), stub_->rpcmethod_HandleRequests_, context, response, reactor);
+}
+
+::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>* Region::Stub::AsyncHandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncWriterFactory< ::greptime::v1::region::RegionRequest>::Create(channel_.get(), cq, rpcmethod_HandleRequests_, context, response, true, tag);
+}
+
+::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>* Region::Stub::PrepareAsyncHandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncWriterFactory< ::greptime::v1::region::RegionRequest>::Create(channel_.get(), cq, rpcmethod_HandleRequests_, context, response, false, nullptr);
+}
+
 Region::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Region_method_names[0],
@@ -71,6 +89,16 @@ Region::Service::Service() {
              ::greptime::v1::region::RegionResponse* resp) {
                return service->Handle(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Region_method_names[1],
+      ::grpc::internal::RpcMethod::CLIENT_STREAMING,
+      new ::grpc::internal::ClientStreamingHandler< Region::Service, ::greptime::v1::region::RegionRequest, ::greptime::v1::region::RegionResponse>(
+          [](Region::Service* service,
+             ::grpc::ServerContext* ctx,
+             ::grpc::ServerReader<::greptime::v1::region::RegionRequest>* reader,
+             ::greptime::v1::region::RegionResponse* resp) {
+               return service->HandleRequests(ctx, reader, resp);
+             }, this)));
 }
 
 Region::Service::~Service() {
@@ -79,6 +107,13 @@ Region::Service::~Service() {
 ::grpc::Status Region::Service::Handle(::grpc::ServerContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response) {
   (void) context;
   (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Region::Service::HandleRequests(::grpc::ServerContext* context, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* reader, ::greptime::v1::region::RegionResponse* response) {
+  (void) context;
+  (void) reader;
   (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }

--- a/c++/greptime/v1/region/server.grpc.pb.h
+++ b/c++/greptime/v1/region/server.grpc.pb.h
@@ -44,10 +44,10 @@ namespace greptime {
 namespace v1 {
 namespace region {
 
-class RegionServer final {
+class Region final {
  public:
   static constexpr char const* service_full_name() {
-    return "greptime.v1.region.RegionServer";
+    return "greptime.v1.region.Region";
   }
   class StubInterface {
    public:

--- a/c++/greptime/v1/region/server.grpc.pb.h
+++ b/c++/greptime/v1/region/server.grpc.pb.h
@@ -59,13 +59,21 @@ class Region final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::region::RegionResponse>> PrepareAsyncHandle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::region::RegionResponse>>(PrepareAsyncHandleRaw(context, request, cq));
     }
-    // TODO: add stream API
+    std::unique_ptr< ::grpc::ClientWriterInterface< ::greptime::v1::region::RegionRequest>> HandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response) {
+      return std::unique_ptr< ::grpc::ClientWriterInterface< ::greptime::v1::region::RegionRequest>>(HandleRequestsRaw(context, response));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriterInterface< ::greptime::v1::region::RegionRequest>> AsyncHandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriterInterface< ::greptime::v1::region::RegionRequest>>(AsyncHandleRequestsRaw(context, response, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriterInterface< ::greptime::v1::region::RegionRequest>> PrepareAsyncHandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriterInterface< ::greptime::v1::region::RegionRequest>>(PrepareAsyncHandleRequestsRaw(context, response, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
       virtual void Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      // TODO: add stream API
+      virtual void HandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientWriteReactor< ::greptime::v1::region::RegionRequest>* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -73,6 +81,9 @@ class Region final {
    private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::region::RegionResponse>* AsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::region::RegionResponse>* PrepareAsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientWriterInterface< ::greptime::v1::region::RegionRequest>* HandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response) = 0;
+    virtual ::grpc::ClientAsyncWriterInterface< ::greptime::v1::region::RegionRequest>* AsyncHandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncWriterInterface< ::greptime::v1::region::RegionRequest>* PrepareAsyncHandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -84,11 +95,21 @@ class Region final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>> PrepareAsyncHandle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>>(PrepareAsyncHandleRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientWriter< ::greptime::v1::region::RegionRequest>> HandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response) {
+      return std::unique_ptr< ::grpc::ClientWriter< ::greptime::v1::region::RegionRequest>>(HandleRequestsRaw(context, response));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>> AsyncHandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>>(AsyncHandleRequestsRaw(context, response, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>> PrepareAsyncHandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>>(PrepareAsyncHandleRequestsRaw(context, response, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
       void Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, std::function<void(::grpc::Status)>) override;
       void Handle(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void HandleRequests(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::ClientWriteReactor< ::greptime::v1::region::RegionRequest>* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -102,7 +123,11 @@ class Region final {
     class async async_stub_{this};
     ::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>* AsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::greptime::v1::region::RegionResponse>* PrepareAsyncHandleRaw(::grpc::ClientContext* context, const ::greptime::v1::region::RegionRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientWriter< ::greptime::v1::region::RegionRequest>* HandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response) override;
+    ::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>* AsyncHandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncWriter< ::greptime::v1::region::RegionRequest>* PrepareAsyncHandleRequestsRaw(::grpc::ClientContext* context, ::greptime::v1::region::RegionResponse* response, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_Handle_;
+    const ::grpc::internal::RpcMethod rpcmethod_HandleRequests_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -111,7 +136,7 @@ class Region final {
     Service();
     virtual ~Service();
     virtual ::grpc::Status Handle(::grpc::ServerContext* context, const ::greptime::v1::region::RegionRequest* request, ::greptime::v1::region::RegionResponse* response);
-    // TODO: add stream API
+    virtual ::grpc::Status HandleRequests(::grpc::ServerContext* context, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* reader, ::greptime::v1::region::RegionResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_Handle : public BaseClass {
@@ -133,7 +158,27 @@ class Region final {
       ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Handle<Service > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_HandleRequests : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_HandleRequests() {
+      ::grpc::Service::MarkMethodAsync(1);
+    }
+    ~WithAsyncMethod_HandleRequests() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status HandleRequests(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* /*reader*/, ::greptime::v1::region::RegionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestHandleRequests(::grpc::ServerContext* context, ::grpc::ServerAsyncReader< ::greptime::v1::region::RegionResponse, ::greptime::v1::region::RegionRequest>* reader, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncClientStreaming(1, context, reader, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_Handle<WithAsyncMethod_HandleRequests<Service > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_Handle : public BaseClass {
    private:
@@ -161,7 +206,29 @@ class Region final {
     virtual ::grpc::ServerUnaryReactor* Handle(
       ::grpc::CallbackServerContext* /*context*/, const ::greptime::v1::region::RegionRequest* /*request*/, ::greptime::v1::region::RegionResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_Handle<Service > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_HandleRequests : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_HandleRequests() {
+      ::grpc::Service::MarkMethodCallback(1,
+          new ::grpc::internal::CallbackClientStreamingHandler< ::greptime::v1::region::RegionRequest, ::greptime::v1::region::RegionResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, ::greptime::v1::region::RegionResponse* response) { return this->HandleRequests(context, response); }));
+    }
+    ~WithCallbackMethod_HandleRequests() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status HandleRequests(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* /*reader*/, ::greptime::v1::region::RegionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerReadReactor< ::greptime::v1::region::RegionRequest>* HandleRequests(
+      ::grpc::CallbackServerContext* /*context*/, ::greptime::v1::region::RegionResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_Handle<WithCallbackMethod_HandleRequests<Service > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Handle : public BaseClass {
@@ -176,6 +243,23 @@ class Region final {
     }
     // disable synchronous version of this method
     ::grpc::Status Handle(::grpc::ServerContext* /*context*/, const ::greptime::v1::region::RegionRequest* /*request*/, ::greptime::v1::region::RegionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_HandleRequests : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_HandleRequests() {
+      ::grpc::Service::MarkMethodGeneric(1);
+    }
+    ~WithGenericMethod_HandleRequests() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status HandleRequests(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* /*reader*/, ::greptime::v1::region::RegionResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -201,6 +285,26 @@ class Region final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_HandleRequests : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_HandleRequests() {
+      ::grpc::Service::MarkMethodRaw(1);
+    }
+    ~WithRawMethod_HandleRequests() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status HandleRequests(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* /*reader*/, ::greptime::v1::region::RegionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestHandleRequests(::grpc::ServerContext* context, ::grpc::ServerAsyncReader< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* reader, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncClientStreaming(1, context, reader, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_Handle : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -221,6 +325,28 @@ class Region final {
     }
     virtual ::grpc::ServerUnaryReactor* Handle(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_HandleRequests : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_HandleRequests() {
+      ::grpc::Service::MarkMethodRawCallback(1,
+          new ::grpc::internal::CallbackClientStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, ::grpc::ByteBuffer* response) { return this->HandleRequests(context, response); }));
+    }
+    ~WithRawCallbackMethod_HandleRequests() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status HandleRequests(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< ::greptime::v1::region::RegionRequest>* /*reader*/, ::greptime::v1::region::RegionResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerReadReactor< ::grpc::ByteBuffer>* HandleRequests(
+      ::grpc::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_Handle : public BaseClass {

--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -26,7 +26,7 @@ namespace region {
 PROTOBUF_CONSTEXPR RegionRequest::RegionRequest(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.header_)*/nullptr
-  , /*decltype(_impl_.region_request_body_)*/{}
+  , /*decltype(_impl_.body_)*/{}
   , /*decltype(_impl_._cached_size_)*/{}
   , /*decltype(_impl_._oneof_case_)*/{}} {}
 struct RegionRequestDefaultTypeInternal {
@@ -285,7 +285,7 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ::_pbi::kInvalidFieldOffsetTag,
   ::_pbi::kInvalidFieldOffsetTag,
   ::_pbi::kInvalidFieldOffsetTag,
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _impl_.region_request_body_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _impl_.body_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -466,7 +466,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\037greptime/v1/region/server.proto\022\022grept"
   "ime.v1.region\032\030greptime/v1/common.proto\032"
-  "\025greptime/v1/row.proto\"\247\004\n\rRegionRequest"
+  "\025greptime/v1/row.proto\"\230\004\n\rRegionRequest"
   "\022*\n\006header\030\001 \001(\0132\032.greptime.v1.RequestHe"
   "ader\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regi"
   "on.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".g"
@@ -479,44 +479,46 @@ const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] P
   "alter\030\t \001(\0132 .greptime.v1.region.AlterRe"
   "questH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.reg"
   "ion.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gr"
-  "eptime.v1.region.CompactRequestH\000B\025\n\023reg"
-  "ion_request_body\"T\n\016RegionResponse\022+\n\006he"
-  "ader\030\001 \001(\0132\033.greptime.v1.ResponseHeader\022"
-  "\025\n\raffacted_rows\030\002 \001(\004\"E\n\016InsertRequests"
-  "\0223\n\010requests\030\001 \003(\0132!.greptime.v1.region."
-  "InsertRequest\"E\n\016DeleteRequests\0223\n\010reque"
-  "sts\030\001 \003(\0132!.greptime.v1.region.DeleteReq"
-  "uest\"B\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(\004"
-  "\022\036\n\004rows\030\002 \003(\0132\020.greptime.v1.Row\"B\n\rDele"
-  "teRequest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003"
-  "(\0132\020.greptime.v1.Row\"/\n\014QueryRequest\022\021\n\t"
-  "region_id\030\001 \001(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreate"
-  "Request\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001"
-  "(\t\0222\n\013column_defs\030\003 \003(\0132\035.greptime.v1.re"
-  "gion.ColumnDef\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024c"
-  "reate_if_not_exists\030\005 \001(\010\022\022\n\nregion_dir\030"
-  "\006 \001(\t\022\?\n\007options\030\007 \003(\0132..greptime.v1.reg"
-  "ion.CreateRequest.OptionsEntry\032.\n\014Option"
-  "sEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" "
-  "\n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013Ope"
-  "nRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 "
-  "\001(\t\022\022\n\nregion_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\013"
-  "2,.greptime.v1.region.OpenRequest.Option"
-  "sEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v"
-  "alue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion"
-  "_id\030\001 \001(\004\"!\n\014AlterRequest\022\021\n\tregion_id\030\001"
-  " \001(\004\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\""
-  "#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n"
-  "\tColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 "
-  "\001(\r\022-\n\010datatype\030\003 \001(\0162\033.greptime.v1.Colu"
-  "mnDataType\022\023\n\013is_nullable\030\004 \001(\010\022\032\n\022defau"
-  "lt_constraint\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001"
-  "(\0162\031.greptime.v1.SemanticType2Y\n\006Region\022"
-  "O\n\006Handle\022!.greptime.v1.region.RegionReq"
-  "uest\032\".greptime.v1.region.RegionResponse"
-  "B]\n\025io.greptime.v1.regionB\006ServerZ<githu"
-  "b.com/GreptimeTeam/greptime-proto/go/gre"
-  "ptime/v1/regionb\006proto3"
+  "eptime.v1.region.CompactRequestH\000B\006\n\004bod"
+  "y\"T\n\016RegionResponse\022+\n\006header\030\001 \001(\0132\033.gr"
+  "eptime.v1.ResponseHeader\022\025\n\raffacted_row"
+  "s\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requests\030\001 "
+  "\003(\0132!.greptime.v1.region.InsertRequest\"E"
+  "\n\016DeleteRequests\0223\n\010requests\030\001 \003(\0132!.gre"
+  "ptime.v1.region.DeleteRequest\"B\n\rInsertR"
+  "equest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003(\0132"
+  "\020.greptime.v1.Row\"B\n\rDeleteRequest\022\021\n\tre"
+  "gion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003(\0132\020.greptime.v"
+  "1.Row\"/\n\014QueryRequest\022\021\n\tregion_id\030\001 \001(\004"
+  "\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tregi"
+  "on_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column_de"
+  "fs\030\003 \003(\0132\035.greptime.v1.region.ColumnDef\022"
+  "\023\n\013primary_key\030\004 \003(\r\022\034\n\024create_if_not_ex"
+  "ists\030\005 \001(\010\022\022\n\nregion_dir\030\006 \001(\t\022\?\n\007option"
+  "s\030\007 \003(\0132..greptime.v1.region.CreateReque"
+  "st.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001"
+  " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021"
+  "\n\tregion_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\treg"
+  "ion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion_d"
+  "ir\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,.greptime.v1."
+  "region.OpenRequest.OptionsEntry\032.\n\014Optio"
+  "nsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\""
+  "!\n\014CloseRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014Al"
+  "terRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014FlushRe"
+  "quest\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactReque"
+  "st\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n\004n"
+  "ame\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010datatype"
+  "\030\003 \001(\0162\033.greptime.v1.ColumnDataType\022\023\n\013i"
+  "s_nullable\030\004 \001(\010\022\032\n\022default_constraint\030\005"
+  " \001(\014\0220\n\rsemantic_type\030\006 \001(\0162\031.greptime.v"
+  "1.SemanticType2\264\001\n\006Region\022O\n\006Handle\022!.gr"
+  "eptime.v1.region.RegionRequest\032\".greptim"
+  "e.v1.region.RegionResponse\022Y\n\016HandleRequ"
+  "ests\022!.greptime.v1.region.RegionRequest\032"
+  "\".greptime.v1.region.RegionResponse(\001B]\n"
+  "\025io.greptime.v1.regionB\006ServerZ<github.c"
+  "om/GreptimeTeam/greptime-proto/go/grepti"
+  "me/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[2] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -524,7 +526,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 2103, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 2180, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
     &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 2, 17,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
@@ -563,39 +565,39 @@ RegionRequest::_Internal::header(const RegionRequest* msg) {
 }
 const ::greptime::v1::region::InsertRequests&
 RegionRequest::_Internal::inserts(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.inserts_;
+  return *msg->_impl_.body_.inserts_;
 }
 const ::greptime::v1::region::DeleteRequests&
 RegionRequest::_Internal::deletes(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.deletes_;
+  return *msg->_impl_.body_.deletes_;
 }
 const ::greptime::v1::region::CreateRequest&
 RegionRequest::_Internal::create(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.create_;
+  return *msg->_impl_.body_.create_;
 }
 const ::greptime::v1::region::DropRequest&
 RegionRequest::_Internal::drop(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.drop_;
+  return *msg->_impl_.body_.drop_;
 }
 const ::greptime::v1::region::OpenRequest&
 RegionRequest::_Internal::open(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.open_;
+  return *msg->_impl_.body_.open_;
 }
 const ::greptime::v1::region::CloseRequest&
 RegionRequest::_Internal::close(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.close_;
+  return *msg->_impl_.body_.close_;
 }
 const ::greptime::v1::region::AlterRequest&
 RegionRequest::_Internal::alter(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.alter_;
+  return *msg->_impl_.body_.alter_;
 }
 const ::greptime::v1::region::FlushRequest&
 RegionRequest::_Internal::flush(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.flush_;
+  return *msg->_impl_.body_.flush_;
 }
 const ::greptime::v1::region::CompactRequest&
 RegionRequest::_Internal::compact(const RegionRequest* msg) {
-  return *msg->_impl_.region_request_body_.compact_;
+  return *msg->_impl_.body_.compact_;
 }
 void RegionRequest::clear_header() {
   if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
@@ -605,7 +607,7 @@ void RegionRequest::clear_header() {
 }
 void RegionRequest::set_allocated_inserts(::greptime::v1::region::InsertRequests* inserts) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (inserts) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(inserts);
@@ -614,13 +616,13 @@ void RegionRequest::set_allocated_inserts(::greptime::v1::region::InsertRequests
           message_arena, inserts, submessage_arena);
     }
     set_has_inserts();
-    _impl_.region_request_body_.inserts_ = inserts;
+    _impl_.body_.inserts_ = inserts;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.inserts)
 }
 void RegionRequest::set_allocated_deletes(::greptime::v1::region::DeleteRequests* deletes) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (deletes) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(deletes);
@@ -629,13 +631,13 @@ void RegionRequest::set_allocated_deletes(::greptime::v1::region::DeleteRequests
           message_arena, deletes, submessage_arena);
     }
     set_has_deletes();
-    _impl_.region_request_body_.deletes_ = deletes;
+    _impl_.body_.deletes_ = deletes;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.deletes)
 }
 void RegionRequest::set_allocated_create(::greptime::v1::region::CreateRequest* create) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (create) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(create);
@@ -644,13 +646,13 @@ void RegionRequest::set_allocated_create(::greptime::v1::region::CreateRequest* 
           message_arena, create, submessage_arena);
     }
     set_has_create();
-    _impl_.region_request_body_.create_ = create;
+    _impl_.body_.create_ = create;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.create)
 }
 void RegionRequest::set_allocated_drop(::greptime::v1::region::DropRequest* drop) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (drop) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(drop);
@@ -659,13 +661,13 @@ void RegionRequest::set_allocated_drop(::greptime::v1::region::DropRequest* drop
           message_arena, drop, submessage_arena);
     }
     set_has_drop();
-    _impl_.region_request_body_.drop_ = drop;
+    _impl_.body_.drop_ = drop;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.drop)
 }
 void RegionRequest::set_allocated_open(::greptime::v1::region::OpenRequest* open) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (open) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(open);
@@ -674,13 +676,13 @@ void RegionRequest::set_allocated_open(::greptime::v1::region::OpenRequest* open
           message_arena, open, submessage_arena);
     }
     set_has_open();
-    _impl_.region_request_body_.open_ = open;
+    _impl_.body_.open_ = open;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.open)
 }
 void RegionRequest::set_allocated_close(::greptime::v1::region::CloseRequest* close) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (close) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(close);
@@ -689,13 +691,13 @@ void RegionRequest::set_allocated_close(::greptime::v1::region::CloseRequest* cl
           message_arena, close, submessage_arena);
     }
     set_has_close();
-    _impl_.region_request_body_.close_ = close;
+    _impl_.body_.close_ = close;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.close)
 }
 void RegionRequest::set_allocated_alter(::greptime::v1::region::AlterRequest* alter) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (alter) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(alter);
@@ -704,13 +706,13 @@ void RegionRequest::set_allocated_alter(::greptime::v1::region::AlterRequest* al
           message_arena, alter, submessage_arena);
     }
     set_has_alter();
-    _impl_.region_request_body_.alter_ = alter;
+    _impl_.body_.alter_ = alter;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.alter)
 }
 void RegionRequest::set_allocated_flush(::greptime::v1::region::FlushRequest* flush) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (flush) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(flush);
@@ -719,13 +721,13 @@ void RegionRequest::set_allocated_flush(::greptime::v1::region::FlushRequest* fl
           message_arena, flush, submessage_arena);
     }
     set_has_flush();
-    _impl_.region_request_body_.flush_ = flush;
+    _impl_.body_.flush_ = flush;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.flush)
 }
 void RegionRequest::set_allocated_compact(::greptime::v1::region::CompactRequest* compact) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_region_request_body();
+  clear_body();
   if (compact) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(compact);
@@ -734,7 +736,7 @@ void RegionRequest::set_allocated_compact(::greptime::v1::region::CompactRequest
           message_arena, compact, submessage_arena);
     }
     set_has_compact();
-    _impl_.region_request_body_.compact_ = compact;
+    _impl_.body_.compact_ = compact;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.compact)
 }
@@ -749,7 +751,7 @@ RegionRequest::RegionRequest(const RegionRequest& from)
   RegionRequest* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.header_){nullptr}
-    , decltype(_impl_.region_request_body_){}
+    , decltype(_impl_.body_){}
     , /*decltype(_impl_._cached_size_)*/{}
     , /*decltype(_impl_._oneof_case_)*/{}};
 
@@ -757,8 +759,8 @@ RegionRequest::RegionRequest(const RegionRequest& from)
   if (from._internal_has_header()) {
     _this->_impl_.header_ = new ::greptime::v1::RequestHeader(*from._impl_.header_);
   }
-  clear_has_region_request_body();
-  switch (from.region_request_body_case()) {
+  clear_has_body();
+  switch (from.body_case()) {
     case kInserts: {
       _this->_internal_mutable_inserts()->::greptime::v1::region::InsertRequests::MergeFrom(
           from._internal_inserts());
@@ -804,7 +806,7 @@ RegionRequest::RegionRequest(const RegionRequest& from)
           from._internal_compact());
       break;
     }
-    case REGION_REQUEST_BODY_NOT_SET: {
+    case BODY_NOT_SET: {
       break;
     }
   }
@@ -817,11 +819,11 @@ inline void RegionRequest::SharedCtor(
   (void)is_message_owned;
   new (&_impl_) Impl_{
       decltype(_impl_.header_){nullptr}
-    , decltype(_impl_.region_request_body_){}
+    , decltype(_impl_.body_){}
     , /*decltype(_impl_._cached_size_)*/{}
     , /*decltype(_impl_._oneof_case_)*/{}
   };
-  clear_has_region_request_body();
+  clear_has_body();
 }
 
 RegionRequest::~RegionRequest() {
@@ -836,8 +838,8 @@ RegionRequest::~RegionRequest() {
 inline void RegionRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   if (this != internal_default_instance()) delete _impl_.header_;
-  if (has_region_request_body()) {
-    clear_region_request_body();
+  if (has_body()) {
+    clear_body();
   }
 }
 
@@ -845,68 +847,68 @@ void RegionRequest::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void RegionRequest::clear_region_request_body() {
+void RegionRequest::clear_body() {
 // @@protoc_insertion_point(one_of_clear_start:greptime.v1.region.RegionRequest)
-  switch (region_request_body_case()) {
+  switch (body_case()) {
     case kInserts: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.inserts_;
+        delete _impl_.body_.inserts_;
       }
       break;
     }
     case kDeletes: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.deletes_;
+        delete _impl_.body_.deletes_;
       }
       break;
     }
     case kCreate: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.create_;
+        delete _impl_.body_.create_;
       }
       break;
     }
     case kDrop: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.drop_;
+        delete _impl_.body_.drop_;
       }
       break;
     }
     case kOpen: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.open_;
+        delete _impl_.body_.open_;
       }
       break;
     }
     case kClose: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.close_;
+        delete _impl_.body_.close_;
       }
       break;
     }
     case kAlter: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.alter_;
+        delete _impl_.body_.alter_;
       }
       break;
     }
     case kFlush: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.flush_;
+        delete _impl_.body_.flush_;
       }
       break;
     }
     case kCompact: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.region_request_body_.compact_;
+        delete _impl_.body_.compact_;
       }
       break;
     }
-    case REGION_REQUEST_BODY_NOT_SET: {
+    case BODY_NOT_SET: {
       break;
     }
   }
-  _impl_._oneof_case_[0] = REGION_REQUEST_BODY_NOT_SET;
+  _impl_._oneof_case_[0] = BODY_NOT_SET;
 }
 
 
@@ -920,7 +922,7 @@ void RegionRequest::Clear() {
     delete _impl_.header_;
   }
   _impl_.header_ = nullptr;
-  clear_region_request_body();
+  clear_body();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -1132,71 +1134,71 @@ size_t RegionRequest::ByteSizeLong() const {
         *_impl_.header_);
   }
 
-  switch (region_request_body_case()) {
+  switch (body_case()) {
     // .greptime.v1.region.InsertRequests inserts = 3;
     case kInserts: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.inserts_);
+          *_impl_.body_.inserts_);
       break;
     }
     // .greptime.v1.region.DeleteRequests deletes = 4;
     case kDeletes: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.deletes_);
+          *_impl_.body_.deletes_);
       break;
     }
     // .greptime.v1.region.CreateRequest create = 5;
     case kCreate: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.create_);
+          *_impl_.body_.create_);
       break;
     }
     // .greptime.v1.region.DropRequest drop = 6;
     case kDrop: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.drop_);
+          *_impl_.body_.drop_);
       break;
     }
     // .greptime.v1.region.OpenRequest open = 7;
     case kOpen: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.open_);
+          *_impl_.body_.open_);
       break;
     }
     // .greptime.v1.region.CloseRequest close = 8;
     case kClose: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.close_);
+          *_impl_.body_.close_);
       break;
     }
     // .greptime.v1.region.AlterRequest alter = 9;
     case kAlter: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.alter_);
+          *_impl_.body_.alter_);
       break;
     }
     // .greptime.v1.region.FlushRequest flush = 10;
     case kFlush: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.flush_);
+          *_impl_.body_.flush_);
       break;
     }
     // .greptime.v1.region.CompactRequest compact = 11;
     case kCompact: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.region_request_body_.compact_);
+          *_impl_.body_.compact_);
       break;
     }
-    case REGION_REQUEST_BODY_NOT_SET: {
+    case BODY_NOT_SET: {
       break;
     }
   }
@@ -1222,7 +1224,7 @@ void RegionRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
     _this->_internal_mutable_header()->::greptime::v1::RequestHeader::MergeFrom(
         from._internal_header());
   }
-  switch (from.region_request_body_case()) {
+  switch (from.body_case()) {
     case kInserts: {
       _this->_internal_mutable_inserts()->::greptime::v1::region::InsertRequests::MergeFrom(
           from._internal_inserts());
@@ -1268,7 +1270,7 @@ void RegionRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
           from._internal_compact());
       break;
     }
-    case REGION_REQUEST_BODY_NOT_SET: {
+    case BODY_NOT_SET: {
       break;
     }
   }
@@ -1290,7 +1292,7 @@ void RegionRequest::InternalSwap(RegionRequest* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(_impl_.header_, other->_impl_.header_);
-  swap(_impl_.region_request_body_, other->_impl_.region_request_body_);
+  swap(_impl_.body_, other->_impl_.body_);
   swap(_impl_._oneof_case_[0], other->_impl_._oneof_case_[0]);
 }
 

--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -26,7 +26,7 @@ namespace region {
 PROTOBUF_CONSTEXPR RegionRequest::RegionRequest(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.header_)*/nullptr
-  , /*decltype(_impl_.request_)*/{}
+  , /*decltype(_impl_.region_request_body_)*/{}
   , /*decltype(_impl_._cached_size_)*/{}
   , /*decltype(_impl_._oneof_case_)*/{}} {}
 struct RegionRequestDefaultTypeInternal {
@@ -285,7 +285,7 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ::_pbi::kInvalidFieldOffsetTag,
   ::_pbi::kInvalidFieldOffsetTag,
   ::_pbi::kInvalidFieldOffsetTag,
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _impl_.request_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _impl_.region_request_body_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -466,7 +466,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\037greptime/v1/region/server.proto\022\022grept"
   "ime.v1.region\032\030greptime/v1/common.proto\032"
-  "\025greptime/v1/row.proto\"\233\004\n\rRegionRequest"
+  "\025greptime/v1/row.proto\"\247\004\n\rRegionRequest"
   "\022*\n\006header\030\001 \001(\0132\032.greptime.v1.RequestHe"
   "ader\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regi"
   "on.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".g"
@@ -479,44 +479,44 @@ const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] P
   "alter\030\t \001(\0132 .greptime.v1.region.AlterRe"
   "questH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.reg"
   "ion.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gr"
-  "eptime.v1.region.CompactRequestH\000B\t\n\007req"
-  "uest\"T\n\016RegionResponse\022+\n\006header\030\001 \001(\0132\033"
-  ".greptime.v1.ResponseHeader\022\025\n\raffacted_"
-  "rows\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requests"
-  "\030\001 \003(\0132!.greptime.v1.region.InsertReques"
-  "t\"E\n\016DeleteRequests\0223\n\010requests\030\001 \003(\0132!."
-  "greptime.v1.region.DeleteRequest\"B\n\rInse"
-  "rtRequest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003"
-  "(\0132\020.greptime.v1.Row\"B\n\rDeleteRequest\022\021\n"
-  "\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003(\0132\020.greptim"
-  "e.v1.Row\"/\n\014QueryRequest\022\021\n\tregion_id\030\001 "
-  "\001(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tr"
-  "egion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column"
-  "_defs\030\003 \003(\0132\035.greptime.v1.region.ColumnD"
-  "ef\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024create_if_not"
-  "_exists\030\005 \001(\010\022\022\n\nregion_dir\030\006 \001(\t\022\?\n\007opt"
-  "ions\030\007 \003(\0132..greptime.v1.region.CreateRe"
-  "quest.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003ke"
-  "y\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropReques"
-  "t\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\t"
-  "region_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregio"
-  "n_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,.greptime."
-  "v1.region.OpenRequest.OptionsEntry\032.\n\014Op"
-  "tionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002"
-  "8\001\"!\n\014CloseRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n"
-  "\014AlterRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014Flus"
-  "hRequest\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactRe"
-  "quest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014"
-  "\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010datat"
-  "ype\030\003 \001(\0162\033.greptime.v1.ColumnDataType\022\023"
-  "\n\013is_nullable\030\004 \001(\010\022\032\n\022default_constrain"
-  "t\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001(\0162\031.greptim"
-  "e.v1.SemanticType2_\n\014RegionServer\022O\n\006Han"
-  "dle\022!.greptime.v1.region.RegionRequest\032\""
-  ".greptime.v1.region.RegionResponseB]\n\025io"
-  ".greptime.v1.regionB\006ServerZ<github.com/"
-  "GreptimeTeam/greptime-proto/go/greptime/"
-  "v1/regionb\006proto3"
+  "eptime.v1.region.CompactRequestH\000B\025\n\023reg"
+  "ion_request_body\"T\n\016RegionResponse\022+\n\006he"
+  "ader\030\001 \001(\0132\033.greptime.v1.ResponseHeader\022"
+  "\025\n\raffacted_rows\030\002 \001(\004\"E\n\016InsertRequests"
+  "\0223\n\010requests\030\001 \003(\0132!.greptime.v1.region."
+  "InsertRequest\"E\n\016DeleteRequests\0223\n\010reque"
+  "sts\030\001 \003(\0132!.greptime.v1.region.DeleteReq"
+  "uest\"B\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(\004"
+  "\022\036\n\004rows\030\002 \003(\0132\020.greptime.v1.Row\"B\n\rDele"
+  "teRequest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003"
+  "(\0132\020.greptime.v1.Row\"/\n\014QueryRequest\022\021\n\t"
+  "region_id\030\001 \001(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreate"
+  "Request\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001"
+  "(\t\0222\n\013column_defs\030\003 \003(\0132\035.greptime.v1.re"
+  "gion.ColumnDef\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024c"
+  "reate_if_not_exists\030\005 \001(\010\022\022\n\nregion_dir\030"
+  "\006 \001(\t\022\?\n\007options\030\007 \003(\0132..greptime.v1.reg"
+  "ion.CreateRequest.OptionsEntry\032.\n\014Option"
+  "sEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" "
+  "\n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013Ope"
+  "nRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 "
+  "\001(\t\022\022\n\nregion_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\013"
+  "2,.greptime.v1.region.OpenRequest.Option"
+  "sEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v"
+  "alue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion"
+  "_id\030\001 \001(\004\"!\n\014AlterRequest\022\021\n\tregion_id\030\001"
+  " \001(\004\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\""
+  "#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n"
+  "\tColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 "
+  "\001(\r\022-\n\010datatype\030\003 \001(\0162\033.greptime.v1.Colu"
+  "mnDataType\022\023\n\013is_nullable\030\004 \001(\010\022\032\n\022defau"
+  "lt_constraint\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001"
+  "(\0162\031.greptime.v1.SemanticType2Y\n\006Region\022"
+  "O\n\006Handle\022!.greptime.v1.region.RegionReq"
+  "uest\032\".greptime.v1.region.RegionResponse"
+  "B]\n\025io.greptime.v1.regionB\006ServerZ<githu"
+  "b.com/GreptimeTeam/greptime-proto/go/gre"
+  "ptime/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[2] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -524,7 +524,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 2097, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 2103, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
     &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 2, 17,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
@@ -563,39 +563,39 @@ RegionRequest::_Internal::header(const RegionRequest* msg) {
 }
 const ::greptime::v1::region::InsertRequests&
 RegionRequest::_Internal::inserts(const RegionRequest* msg) {
-  return *msg->_impl_.request_.inserts_;
+  return *msg->_impl_.region_request_body_.inserts_;
 }
 const ::greptime::v1::region::DeleteRequests&
 RegionRequest::_Internal::deletes(const RegionRequest* msg) {
-  return *msg->_impl_.request_.deletes_;
+  return *msg->_impl_.region_request_body_.deletes_;
 }
 const ::greptime::v1::region::CreateRequest&
 RegionRequest::_Internal::create(const RegionRequest* msg) {
-  return *msg->_impl_.request_.create_;
+  return *msg->_impl_.region_request_body_.create_;
 }
 const ::greptime::v1::region::DropRequest&
 RegionRequest::_Internal::drop(const RegionRequest* msg) {
-  return *msg->_impl_.request_.drop_;
+  return *msg->_impl_.region_request_body_.drop_;
 }
 const ::greptime::v1::region::OpenRequest&
 RegionRequest::_Internal::open(const RegionRequest* msg) {
-  return *msg->_impl_.request_.open_;
+  return *msg->_impl_.region_request_body_.open_;
 }
 const ::greptime::v1::region::CloseRequest&
 RegionRequest::_Internal::close(const RegionRequest* msg) {
-  return *msg->_impl_.request_.close_;
+  return *msg->_impl_.region_request_body_.close_;
 }
 const ::greptime::v1::region::AlterRequest&
 RegionRequest::_Internal::alter(const RegionRequest* msg) {
-  return *msg->_impl_.request_.alter_;
+  return *msg->_impl_.region_request_body_.alter_;
 }
 const ::greptime::v1::region::FlushRequest&
 RegionRequest::_Internal::flush(const RegionRequest* msg) {
-  return *msg->_impl_.request_.flush_;
+  return *msg->_impl_.region_request_body_.flush_;
 }
 const ::greptime::v1::region::CompactRequest&
 RegionRequest::_Internal::compact(const RegionRequest* msg) {
-  return *msg->_impl_.request_.compact_;
+  return *msg->_impl_.region_request_body_.compact_;
 }
 void RegionRequest::clear_header() {
   if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
@@ -605,7 +605,7 @@ void RegionRequest::clear_header() {
 }
 void RegionRequest::set_allocated_inserts(::greptime::v1::region::InsertRequests* inserts) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (inserts) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(inserts);
@@ -614,13 +614,13 @@ void RegionRequest::set_allocated_inserts(::greptime::v1::region::InsertRequests
           message_arena, inserts, submessage_arena);
     }
     set_has_inserts();
-    _impl_.request_.inserts_ = inserts;
+    _impl_.region_request_body_.inserts_ = inserts;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.inserts)
 }
 void RegionRequest::set_allocated_deletes(::greptime::v1::region::DeleteRequests* deletes) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (deletes) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(deletes);
@@ -629,13 +629,13 @@ void RegionRequest::set_allocated_deletes(::greptime::v1::region::DeleteRequests
           message_arena, deletes, submessage_arena);
     }
     set_has_deletes();
-    _impl_.request_.deletes_ = deletes;
+    _impl_.region_request_body_.deletes_ = deletes;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.deletes)
 }
 void RegionRequest::set_allocated_create(::greptime::v1::region::CreateRequest* create) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (create) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(create);
@@ -644,13 +644,13 @@ void RegionRequest::set_allocated_create(::greptime::v1::region::CreateRequest* 
           message_arena, create, submessage_arena);
     }
     set_has_create();
-    _impl_.request_.create_ = create;
+    _impl_.region_request_body_.create_ = create;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.create)
 }
 void RegionRequest::set_allocated_drop(::greptime::v1::region::DropRequest* drop) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (drop) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(drop);
@@ -659,13 +659,13 @@ void RegionRequest::set_allocated_drop(::greptime::v1::region::DropRequest* drop
           message_arena, drop, submessage_arena);
     }
     set_has_drop();
-    _impl_.request_.drop_ = drop;
+    _impl_.region_request_body_.drop_ = drop;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.drop)
 }
 void RegionRequest::set_allocated_open(::greptime::v1::region::OpenRequest* open) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (open) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(open);
@@ -674,13 +674,13 @@ void RegionRequest::set_allocated_open(::greptime::v1::region::OpenRequest* open
           message_arena, open, submessage_arena);
     }
     set_has_open();
-    _impl_.request_.open_ = open;
+    _impl_.region_request_body_.open_ = open;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.open)
 }
 void RegionRequest::set_allocated_close(::greptime::v1::region::CloseRequest* close) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (close) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(close);
@@ -689,13 +689,13 @@ void RegionRequest::set_allocated_close(::greptime::v1::region::CloseRequest* cl
           message_arena, close, submessage_arena);
     }
     set_has_close();
-    _impl_.request_.close_ = close;
+    _impl_.region_request_body_.close_ = close;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.close)
 }
 void RegionRequest::set_allocated_alter(::greptime::v1::region::AlterRequest* alter) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (alter) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(alter);
@@ -704,13 +704,13 @@ void RegionRequest::set_allocated_alter(::greptime::v1::region::AlterRequest* al
           message_arena, alter, submessage_arena);
     }
     set_has_alter();
-    _impl_.request_.alter_ = alter;
+    _impl_.region_request_body_.alter_ = alter;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.alter)
 }
 void RegionRequest::set_allocated_flush(::greptime::v1::region::FlushRequest* flush) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (flush) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(flush);
@@ -719,13 +719,13 @@ void RegionRequest::set_allocated_flush(::greptime::v1::region::FlushRequest* fl
           message_arena, flush, submessage_arena);
     }
     set_has_flush();
-    _impl_.request_.flush_ = flush;
+    _impl_.region_request_body_.flush_ = flush;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.flush)
 }
 void RegionRequest::set_allocated_compact(::greptime::v1::region::CompactRequest* compact) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  clear_request();
+  clear_region_request_body();
   if (compact) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
       ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(compact);
@@ -734,7 +734,7 @@ void RegionRequest::set_allocated_compact(::greptime::v1::region::CompactRequest
           message_arena, compact, submessage_arena);
     }
     set_has_compact();
-    _impl_.request_.compact_ = compact;
+    _impl_.region_request_body_.compact_ = compact;
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequest.compact)
 }
@@ -749,7 +749,7 @@ RegionRequest::RegionRequest(const RegionRequest& from)
   RegionRequest* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.header_){nullptr}
-    , decltype(_impl_.request_){}
+    , decltype(_impl_.region_request_body_){}
     , /*decltype(_impl_._cached_size_)*/{}
     , /*decltype(_impl_._oneof_case_)*/{}};
 
@@ -757,8 +757,8 @@ RegionRequest::RegionRequest(const RegionRequest& from)
   if (from._internal_has_header()) {
     _this->_impl_.header_ = new ::greptime::v1::RequestHeader(*from._impl_.header_);
   }
-  clear_has_request();
-  switch (from.request_case()) {
+  clear_has_region_request_body();
+  switch (from.region_request_body_case()) {
     case kInserts: {
       _this->_internal_mutable_inserts()->::greptime::v1::region::InsertRequests::MergeFrom(
           from._internal_inserts());
@@ -804,7 +804,7 @@ RegionRequest::RegionRequest(const RegionRequest& from)
           from._internal_compact());
       break;
     }
-    case REQUEST_NOT_SET: {
+    case REGION_REQUEST_BODY_NOT_SET: {
       break;
     }
   }
@@ -817,11 +817,11 @@ inline void RegionRequest::SharedCtor(
   (void)is_message_owned;
   new (&_impl_) Impl_{
       decltype(_impl_.header_){nullptr}
-    , decltype(_impl_.request_){}
+    , decltype(_impl_.region_request_body_){}
     , /*decltype(_impl_._cached_size_)*/{}
     , /*decltype(_impl_._oneof_case_)*/{}
   };
-  clear_has_request();
+  clear_has_region_request_body();
 }
 
 RegionRequest::~RegionRequest() {
@@ -836,8 +836,8 @@ RegionRequest::~RegionRequest() {
 inline void RegionRequest::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   if (this != internal_default_instance()) delete _impl_.header_;
-  if (has_request()) {
-    clear_request();
+  if (has_region_request_body()) {
+    clear_region_request_body();
   }
 }
 
@@ -845,68 +845,68 @@ void RegionRequest::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void RegionRequest::clear_request() {
+void RegionRequest::clear_region_request_body() {
 // @@protoc_insertion_point(one_of_clear_start:greptime.v1.region.RegionRequest)
-  switch (request_case()) {
+  switch (region_request_body_case()) {
     case kInserts: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.inserts_;
+        delete _impl_.region_request_body_.inserts_;
       }
       break;
     }
     case kDeletes: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.deletes_;
+        delete _impl_.region_request_body_.deletes_;
       }
       break;
     }
     case kCreate: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.create_;
+        delete _impl_.region_request_body_.create_;
       }
       break;
     }
     case kDrop: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.drop_;
+        delete _impl_.region_request_body_.drop_;
       }
       break;
     }
     case kOpen: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.open_;
+        delete _impl_.region_request_body_.open_;
       }
       break;
     }
     case kClose: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.close_;
+        delete _impl_.region_request_body_.close_;
       }
       break;
     }
     case kAlter: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.alter_;
+        delete _impl_.region_request_body_.alter_;
       }
       break;
     }
     case kFlush: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.flush_;
+        delete _impl_.region_request_body_.flush_;
       }
       break;
     }
     case kCompact: {
       if (GetArenaForAllocation() == nullptr) {
-        delete _impl_.request_.compact_;
+        delete _impl_.region_request_body_.compact_;
       }
       break;
     }
-    case REQUEST_NOT_SET: {
+    case REGION_REQUEST_BODY_NOT_SET: {
       break;
     }
   }
-  _impl_._oneof_case_[0] = REQUEST_NOT_SET;
+  _impl_._oneof_case_[0] = REGION_REQUEST_BODY_NOT_SET;
 }
 
 
@@ -920,7 +920,7 @@ void RegionRequest::Clear() {
     delete _impl_.header_;
   }
   _impl_.header_ = nullptr;
-  clear_request();
+  clear_region_request_body();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -1132,71 +1132,71 @@ size_t RegionRequest::ByteSizeLong() const {
         *_impl_.header_);
   }
 
-  switch (request_case()) {
+  switch (region_request_body_case()) {
     // .greptime.v1.region.InsertRequests inserts = 3;
     case kInserts: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.inserts_);
+          *_impl_.region_request_body_.inserts_);
       break;
     }
     // .greptime.v1.region.DeleteRequests deletes = 4;
     case kDeletes: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.deletes_);
+          *_impl_.region_request_body_.deletes_);
       break;
     }
     // .greptime.v1.region.CreateRequest create = 5;
     case kCreate: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.create_);
+          *_impl_.region_request_body_.create_);
       break;
     }
     // .greptime.v1.region.DropRequest drop = 6;
     case kDrop: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.drop_);
+          *_impl_.region_request_body_.drop_);
       break;
     }
     // .greptime.v1.region.OpenRequest open = 7;
     case kOpen: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.open_);
+          *_impl_.region_request_body_.open_);
       break;
     }
     // .greptime.v1.region.CloseRequest close = 8;
     case kClose: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.close_);
+          *_impl_.region_request_body_.close_);
       break;
     }
     // .greptime.v1.region.AlterRequest alter = 9;
     case kAlter: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.alter_);
+          *_impl_.region_request_body_.alter_);
       break;
     }
     // .greptime.v1.region.FlushRequest flush = 10;
     case kFlush: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.flush_);
+          *_impl_.region_request_body_.flush_);
       break;
     }
     // .greptime.v1.region.CompactRequest compact = 11;
     case kCompact: {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-          *_impl_.request_.compact_);
+          *_impl_.region_request_body_.compact_);
       break;
     }
-    case REQUEST_NOT_SET: {
+    case REGION_REQUEST_BODY_NOT_SET: {
       break;
     }
   }
@@ -1222,7 +1222,7 @@ void RegionRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
     _this->_internal_mutable_header()->::greptime::v1::RequestHeader::MergeFrom(
         from._internal_header());
   }
-  switch (from.request_case()) {
+  switch (from.region_request_body_case()) {
     case kInserts: {
       _this->_internal_mutable_inserts()->::greptime::v1::region::InsertRequests::MergeFrom(
           from._internal_inserts());
@@ -1268,7 +1268,7 @@ void RegionRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
           from._internal_compact());
       break;
     }
-    case REQUEST_NOT_SET: {
+    case REGION_REQUEST_BODY_NOT_SET: {
       break;
     }
   }
@@ -1290,7 +1290,7 @@ void RegionRequest::InternalSwap(RegionRequest* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(_impl_.header_, other->_impl_.header_);
-  swap(_impl_.request_, other->_impl_.request_);
+  swap(_impl_.region_request_body_, other->_impl_.region_request_body_);
   swap(_impl_._oneof_case_[0], other->_impl_._oneof_case_[0]);
 }
 

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -174,7 +174,7 @@ class RegionRequest final :
   static const RegionRequest& default_instance() {
     return *internal_default_instance();
   }
-  enum RegionRequestBodyCase {
+  enum BodyCase {
     kInserts = 3,
     kDeletes = 4,
     kCreate = 5,
@@ -184,7 +184,7 @@ class RegionRequest final :
     kAlter = 9,
     kFlush = 10,
     kCompact = 11,
-    REGION_REQUEST_BODY_NOT_SET = 0,
+    BODY_NOT_SET = 0,
   };
 
   static inline const RegionRequest* internal_default_instance() {
@@ -456,8 +456,8 @@ class RegionRequest final :
       ::greptime::v1::region::CompactRequest* compact);
   ::greptime::v1::region::CompactRequest* unsafe_arena_release_compact();
 
-  void clear_region_request_body();
-  RegionRequestBodyCase region_request_body_case() const;
+  void clear_body();
+  BodyCase body_case() const;
   // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionRequest)
  private:
   class _Internal;
@@ -471,16 +471,16 @@ class RegionRequest final :
   void set_has_flush();
   void set_has_compact();
 
-  inline bool has_region_request_body() const;
-  inline void clear_has_region_request_body();
+  inline bool has_body() const;
+  inline void clear_has_body();
 
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
     ::greptime::v1::RequestHeader* header_;
-    union RegionRequestBodyUnion {
-      constexpr RegionRequestBodyUnion() : _constinit_{} {}
+    union BodyUnion {
+      constexpr BodyUnion() : _constinit_{} {}
         ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized _constinit_;
       ::greptime::v1::region::InsertRequests* inserts_;
       ::greptime::v1::region::DeleteRequests* deletes_;
@@ -491,7 +491,7 @@ class RegionRequest final :
       ::greptime::v1::region::AlterRequest* alter_;
       ::greptime::v1::region::FlushRequest* flush_;
       ::greptime::v1::region::CompactRequest* compact_;
-    } region_request_body_;
+    } body_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     uint32_t _oneof_case_[1];
 
@@ -3056,7 +3056,7 @@ inline void RegionRequest::set_allocated_header(::greptime::v1::RequestHeader* h
 
 // .greptime.v1.region.InsertRequests inserts = 3;
 inline bool RegionRequest::_internal_has_inserts() const {
-  return region_request_body_case() == kInserts;
+  return body_case() == kInserts;
 }
 inline bool RegionRequest::has_inserts() const {
   return _internal_has_inserts();
@@ -3067,20 +3067,20 @@ inline void RegionRequest::set_has_inserts() {
 inline void RegionRequest::clear_inserts() {
   if (_internal_has_inserts()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.inserts_;
+      delete _impl_.body_.inserts_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::InsertRequests* RegionRequest::release_inserts() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.inserts)
   if (_internal_has_inserts()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::InsertRequests* temp = _impl_.region_request_body_.inserts_;
+    clear_has_body();
+    ::greptime::v1::region::InsertRequests* temp = _impl_.body_.inserts_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.inserts_ = nullptr;
+    _impl_.body_.inserts_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3088,7 +3088,7 @@ inline ::greptime::v1::region::InsertRequests* RegionRequest::release_inserts() 
 }
 inline const ::greptime::v1::region::InsertRequests& RegionRequest::_internal_inserts() const {
   return _internal_has_inserts()
-      ? *_impl_.region_request_body_.inserts_
+      ? *_impl_.body_.inserts_
       : reinterpret_cast< ::greptime::v1::region::InsertRequests&>(::greptime::v1::region::_InsertRequests_default_instance_);
 }
 inline const ::greptime::v1::region::InsertRequests& RegionRequest::inserts() const {
@@ -3098,29 +3098,29 @@ inline const ::greptime::v1::region::InsertRequests& RegionRequest::inserts() co
 inline ::greptime::v1::region::InsertRequests* RegionRequest::unsafe_arena_release_inserts() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.inserts)
   if (_internal_has_inserts()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::InsertRequests* temp = _impl_.region_request_body_.inserts_;
-    _impl_.region_request_body_.inserts_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::InsertRequests* temp = _impl_.body_.inserts_;
+    _impl_.body_.inserts_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_inserts(::greptime::v1::region::InsertRequests* inserts) {
-  clear_region_request_body();
+  clear_body();
   if (inserts) {
     set_has_inserts();
-    _impl_.region_request_body_.inserts_ = inserts;
+    _impl_.body_.inserts_ = inserts;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.inserts)
 }
 inline ::greptime::v1::region::InsertRequests* RegionRequest::_internal_mutable_inserts() {
   if (!_internal_has_inserts()) {
-    clear_region_request_body();
+    clear_body();
     set_has_inserts();
-    _impl_.region_request_body_.inserts_ = CreateMaybeMessage< ::greptime::v1::region::InsertRequests >(GetArenaForAllocation());
+    _impl_.body_.inserts_ = CreateMaybeMessage< ::greptime::v1::region::InsertRequests >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.inserts_;
+  return _impl_.body_.inserts_;
 }
 inline ::greptime::v1::region::InsertRequests* RegionRequest::mutable_inserts() {
   ::greptime::v1::region::InsertRequests* _msg = _internal_mutable_inserts();
@@ -3130,7 +3130,7 @@ inline ::greptime::v1::region::InsertRequests* RegionRequest::mutable_inserts() 
 
 // .greptime.v1.region.DeleteRequests deletes = 4;
 inline bool RegionRequest::_internal_has_deletes() const {
-  return region_request_body_case() == kDeletes;
+  return body_case() == kDeletes;
 }
 inline bool RegionRequest::has_deletes() const {
   return _internal_has_deletes();
@@ -3141,20 +3141,20 @@ inline void RegionRequest::set_has_deletes() {
 inline void RegionRequest::clear_deletes() {
   if (_internal_has_deletes()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.deletes_;
+      delete _impl_.body_.deletes_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::release_deletes() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.deletes)
   if (_internal_has_deletes()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::DeleteRequests* temp = _impl_.region_request_body_.deletes_;
+    clear_has_body();
+    ::greptime::v1::region::DeleteRequests* temp = _impl_.body_.deletes_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.deletes_ = nullptr;
+    _impl_.body_.deletes_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3162,7 +3162,7 @@ inline ::greptime::v1::region::DeleteRequests* RegionRequest::release_deletes() 
 }
 inline const ::greptime::v1::region::DeleteRequests& RegionRequest::_internal_deletes() const {
   return _internal_has_deletes()
-      ? *_impl_.region_request_body_.deletes_
+      ? *_impl_.body_.deletes_
       : reinterpret_cast< ::greptime::v1::region::DeleteRequests&>(::greptime::v1::region::_DeleteRequests_default_instance_);
 }
 inline const ::greptime::v1::region::DeleteRequests& RegionRequest::deletes() const {
@@ -3172,29 +3172,29 @@ inline const ::greptime::v1::region::DeleteRequests& RegionRequest::deletes() co
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::unsafe_arena_release_deletes() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.deletes)
   if (_internal_has_deletes()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::DeleteRequests* temp = _impl_.region_request_body_.deletes_;
-    _impl_.region_request_body_.deletes_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::DeleteRequests* temp = _impl_.body_.deletes_;
+    _impl_.body_.deletes_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_deletes(::greptime::v1::region::DeleteRequests* deletes) {
-  clear_region_request_body();
+  clear_body();
   if (deletes) {
     set_has_deletes();
-    _impl_.region_request_body_.deletes_ = deletes;
+    _impl_.body_.deletes_ = deletes;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.deletes)
 }
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::_internal_mutable_deletes() {
   if (!_internal_has_deletes()) {
-    clear_region_request_body();
+    clear_body();
     set_has_deletes();
-    _impl_.region_request_body_.deletes_ = CreateMaybeMessage< ::greptime::v1::region::DeleteRequests >(GetArenaForAllocation());
+    _impl_.body_.deletes_ = CreateMaybeMessage< ::greptime::v1::region::DeleteRequests >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.deletes_;
+  return _impl_.body_.deletes_;
 }
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::mutable_deletes() {
   ::greptime::v1::region::DeleteRequests* _msg = _internal_mutable_deletes();
@@ -3204,7 +3204,7 @@ inline ::greptime::v1::region::DeleteRequests* RegionRequest::mutable_deletes() 
 
 // .greptime.v1.region.CreateRequest create = 5;
 inline bool RegionRequest::_internal_has_create() const {
-  return region_request_body_case() == kCreate;
+  return body_case() == kCreate;
 }
 inline bool RegionRequest::has_create() const {
   return _internal_has_create();
@@ -3215,20 +3215,20 @@ inline void RegionRequest::set_has_create() {
 inline void RegionRequest::clear_create() {
   if (_internal_has_create()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.create_;
+      delete _impl_.body_.create_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::CreateRequest* RegionRequest::release_create() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.create)
   if (_internal_has_create()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::CreateRequest* temp = _impl_.region_request_body_.create_;
+    clear_has_body();
+    ::greptime::v1::region::CreateRequest* temp = _impl_.body_.create_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.create_ = nullptr;
+    _impl_.body_.create_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3236,7 +3236,7 @@ inline ::greptime::v1::region::CreateRequest* RegionRequest::release_create() {
 }
 inline const ::greptime::v1::region::CreateRequest& RegionRequest::_internal_create() const {
   return _internal_has_create()
-      ? *_impl_.region_request_body_.create_
+      ? *_impl_.body_.create_
       : reinterpret_cast< ::greptime::v1::region::CreateRequest&>(::greptime::v1::region::_CreateRequest_default_instance_);
 }
 inline const ::greptime::v1::region::CreateRequest& RegionRequest::create() const {
@@ -3246,29 +3246,29 @@ inline const ::greptime::v1::region::CreateRequest& RegionRequest::create() cons
 inline ::greptime::v1::region::CreateRequest* RegionRequest::unsafe_arena_release_create() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.create)
   if (_internal_has_create()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::CreateRequest* temp = _impl_.region_request_body_.create_;
-    _impl_.region_request_body_.create_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::CreateRequest* temp = _impl_.body_.create_;
+    _impl_.body_.create_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_create(::greptime::v1::region::CreateRequest* create) {
-  clear_region_request_body();
+  clear_body();
   if (create) {
     set_has_create();
-    _impl_.region_request_body_.create_ = create;
+    _impl_.body_.create_ = create;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.create)
 }
 inline ::greptime::v1::region::CreateRequest* RegionRequest::_internal_mutable_create() {
   if (!_internal_has_create()) {
-    clear_region_request_body();
+    clear_body();
     set_has_create();
-    _impl_.region_request_body_.create_ = CreateMaybeMessage< ::greptime::v1::region::CreateRequest >(GetArenaForAllocation());
+    _impl_.body_.create_ = CreateMaybeMessage< ::greptime::v1::region::CreateRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.create_;
+  return _impl_.body_.create_;
 }
 inline ::greptime::v1::region::CreateRequest* RegionRequest::mutable_create() {
   ::greptime::v1::region::CreateRequest* _msg = _internal_mutable_create();
@@ -3278,7 +3278,7 @@ inline ::greptime::v1::region::CreateRequest* RegionRequest::mutable_create() {
 
 // .greptime.v1.region.DropRequest drop = 6;
 inline bool RegionRequest::_internal_has_drop() const {
-  return region_request_body_case() == kDrop;
+  return body_case() == kDrop;
 }
 inline bool RegionRequest::has_drop() const {
   return _internal_has_drop();
@@ -3289,20 +3289,20 @@ inline void RegionRequest::set_has_drop() {
 inline void RegionRequest::clear_drop() {
   if (_internal_has_drop()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.drop_;
+      delete _impl_.body_.drop_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::DropRequest* RegionRequest::release_drop() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.drop)
   if (_internal_has_drop()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::DropRequest* temp = _impl_.region_request_body_.drop_;
+    clear_has_body();
+    ::greptime::v1::region::DropRequest* temp = _impl_.body_.drop_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.drop_ = nullptr;
+    _impl_.body_.drop_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3310,7 +3310,7 @@ inline ::greptime::v1::region::DropRequest* RegionRequest::release_drop() {
 }
 inline const ::greptime::v1::region::DropRequest& RegionRequest::_internal_drop() const {
   return _internal_has_drop()
-      ? *_impl_.region_request_body_.drop_
+      ? *_impl_.body_.drop_
       : reinterpret_cast< ::greptime::v1::region::DropRequest&>(::greptime::v1::region::_DropRequest_default_instance_);
 }
 inline const ::greptime::v1::region::DropRequest& RegionRequest::drop() const {
@@ -3320,29 +3320,29 @@ inline const ::greptime::v1::region::DropRequest& RegionRequest::drop() const {
 inline ::greptime::v1::region::DropRequest* RegionRequest::unsafe_arena_release_drop() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.drop)
   if (_internal_has_drop()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::DropRequest* temp = _impl_.region_request_body_.drop_;
-    _impl_.region_request_body_.drop_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::DropRequest* temp = _impl_.body_.drop_;
+    _impl_.body_.drop_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_drop(::greptime::v1::region::DropRequest* drop) {
-  clear_region_request_body();
+  clear_body();
   if (drop) {
     set_has_drop();
-    _impl_.region_request_body_.drop_ = drop;
+    _impl_.body_.drop_ = drop;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.drop)
 }
 inline ::greptime::v1::region::DropRequest* RegionRequest::_internal_mutable_drop() {
   if (!_internal_has_drop()) {
-    clear_region_request_body();
+    clear_body();
     set_has_drop();
-    _impl_.region_request_body_.drop_ = CreateMaybeMessage< ::greptime::v1::region::DropRequest >(GetArenaForAllocation());
+    _impl_.body_.drop_ = CreateMaybeMessage< ::greptime::v1::region::DropRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.drop_;
+  return _impl_.body_.drop_;
 }
 inline ::greptime::v1::region::DropRequest* RegionRequest::mutable_drop() {
   ::greptime::v1::region::DropRequest* _msg = _internal_mutable_drop();
@@ -3352,7 +3352,7 @@ inline ::greptime::v1::region::DropRequest* RegionRequest::mutable_drop() {
 
 // .greptime.v1.region.OpenRequest open = 7;
 inline bool RegionRequest::_internal_has_open() const {
-  return region_request_body_case() == kOpen;
+  return body_case() == kOpen;
 }
 inline bool RegionRequest::has_open() const {
   return _internal_has_open();
@@ -3363,20 +3363,20 @@ inline void RegionRequest::set_has_open() {
 inline void RegionRequest::clear_open() {
   if (_internal_has_open()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.open_;
+      delete _impl_.body_.open_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::OpenRequest* RegionRequest::release_open() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.open)
   if (_internal_has_open()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::OpenRequest* temp = _impl_.region_request_body_.open_;
+    clear_has_body();
+    ::greptime::v1::region::OpenRequest* temp = _impl_.body_.open_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.open_ = nullptr;
+    _impl_.body_.open_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3384,7 +3384,7 @@ inline ::greptime::v1::region::OpenRequest* RegionRequest::release_open() {
 }
 inline const ::greptime::v1::region::OpenRequest& RegionRequest::_internal_open() const {
   return _internal_has_open()
-      ? *_impl_.region_request_body_.open_
+      ? *_impl_.body_.open_
       : reinterpret_cast< ::greptime::v1::region::OpenRequest&>(::greptime::v1::region::_OpenRequest_default_instance_);
 }
 inline const ::greptime::v1::region::OpenRequest& RegionRequest::open() const {
@@ -3394,29 +3394,29 @@ inline const ::greptime::v1::region::OpenRequest& RegionRequest::open() const {
 inline ::greptime::v1::region::OpenRequest* RegionRequest::unsafe_arena_release_open() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.open)
   if (_internal_has_open()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::OpenRequest* temp = _impl_.region_request_body_.open_;
-    _impl_.region_request_body_.open_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::OpenRequest* temp = _impl_.body_.open_;
+    _impl_.body_.open_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_open(::greptime::v1::region::OpenRequest* open) {
-  clear_region_request_body();
+  clear_body();
   if (open) {
     set_has_open();
-    _impl_.region_request_body_.open_ = open;
+    _impl_.body_.open_ = open;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.open)
 }
 inline ::greptime::v1::region::OpenRequest* RegionRequest::_internal_mutable_open() {
   if (!_internal_has_open()) {
-    clear_region_request_body();
+    clear_body();
     set_has_open();
-    _impl_.region_request_body_.open_ = CreateMaybeMessage< ::greptime::v1::region::OpenRequest >(GetArenaForAllocation());
+    _impl_.body_.open_ = CreateMaybeMessage< ::greptime::v1::region::OpenRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.open_;
+  return _impl_.body_.open_;
 }
 inline ::greptime::v1::region::OpenRequest* RegionRequest::mutable_open() {
   ::greptime::v1::region::OpenRequest* _msg = _internal_mutable_open();
@@ -3426,7 +3426,7 @@ inline ::greptime::v1::region::OpenRequest* RegionRequest::mutable_open() {
 
 // .greptime.v1.region.CloseRequest close = 8;
 inline bool RegionRequest::_internal_has_close() const {
-  return region_request_body_case() == kClose;
+  return body_case() == kClose;
 }
 inline bool RegionRequest::has_close() const {
   return _internal_has_close();
@@ -3437,20 +3437,20 @@ inline void RegionRequest::set_has_close() {
 inline void RegionRequest::clear_close() {
   if (_internal_has_close()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.close_;
+      delete _impl_.body_.close_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::CloseRequest* RegionRequest::release_close() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.close)
   if (_internal_has_close()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::CloseRequest* temp = _impl_.region_request_body_.close_;
+    clear_has_body();
+    ::greptime::v1::region::CloseRequest* temp = _impl_.body_.close_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.close_ = nullptr;
+    _impl_.body_.close_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3458,7 +3458,7 @@ inline ::greptime::v1::region::CloseRequest* RegionRequest::release_close() {
 }
 inline const ::greptime::v1::region::CloseRequest& RegionRequest::_internal_close() const {
   return _internal_has_close()
-      ? *_impl_.region_request_body_.close_
+      ? *_impl_.body_.close_
       : reinterpret_cast< ::greptime::v1::region::CloseRequest&>(::greptime::v1::region::_CloseRequest_default_instance_);
 }
 inline const ::greptime::v1::region::CloseRequest& RegionRequest::close() const {
@@ -3468,29 +3468,29 @@ inline const ::greptime::v1::region::CloseRequest& RegionRequest::close() const 
 inline ::greptime::v1::region::CloseRequest* RegionRequest::unsafe_arena_release_close() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.close)
   if (_internal_has_close()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::CloseRequest* temp = _impl_.region_request_body_.close_;
-    _impl_.region_request_body_.close_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::CloseRequest* temp = _impl_.body_.close_;
+    _impl_.body_.close_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_close(::greptime::v1::region::CloseRequest* close) {
-  clear_region_request_body();
+  clear_body();
   if (close) {
     set_has_close();
-    _impl_.region_request_body_.close_ = close;
+    _impl_.body_.close_ = close;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.close)
 }
 inline ::greptime::v1::region::CloseRequest* RegionRequest::_internal_mutable_close() {
   if (!_internal_has_close()) {
-    clear_region_request_body();
+    clear_body();
     set_has_close();
-    _impl_.region_request_body_.close_ = CreateMaybeMessage< ::greptime::v1::region::CloseRequest >(GetArenaForAllocation());
+    _impl_.body_.close_ = CreateMaybeMessage< ::greptime::v1::region::CloseRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.close_;
+  return _impl_.body_.close_;
 }
 inline ::greptime::v1::region::CloseRequest* RegionRequest::mutable_close() {
   ::greptime::v1::region::CloseRequest* _msg = _internal_mutable_close();
@@ -3500,7 +3500,7 @@ inline ::greptime::v1::region::CloseRequest* RegionRequest::mutable_close() {
 
 // .greptime.v1.region.AlterRequest alter = 9;
 inline bool RegionRequest::_internal_has_alter() const {
-  return region_request_body_case() == kAlter;
+  return body_case() == kAlter;
 }
 inline bool RegionRequest::has_alter() const {
   return _internal_has_alter();
@@ -3511,20 +3511,20 @@ inline void RegionRequest::set_has_alter() {
 inline void RegionRequest::clear_alter() {
   if (_internal_has_alter()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.alter_;
+      delete _impl_.body_.alter_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::AlterRequest* RegionRequest::release_alter() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.alter)
   if (_internal_has_alter()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::AlterRequest* temp = _impl_.region_request_body_.alter_;
+    clear_has_body();
+    ::greptime::v1::region::AlterRequest* temp = _impl_.body_.alter_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.alter_ = nullptr;
+    _impl_.body_.alter_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3532,7 +3532,7 @@ inline ::greptime::v1::region::AlterRequest* RegionRequest::release_alter() {
 }
 inline const ::greptime::v1::region::AlterRequest& RegionRequest::_internal_alter() const {
   return _internal_has_alter()
-      ? *_impl_.region_request_body_.alter_
+      ? *_impl_.body_.alter_
       : reinterpret_cast< ::greptime::v1::region::AlterRequest&>(::greptime::v1::region::_AlterRequest_default_instance_);
 }
 inline const ::greptime::v1::region::AlterRequest& RegionRequest::alter() const {
@@ -3542,29 +3542,29 @@ inline const ::greptime::v1::region::AlterRequest& RegionRequest::alter() const 
 inline ::greptime::v1::region::AlterRequest* RegionRequest::unsafe_arena_release_alter() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.alter)
   if (_internal_has_alter()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::AlterRequest* temp = _impl_.region_request_body_.alter_;
-    _impl_.region_request_body_.alter_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::AlterRequest* temp = _impl_.body_.alter_;
+    _impl_.body_.alter_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_alter(::greptime::v1::region::AlterRequest* alter) {
-  clear_region_request_body();
+  clear_body();
   if (alter) {
     set_has_alter();
-    _impl_.region_request_body_.alter_ = alter;
+    _impl_.body_.alter_ = alter;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.alter)
 }
 inline ::greptime::v1::region::AlterRequest* RegionRequest::_internal_mutable_alter() {
   if (!_internal_has_alter()) {
-    clear_region_request_body();
+    clear_body();
     set_has_alter();
-    _impl_.region_request_body_.alter_ = CreateMaybeMessage< ::greptime::v1::region::AlterRequest >(GetArenaForAllocation());
+    _impl_.body_.alter_ = CreateMaybeMessage< ::greptime::v1::region::AlterRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.alter_;
+  return _impl_.body_.alter_;
 }
 inline ::greptime::v1::region::AlterRequest* RegionRequest::mutable_alter() {
   ::greptime::v1::region::AlterRequest* _msg = _internal_mutable_alter();
@@ -3574,7 +3574,7 @@ inline ::greptime::v1::region::AlterRequest* RegionRequest::mutable_alter() {
 
 // .greptime.v1.region.FlushRequest flush = 10;
 inline bool RegionRequest::_internal_has_flush() const {
-  return region_request_body_case() == kFlush;
+  return body_case() == kFlush;
 }
 inline bool RegionRequest::has_flush() const {
   return _internal_has_flush();
@@ -3585,20 +3585,20 @@ inline void RegionRequest::set_has_flush() {
 inline void RegionRequest::clear_flush() {
   if (_internal_has_flush()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.flush_;
+      delete _impl_.body_.flush_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::FlushRequest* RegionRequest::release_flush() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.flush)
   if (_internal_has_flush()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::FlushRequest* temp = _impl_.region_request_body_.flush_;
+    clear_has_body();
+    ::greptime::v1::region::FlushRequest* temp = _impl_.body_.flush_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.flush_ = nullptr;
+    _impl_.body_.flush_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3606,7 +3606,7 @@ inline ::greptime::v1::region::FlushRequest* RegionRequest::release_flush() {
 }
 inline const ::greptime::v1::region::FlushRequest& RegionRequest::_internal_flush() const {
   return _internal_has_flush()
-      ? *_impl_.region_request_body_.flush_
+      ? *_impl_.body_.flush_
       : reinterpret_cast< ::greptime::v1::region::FlushRequest&>(::greptime::v1::region::_FlushRequest_default_instance_);
 }
 inline const ::greptime::v1::region::FlushRequest& RegionRequest::flush() const {
@@ -3616,29 +3616,29 @@ inline const ::greptime::v1::region::FlushRequest& RegionRequest::flush() const 
 inline ::greptime::v1::region::FlushRequest* RegionRequest::unsafe_arena_release_flush() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.flush)
   if (_internal_has_flush()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::FlushRequest* temp = _impl_.region_request_body_.flush_;
-    _impl_.region_request_body_.flush_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::FlushRequest* temp = _impl_.body_.flush_;
+    _impl_.body_.flush_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_flush(::greptime::v1::region::FlushRequest* flush) {
-  clear_region_request_body();
+  clear_body();
   if (flush) {
     set_has_flush();
-    _impl_.region_request_body_.flush_ = flush;
+    _impl_.body_.flush_ = flush;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.flush)
 }
 inline ::greptime::v1::region::FlushRequest* RegionRequest::_internal_mutable_flush() {
   if (!_internal_has_flush()) {
-    clear_region_request_body();
+    clear_body();
     set_has_flush();
-    _impl_.region_request_body_.flush_ = CreateMaybeMessage< ::greptime::v1::region::FlushRequest >(GetArenaForAllocation());
+    _impl_.body_.flush_ = CreateMaybeMessage< ::greptime::v1::region::FlushRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.flush_;
+  return _impl_.body_.flush_;
 }
 inline ::greptime::v1::region::FlushRequest* RegionRequest::mutable_flush() {
   ::greptime::v1::region::FlushRequest* _msg = _internal_mutable_flush();
@@ -3648,7 +3648,7 @@ inline ::greptime::v1::region::FlushRequest* RegionRequest::mutable_flush() {
 
 // .greptime.v1.region.CompactRequest compact = 11;
 inline bool RegionRequest::_internal_has_compact() const {
-  return region_request_body_case() == kCompact;
+  return body_case() == kCompact;
 }
 inline bool RegionRequest::has_compact() const {
   return _internal_has_compact();
@@ -3659,20 +3659,20 @@ inline void RegionRequest::set_has_compact() {
 inline void RegionRequest::clear_compact() {
   if (_internal_has_compact()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.region_request_body_.compact_;
+      delete _impl_.body_.compact_;
     }
-    clear_has_region_request_body();
+    clear_has_body();
   }
 }
 inline ::greptime::v1::region::CompactRequest* RegionRequest::release_compact() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.compact)
   if (_internal_has_compact()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::CompactRequest* temp = _impl_.region_request_body_.compact_;
+    clear_has_body();
+    ::greptime::v1::region::CompactRequest* temp = _impl_.body_.compact_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.region_request_body_.compact_ = nullptr;
+    _impl_.body_.compact_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3680,7 +3680,7 @@ inline ::greptime::v1::region::CompactRequest* RegionRequest::release_compact() 
 }
 inline const ::greptime::v1::region::CompactRequest& RegionRequest::_internal_compact() const {
   return _internal_has_compact()
-      ? *_impl_.region_request_body_.compact_
+      ? *_impl_.body_.compact_
       : reinterpret_cast< ::greptime::v1::region::CompactRequest&>(::greptime::v1::region::_CompactRequest_default_instance_);
 }
 inline const ::greptime::v1::region::CompactRequest& RegionRequest::compact() const {
@@ -3690,29 +3690,29 @@ inline const ::greptime::v1::region::CompactRequest& RegionRequest::compact() co
 inline ::greptime::v1::region::CompactRequest* RegionRequest::unsafe_arena_release_compact() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.compact)
   if (_internal_has_compact()) {
-    clear_has_region_request_body();
-    ::greptime::v1::region::CompactRequest* temp = _impl_.region_request_body_.compact_;
-    _impl_.region_request_body_.compact_ = nullptr;
+    clear_has_body();
+    ::greptime::v1::region::CompactRequest* temp = _impl_.body_.compact_;
+    _impl_.body_.compact_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_compact(::greptime::v1::region::CompactRequest* compact) {
-  clear_region_request_body();
+  clear_body();
   if (compact) {
     set_has_compact();
-    _impl_.region_request_body_.compact_ = compact;
+    _impl_.body_.compact_ = compact;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.compact)
 }
 inline ::greptime::v1::region::CompactRequest* RegionRequest::_internal_mutable_compact() {
   if (!_internal_has_compact()) {
-    clear_region_request_body();
+    clear_body();
     set_has_compact();
-    _impl_.region_request_body_.compact_ = CreateMaybeMessage< ::greptime::v1::region::CompactRequest >(GetArenaForAllocation());
+    _impl_.body_.compact_ = CreateMaybeMessage< ::greptime::v1::region::CompactRequest >(GetArenaForAllocation());
   }
-  return _impl_.region_request_body_.compact_;
+  return _impl_.body_.compact_;
 }
 inline ::greptime::v1::region::CompactRequest* RegionRequest::mutable_compact() {
   ::greptime::v1::region::CompactRequest* _msg = _internal_mutable_compact();
@@ -3720,14 +3720,14 @@ inline ::greptime::v1::region::CompactRequest* RegionRequest::mutable_compact() 
   return _msg;
 }
 
-inline bool RegionRequest::has_region_request_body() const {
-  return region_request_body_case() != REGION_REQUEST_BODY_NOT_SET;
+inline bool RegionRequest::has_body() const {
+  return body_case() != BODY_NOT_SET;
 }
-inline void RegionRequest::clear_has_region_request_body() {
-  _impl_._oneof_case_[0] = REGION_REQUEST_BODY_NOT_SET;
+inline void RegionRequest::clear_has_body() {
+  _impl_._oneof_case_[0] = BODY_NOT_SET;
 }
-inline RegionRequest::RegionRequestBodyCase RegionRequest::region_request_body_case() const {
-  return RegionRequest::RegionRequestBodyCase(_impl_._oneof_case_[0]);
+inline RegionRequest::BodyCase RegionRequest::body_case() const {
+  return RegionRequest::BodyCase(_impl_._oneof_case_[0]);
 }
 // -------------------------------------------------------------------
 

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -174,7 +174,7 @@ class RegionRequest final :
   static const RegionRequest& default_instance() {
     return *internal_default_instance();
   }
-  enum RequestCase {
+  enum RegionRequestBodyCase {
     kInserts = 3,
     kDeletes = 4,
     kCreate = 5,
@@ -184,7 +184,7 @@ class RegionRequest final :
     kAlter = 9,
     kFlush = 10,
     kCompact = 11,
-    REQUEST_NOT_SET = 0,
+    REGION_REQUEST_BODY_NOT_SET = 0,
   };
 
   static inline const RegionRequest* internal_default_instance() {
@@ -456,8 +456,8 @@ class RegionRequest final :
       ::greptime::v1::region::CompactRequest* compact);
   ::greptime::v1::region::CompactRequest* unsafe_arena_release_compact();
 
-  void clear_request();
-  RequestCase request_case() const;
+  void clear_region_request_body();
+  RegionRequestBodyCase region_request_body_case() const;
   // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionRequest)
  private:
   class _Internal;
@@ -471,16 +471,16 @@ class RegionRequest final :
   void set_has_flush();
   void set_has_compact();
 
-  inline bool has_request() const;
-  inline void clear_has_request();
+  inline bool has_region_request_body() const;
+  inline void clear_has_region_request_body();
 
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
     ::greptime::v1::RequestHeader* header_;
-    union RequestUnion {
-      constexpr RequestUnion() : _constinit_{} {}
+    union RegionRequestBodyUnion {
+      constexpr RegionRequestBodyUnion() : _constinit_{} {}
         ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized _constinit_;
       ::greptime::v1::region::InsertRequests* inserts_;
       ::greptime::v1::region::DeleteRequests* deletes_;
@@ -491,7 +491,7 @@ class RegionRequest final :
       ::greptime::v1::region::AlterRequest* alter_;
       ::greptime::v1::region::FlushRequest* flush_;
       ::greptime::v1::region::CompactRequest* compact_;
-    } request_;
+    } region_request_body_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     uint32_t _oneof_case_[1];
 
@@ -3056,7 +3056,7 @@ inline void RegionRequest::set_allocated_header(::greptime::v1::RequestHeader* h
 
 // .greptime.v1.region.InsertRequests inserts = 3;
 inline bool RegionRequest::_internal_has_inserts() const {
-  return request_case() == kInserts;
+  return region_request_body_case() == kInserts;
 }
 inline bool RegionRequest::has_inserts() const {
   return _internal_has_inserts();
@@ -3067,20 +3067,20 @@ inline void RegionRequest::set_has_inserts() {
 inline void RegionRequest::clear_inserts() {
   if (_internal_has_inserts()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.inserts_;
+      delete _impl_.region_request_body_.inserts_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::InsertRequests* RegionRequest::release_inserts() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.inserts)
   if (_internal_has_inserts()) {
-    clear_has_request();
-    ::greptime::v1::region::InsertRequests* temp = _impl_.request_.inserts_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::InsertRequests* temp = _impl_.region_request_body_.inserts_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.inserts_ = nullptr;
+    _impl_.region_request_body_.inserts_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3088,7 +3088,7 @@ inline ::greptime::v1::region::InsertRequests* RegionRequest::release_inserts() 
 }
 inline const ::greptime::v1::region::InsertRequests& RegionRequest::_internal_inserts() const {
   return _internal_has_inserts()
-      ? *_impl_.request_.inserts_
+      ? *_impl_.region_request_body_.inserts_
       : reinterpret_cast< ::greptime::v1::region::InsertRequests&>(::greptime::v1::region::_InsertRequests_default_instance_);
 }
 inline const ::greptime::v1::region::InsertRequests& RegionRequest::inserts() const {
@@ -3098,29 +3098,29 @@ inline const ::greptime::v1::region::InsertRequests& RegionRequest::inserts() co
 inline ::greptime::v1::region::InsertRequests* RegionRequest::unsafe_arena_release_inserts() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.inserts)
   if (_internal_has_inserts()) {
-    clear_has_request();
-    ::greptime::v1::region::InsertRequests* temp = _impl_.request_.inserts_;
-    _impl_.request_.inserts_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::InsertRequests* temp = _impl_.region_request_body_.inserts_;
+    _impl_.region_request_body_.inserts_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_inserts(::greptime::v1::region::InsertRequests* inserts) {
-  clear_request();
+  clear_region_request_body();
   if (inserts) {
     set_has_inserts();
-    _impl_.request_.inserts_ = inserts;
+    _impl_.region_request_body_.inserts_ = inserts;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.inserts)
 }
 inline ::greptime::v1::region::InsertRequests* RegionRequest::_internal_mutable_inserts() {
   if (!_internal_has_inserts()) {
-    clear_request();
+    clear_region_request_body();
     set_has_inserts();
-    _impl_.request_.inserts_ = CreateMaybeMessage< ::greptime::v1::region::InsertRequests >(GetArenaForAllocation());
+    _impl_.region_request_body_.inserts_ = CreateMaybeMessage< ::greptime::v1::region::InsertRequests >(GetArenaForAllocation());
   }
-  return _impl_.request_.inserts_;
+  return _impl_.region_request_body_.inserts_;
 }
 inline ::greptime::v1::region::InsertRequests* RegionRequest::mutable_inserts() {
   ::greptime::v1::region::InsertRequests* _msg = _internal_mutable_inserts();
@@ -3130,7 +3130,7 @@ inline ::greptime::v1::region::InsertRequests* RegionRequest::mutable_inserts() 
 
 // .greptime.v1.region.DeleteRequests deletes = 4;
 inline bool RegionRequest::_internal_has_deletes() const {
-  return request_case() == kDeletes;
+  return region_request_body_case() == kDeletes;
 }
 inline bool RegionRequest::has_deletes() const {
   return _internal_has_deletes();
@@ -3141,20 +3141,20 @@ inline void RegionRequest::set_has_deletes() {
 inline void RegionRequest::clear_deletes() {
   if (_internal_has_deletes()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.deletes_;
+      delete _impl_.region_request_body_.deletes_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::release_deletes() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.deletes)
   if (_internal_has_deletes()) {
-    clear_has_request();
-    ::greptime::v1::region::DeleteRequests* temp = _impl_.request_.deletes_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::DeleteRequests* temp = _impl_.region_request_body_.deletes_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.deletes_ = nullptr;
+    _impl_.region_request_body_.deletes_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3162,7 +3162,7 @@ inline ::greptime::v1::region::DeleteRequests* RegionRequest::release_deletes() 
 }
 inline const ::greptime::v1::region::DeleteRequests& RegionRequest::_internal_deletes() const {
   return _internal_has_deletes()
-      ? *_impl_.request_.deletes_
+      ? *_impl_.region_request_body_.deletes_
       : reinterpret_cast< ::greptime::v1::region::DeleteRequests&>(::greptime::v1::region::_DeleteRequests_default_instance_);
 }
 inline const ::greptime::v1::region::DeleteRequests& RegionRequest::deletes() const {
@@ -3172,29 +3172,29 @@ inline const ::greptime::v1::region::DeleteRequests& RegionRequest::deletes() co
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::unsafe_arena_release_deletes() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.deletes)
   if (_internal_has_deletes()) {
-    clear_has_request();
-    ::greptime::v1::region::DeleteRequests* temp = _impl_.request_.deletes_;
-    _impl_.request_.deletes_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::DeleteRequests* temp = _impl_.region_request_body_.deletes_;
+    _impl_.region_request_body_.deletes_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_deletes(::greptime::v1::region::DeleteRequests* deletes) {
-  clear_request();
+  clear_region_request_body();
   if (deletes) {
     set_has_deletes();
-    _impl_.request_.deletes_ = deletes;
+    _impl_.region_request_body_.deletes_ = deletes;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.deletes)
 }
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::_internal_mutable_deletes() {
   if (!_internal_has_deletes()) {
-    clear_request();
+    clear_region_request_body();
     set_has_deletes();
-    _impl_.request_.deletes_ = CreateMaybeMessage< ::greptime::v1::region::DeleteRequests >(GetArenaForAllocation());
+    _impl_.region_request_body_.deletes_ = CreateMaybeMessage< ::greptime::v1::region::DeleteRequests >(GetArenaForAllocation());
   }
-  return _impl_.request_.deletes_;
+  return _impl_.region_request_body_.deletes_;
 }
 inline ::greptime::v1::region::DeleteRequests* RegionRequest::mutable_deletes() {
   ::greptime::v1::region::DeleteRequests* _msg = _internal_mutable_deletes();
@@ -3204,7 +3204,7 @@ inline ::greptime::v1::region::DeleteRequests* RegionRequest::mutable_deletes() 
 
 // .greptime.v1.region.CreateRequest create = 5;
 inline bool RegionRequest::_internal_has_create() const {
-  return request_case() == kCreate;
+  return region_request_body_case() == kCreate;
 }
 inline bool RegionRequest::has_create() const {
   return _internal_has_create();
@@ -3215,20 +3215,20 @@ inline void RegionRequest::set_has_create() {
 inline void RegionRequest::clear_create() {
   if (_internal_has_create()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.create_;
+      delete _impl_.region_request_body_.create_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::CreateRequest* RegionRequest::release_create() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.create)
   if (_internal_has_create()) {
-    clear_has_request();
-    ::greptime::v1::region::CreateRequest* temp = _impl_.request_.create_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::CreateRequest* temp = _impl_.region_request_body_.create_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.create_ = nullptr;
+    _impl_.region_request_body_.create_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3236,7 +3236,7 @@ inline ::greptime::v1::region::CreateRequest* RegionRequest::release_create() {
 }
 inline const ::greptime::v1::region::CreateRequest& RegionRequest::_internal_create() const {
   return _internal_has_create()
-      ? *_impl_.request_.create_
+      ? *_impl_.region_request_body_.create_
       : reinterpret_cast< ::greptime::v1::region::CreateRequest&>(::greptime::v1::region::_CreateRequest_default_instance_);
 }
 inline const ::greptime::v1::region::CreateRequest& RegionRequest::create() const {
@@ -3246,29 +3246,29 @@ inline const ::greptime::v1::region::CreateRequest& RegionRequest::create() cons
 inline ::greptime::v1::region::CreateRequest* RegionRequest::unsafe_arena_release_create() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.create)
   if (_internal_has_create()) {
-    clear_has_request();
-    ::greptime::v1::region::CreateRequest* temp = _impl_.request_.create_;
-    _impl_.request_.create_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::CreateRequest* temp = _impl_.region_request_body_.create_;
+    _impl_.region_request_body_.create_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_create(::greptime::v1::region::CreateRequest* create) {
-  clear_request();
+  clear_region_request_body();
   if (create) {
     set_has_create();
-    _impl_.request_.create_ = create;
+    _impl_.region_request_body_.create_ = create;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.create)
 }
 inline ::greptime::v1::region::CreateRequest* RegionRequest::_internal_mutable_create() {
   if (!_internal_has_create()) {
-    clear_request();
+    clear_region_request_body();
     set_has_create();
-    _impl_.request_.create_ = CreateMaybeMessage< ::greptime::v1::region::CreateRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.create_ = CreateMaybeMessage< ::greptime::v1::region::CreateRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.create_;
+  return _impl_.region_request_body_.create_;
 }
 inline ::greptime::v1::region::CreateRequest* RegionRequest::mutable_create() {
   ::greptime::v1::region::CreateRequest* _msg = _internal_mutable_create();
@@ -3278,7 +3278,7 @@ inline ::greptime::v1::region::CreateRequest* RegionRequest::mutable_create() {
 
 // .greptime.v1.region.DropRequest drop = 6;
 inline bool RegionRequest::_internal_has_drop() const {
-  return request_case() == kDrop;
+  return region_request_body_case() == kDrop;
 }
 inline bool RegionRequest::has_drop() const {
   return _internal_has_drop();
@@ -3289,20 +3289,20 @@ inline void RegionRequest::set_has_drop() {
 inline void RegionRequest::clear_drop() {
   if (_internal_has_drop()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.drop_;
+      delete _impl_.region_request_body_.drop_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::DropRequest* RegionRequest::release_drop() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.drop)
   if (_internal_has_drop()) {
-    clear_has_request();
-    ::greptime::v1::region::DropRequest* temp = _impl_.request_.drop_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::DropRequest* temp = _impl_.region_request_body_.drop_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.drop_ = nullptr;
+    _impl_.region_request_body_.drop_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3310,7 +3310,7 @@ inline ::greptime::v1::region::DropRequest* RegionRequest::release_drop() {
 }
 inline const ::greptime::v1::region::DropRequest& RegionRequest::_internal_drop() const {
   return _internal_has_drop()
-      ? *_impl_.request_.drop_
+      ? *_impl_.region_request_body_.drop_
       : reinterpret_cast< ::greptime::v1::region::DropRequest&>(::greptime::v1::region::_DropRequest_default_instance_);
 }
 inline const ::greptime::v1::region::DropRequest& RegionRequest::drop() const {
@@ -3320,29 +3320,29 @@ inline const ::greptime::v1::region::DropRequest& RegionRequest::drop() const {
 inline ::greptime::v1::region::DropRequest* RegionRequest::unsafe_arena_release_drop() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.drop)
   if (_internal_has_drop()) {
-    clear_has_request();
-    ::greptime::v1::region::DropRequest* temp = _impl_.request_.drop_;
-    _impl_.request_.drop_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::DropRequest* temp = _impl_.region_request_body_.drop_;
+    _impl_.region_request_body_.drop_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_drop(::greptime::v1::region::DropRequest* drop) {
-  clear_request();
+  clear_region_request_body();
   if (drop) {
     set_has_drop();
-    _impl_.request_.drop_ = drop;
+    _impl_.region_request_body_.drop_ = drop;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.drop)
 }
 inline ::greptime::v1::region::DropRequest* RegionRequest::_internal_mutable_drop() {
   if (!_internal_has_drop()) {
-    clear_request();
+    clear_region_request_body();
     set_has_drop();
-    _impl_.request_.drop_ = CreateMaybeMessage< ::greptime::v1::region::DropRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.drop_ = CreateMaybeMessage< ::greptime::v1::region::DropRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.drop_;
+  return _impl_.region_request_body_.drop_;
 }
 inline ::greptime::v1::region::DropRequest* RegionRequest::mutable_drop() {
   ::greptime::v1::region::DropRequest* _msg = _internal_mutable_drop();
@@ -3352,7 +3352,7 @@ inline ::greptime::v1::region::DropRequest* RegionRequest::mutable_drop() {
 
 // .greptime.v1.region.OpenRequest open = 7;
 inline bool RegionRequest::_internal_has_open() const {
-  return request_case() == kOpen;
+  return region_request_body_case() == kOpen;
 }
 inline bool RegionRequest::has_open() const {
   return _internal_has_open();
@@ -3363,20 +3363,20 @@ inline void RegionRequest::set_has_open() {
 inline void RegionRequest::clear_open() {
   if (_internal_has_open()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.open_;
+      delete _impl_.region_request_body_.open_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::OpenRequest* RegionRequest::release_open() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.open)
   if (_internal_has_open()) {
-    clear_has_request();
-    ::greptime::v1::region::OpenRequest* temp = _impl_.request_.open_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::OpenRequest* temp = _impl_.region_request_body_.open_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.open_ = nullptr;
+    _impl_.region_request_body_.open_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3384,7 +3384,7 @@ inline ::greptime::v1::region::OpenRequest* RegionRequest::release_open() {
 }
 inline const ::greptime::v1::region::OpenRequest& RegionRequest::_internal_open() const {
   return _internal_has_open()
-      ? *_impl_.request_.open_
+      ? *_impl_.region_request_body_.open_
       : reinterpret_cast< ::greptime::v1::region::OpenRequest&>(::greptime::v1::region::_OpenRequest_default_instance_);
 }
 inline const ::greptime::v1::region::OpenRequest& RegionRequest::open() const {
@@ -3394,29 +3394,29 @@ inline const ::greptime::v1::region::OpenRequest& RegionRequest::open() const {
 inline ::greptime::v1::region::OpenRequest* RegionRequest::unsafe_arena_release_open() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.open)
   if (_internal_has_open()) {
-    clear_has_request();
-    ::greptime::v1::region::OpenRequest* temp = _impl_.request_.open_;
-    _impl_.request_.open_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::OpenRequest* temp = _impl_.region_request_body_.open_;
+    _impl_.region_request_body_.open_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_open(::greptime::v1::region::OpenRequest* open) {
-  clear_request();
+  clear_region_request_body();
   if (open) {
     set_has_open();
-    _impl_.request_.open_ = open;
+    _impl_.region_request_body_.open_ = open;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.open)
 }
 inline ::greptime::v1::region::OpenRequest* RegionRequest::_internal_mutable_open() {
   if (!_internal_has_open()) {
-    clear_request();
+    clear_region_request_body();
     set_has_open();
-    _impl_.request_.open_ = CreateMaybeMessage< ::greptime::v1::region::OpenRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.open_ = CreateMaybeMessage< ::greptime::v1::region::OpenRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.open_;
+  return _impl_.region_request_body_.open_;
 }
 inline ::greptime::v1::region::OpenRequest* RegionRequest::mutable_open() {
   ::greptime::v1::region::OpenRequest* _msg = _internal_mutable_open();
@@ -3426,7 +3426,7 @@ inline ::greptime::v1::region::OpenRequest* RegionRequest::mutable_open() {
 
 // .greptime.v1.region.CloseRequest close = 8;
 inline bool RegionRequest::_internal_has_close() const {
-  return request_case() == kClose;
+  return region_request_body_case() == kClose;
 }
 inline bool RegionRequest::has_close() const {
   return _internal_has_close();
@@ -3437,20 +3437,20 @@ inline void RegionRequest::set_has_close() {
 inline void RegionRequest::clear_close() {
   if (_internal_has_close()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.close_;
+      delete _impl_.region_request_body_.close_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::CloseRequest* RegionRequest::release_close() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.close)
   if (_internal_has_close()) {
-    clear_has_request();
-    ::greptime::v1::region::CloseRequest* temp = _impl_.request_.close_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::CloseRequest* temp = _impl_.region_request_body_.close_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.close_ = nullptr;
+    _impl_.region_request_body_.close_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3458,7 +3458,7 @@ inline ::greptime::v1::region::CloseRequest* RegionRequest::release_close() {
 }
 inline const ::greptime::v1::region::CloseRequest& RegionRequest::_internal_close() const {
   return _internal_has_close()
-      ? *_impl_.request_.close_
+      ? *_impl_.region_request_body_.close_
       : reinterpret_cast< ::greptime::v1::region::CloseRequest&>(::greptime::v1::region::_CloseRequest_default_instance_);
 }
 inline const ::greptime::v1::region::CloseRequest& RegionRequest::close() const {
@@ -3468,29 +3468,29 @@ inline const ::greptime::v1::region::CloseRequest& RegionRequest::close() const 
 inline ::greptime::v1::region::CloseRequest* RegionRequest::unsafe_arena_release_close() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.close)
   if (_internal_has_close()) {
-    clear_has_request();
-    ::greptime::v1::region::CloseRequest* temp = _impl_.request_.close_;
-    _impl_.request_.close_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::CloseRequest* temp = _impl_.region_request_body_.close_;
+    _impl_.region_request_body_.close_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_close(::greptime::v1::region::CloseRequest* close) {
-  clear_request();
+  clear_region_request_body();
   if (close) {
     set_has_close();
-    _impl_.request_.close_ = close;
+    _impl_.region_request_body_.close_ = close;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.close)
 }
 inline ::greptime::v1::region::CloseRequest* RegionRequest::_internal_mutable_close() {
   if (!_internal_has_close()) {
-    clear_request();
+    clear_region_request_body();
     set_has_close();
-    _impl_.request_.close_ = CreateMaybeMessage< ::greptime::v1::region::CloseRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.close_ = CreateMaybeMessage< ::greptime::v1::region::CloseRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.close_;
+  return _impl_.region_request_body_.close_;
 }
 inline ::greptime::v1::region::CloseRequest* RegionRequest::mutable_close() {
   ::greptime::v1::region::CloseRequest* _msg = _internal_mutable_close();
@@ -3500,7 +3500,7 @@ inline ::greptime::v1::region::CloseRequest* RegionRequest::mutable_close() {
 
 // .greptime.v1.region.AlterRequest alter = 9;
 inline bool RegionRequest::_internal_has_alter() const {
-  return request_case() == kAlter;
+  return region_request_body_case() == kAlter;
 }
 inline bool RegionRequest::has_alter() const {
   return _internal_has_alter();
@@ -3511,20 +3511,20 @@ inline void RegionRequest::set_has_alter() {
 inline void RegionRequest::clear_alter() {
   if (_internal_has_alter()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.alter_;
+      delete _impl_.region_request_body_.alter_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::AlterRequest* RegionRequest::release_alter() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.alter)
   if (_internal_has_alter()) {
-    clear_has_request();
-    ::greptime::v1::region::AlterRequest* temp = _impl_.request_.alter_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::AlterRequest* temp = _impl_.region_request_body_.alter_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.alter_ = nullptr;
+    _impl_.region_request_body_.alter_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3532,7 +3532,7 @@ inline ::greptime::v1::region::AlterRequest* RegionRequest::release_alter() {
 }
 inline const ::greptime::v1::region::AlterRequest& RegionRequest::_internal_alter() const {
   return _internal_has_alter()
-      ? *_impl_.request_.alter_
+      ? *_impl_.region_request_body_.alter_
       : reinterpret_cast< ::greptime::v1::region::AlterRequest&>(::greptime::v1::region::_AlterRequest_default_instance_);
 }
 inline const ::greptime::v1::region::AlterRequest& RegionRequest::alter() const {
@@ -3542,29 +3542,29 @@ inline const ::greptime::v1::region::AlterRequest& RegionRequest::alter() const 
 inline ::greptime::v1::region::AlterRequest* RegionRequest::unsafe_arena_release_alter() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.alter)
   if (_internal_has_alter()) {
-    clear_has_request();
-    ::greptime::v1::region::AlterRequest* temp = _impl_.request_.alter_;
-    _impl_.request_.alter_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::AlterRequest* temp = _impl_.region_request_body_.alter_;
+    _impl_.region_request_body_.alter_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_alter(::greptime::v1::region::AlterRequest* alter) {
-  clear_request();
+  clear_region_request_body();
   if (alter) {
     set_has_alter();
-    _impl_.request_.alter_ = alter;
+    _impl_.region_request_body_.alter_ = alter;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.alter)
 }
 inline ::greptime::v1::region::AlterRequest* RegionRequest::_internal_mutable_alter() {
   if (!_internal_has_alter()) {
-    clear_request();
+    clear_region_request_body();
     set_has_alter();
-    _impl_.request_.alter_ = CreateMaybeMessage< ::greptime::v1::region::AlterRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.alter_ = CreateMaybeMessage< ::greptime::v1::region::AlterRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.alter_;
+  return _impl_.region_request_body_.alter_;
 }
 inline ::greptime::v1::region::AlterRequest* RegionRequest::mutable_alter() {
   ::greptime::v1::region::AlterRequest* _msg = _internal_mutable_alter();
@@ -3574,7 +3574,7 @@ inline ::greptime::v1::region::AlterRequest* RegionRequest::mutable_alter() {
 
 // .greptime.v1.region.FlushRequest flush = 10;
 inline bool RegionRequest::_internal_has_flush() const {
-  return request_case() == kFlush;
+  return region_request_body_case() == kFlush;
 }
 inline bool RegionRequest::has_flush() const {
   return _internal_has_flush();
@@ -3585,20 +3585,20 @@ inline void RegionRequest::set_has_flush() {
 inline void RegionRequest::clear_flush() {
   if (_internal_has_flush()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.flush_;
+      delete _impl_.region_request_body_.flush_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::FlushRequest* RegionRequest::release_flush() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.flush)
   if (_internal_has_flush()) {
-    clear_has_request();
-    ::greptime::v1::region::FlushRequest* temp = _impl_.request_.flush_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::FlushRequest* temp = _impl_.region_request_body_.flush_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.flush_ = nullptr;
+    _impl_.region_request_body_.flush_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3606,7 +3606,7 @@ inline ::greptime::v1::region::FlushRequest* RegionRequest::release_flush() {
 }
 inline const ::greptime::v1::region::FlushRequest& RegionRequest::_internal_flush() const {
   return _internal_has_flush()
-      ? *_impl_.request_.flush_
+      ? *_impl_.region_request_body_.flush_
       : reinterpret_cast< ::greptime::v1::region::FlushRequest&>(::greptime::v1::region::_FlushRequest_default_instance_);
 }
 inline const ::greptime::v1::region::FlushRequest& RegionRequest::flush() const {
@@ -3616,29 +3616,29 @@ inline const ::greptime::v1::region::FlushRequest& RegionRequest::flush() const 
 inline ::greptime::v1::region::FlushRequest* RegionRequest::unsafe_arena_release_flush() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.flush)
   if (_internal_has_flush()) {
-    clear_has_request();
-    ::greptime::v1::region::FlushRequest* temp = _impl_.request_.flush_;
-    _impl_.request_.flush_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::FlushRequest* temp = _impl_.region_request_body_.flush_;
+    _impl_.region_request_body_.flush_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_flush(::greptime::v1::region::FlushRequest* flush) {
-  clear_request();
+  clear_region_request_body();
   if (flush) {
     set_has_flush();
-    _impl_.request_.flush_ = flush;
+    _impl_.region_request_body_.flush_ = flush;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.flush)
 }
 inline ::greptime::v1::region::FlushRequest* RegionRequest::_internal_mutable_flush() {
   if (!_internal_has_flush()) {
-    clear_request();
+    clear_region_request_body();
     set_has_flush();
-    _impl_.request_.flush_ = CreateMaybeMessage< ::greptime::v1::region::FlushRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.flush_ = CreateMaybeMessage< ::greptime::v1::region::FlushRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.flush_;
+  return _impl_.region_request_body_.flush_;
 }
 inline ::greptime::v1::region::FlushRequest* RegionRequest::mutable_flush() {
   ::greptime::v1::region::FlushRequest* _msg = _internal_mutable_flush();
@@ -3648,7 +3648,7 @@ inline ::greptime::v1::region::FlushRequest* RegionRequest::mutable_flush() {
 
 // .greptime.v1.region.CompactRequest compact = 11;
 inline bool RegionRequest::_internal_has_compact() const {
-  return request_case() == kCompact;
+  return region_request_body_case() == kCompact;
 }
 inline bool RegionRequest::has_compact() const {
   return _internal_has_compact();
@@ -3659,20 +3659,20 @@ inline void RegionRequest::set_has_compact() {
 inline void RegionRequest::clear_compact() {
   if (_internal_has_compact()) {
     if (GetArenaForAllocation() == nullptr) {
-      delete _impl_.request_.compact_;
+      delete _impl_.region_request_body_.compact_;
     }
-    clear_has_request();
+    clear_has_region_request_body();
   }
 }
 inline ::greptime::v1::region::CompactRequest* RegionRequest::release_compact() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.compact)
   if (_internal_has_compact()) {
-    clear_has_request();
-    ::greptime::v1::region::CompactRequest* temp = _impl_.request_.compact_;
+    clear_has_region_request_body();
+    ::greptime::v1::region::CompactRequest* temp = _impl_.region_request_body_.compact_;
     if (GetArenaForAllocation() != nullptr) {
       temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.request_.compact_ = nullptr;
+    _impl_.region_request_body_.compact_ = nullptr;
     return temp;
   } else {
     return nullptr;
@@ -3680,7 +3680,7 @@ inline ::greptime::v1::region::CompactRequest* RegionRequest::release_compact() 
 }
 inline const ::greptime::v1::region::CompactRequest& RegionRequest::_internal_compact() const {
   return _internal_has_compact()
-      ? *_impl_.request_.compact_
+      ? *_impl_.region_request_body_.compact_
       : reinterpret_cast< ::greptime::v1::region::CompactRequest&>(::greptime::v1::region::_CompactRequest_default_instance_);
 }
 inline const ::greptime::v1::region::CompactRequest& RegionRequest::compact() const {
@@ -3690,29 +3690,29 @@ inline const ::greptime::v1::region::CompactRequest& RegionRequest::compact() co
 inline ::greptime::v1::region::CompactRequest* RegionRequest::unsafe_arena_release_compact() {
   // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.RegionRequest.compact)
   if (_internal_has_compact()) {
-    clear_has_request();
-    ::greptime::v1::region::CompactRequest* temp = _impl_.request_.compact_;
-    _impl_.request_.compact_ = nullptr;
+    clear_has_region_request_body();
+    ::greptime::v1::region::CompactRequest* temp = _impl_.region_request_body_.compact_;
+    _impl_.region_request_body_.compact_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
 inline void RegionRequest::unsafe_arena_set_allocated_compact(::greptime::v1::region::CompactRequest* compact) {
-  clear_request();
+  clear_region_request_body();
   if (compact) {
     set_has_compact();
-    _impl_.request_.compact_ = compact;
+    _impl_.region_request_body_.compact_ = compact;
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.compact)
 }
 inline ::greptime::v1::region::CompactRequest* RegionRequest::_internal_mutable_compact() {
   if (!_internal_has_compact()) {
-    clear_request();
+    clear_region_request_body();
     set_has_compact();
-    _impl_.request_.compact_ = CreateMaybeMessage< ::greptime::v1::region::CompactRequest >(GetArenaForAllocation());
+    _impl_.region_request_body_.compact_ = CreateMaybeMessage< ::greptime::v1::region::CompactRequest >(GetArenaForAllocation());
   }
-  return _impl_.request_.compact_;
+  return _impl_.region_request_body_.compact_;
 }
 inline ::greptime::v1::region::CompactRequest* RegionRequest::mutable_compact() {
   ::greptime::v1::region::CompactRequest* _msg = _internal_mutable_compact();
@@ -3720,14 +3720,14 @@ inline ::greptime::v1::region::CompactRequest* RegionRequest::mutable_compact() 
   return _msg;
 }
 
-inline bool RegionRequest::has_request() const {
-  return request_case() != REQUEST_NOT_SET;
+inline bool RegionRequest::has_region_request_body() const {
+  return region_request_body_case() != REGION_REQUEST_BODY_NOT_SET;
 }
-inline void RegionRequest::clear_has_request() {
-  _impl_._oneof_case_[0] = REQUEST_NOT_SET;
+inline void RegionRequest::clear_has_region_request_body() {
+  _impl_._oneof_case_[0] = REGION_REQUEST_BODY_NOT_SET;
 }
-inline RegionRequest::RequestCase RegionRequest::request_case() const {
-  return RegionRequest::RequestCase(_impl_._oneof_case_[0]);
+inline RegionRequest::RegionRequestBodyCase RegionRequest::region_request_body_case() const {
+  return RegionRequest::RegionRequestBodyCase(_impl_._oneof_case_[0]);
 }
 // -------------------------------------------------------------------
 

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -168,7 +168,7 @@ public final class Server {
      */
     io.greptime.v1.region.Server.CompactRequestOrBuilder getCompactOrBuilder();
 
-    public io.greptime.v1.region.Server.RegionRequest.RequestCase getRequestCase();
+    public io.greptime.v1.region.Server.RegionRequest.RegionRequestBodyCase getRegionRequestBodyCase();
   }
   /**
    * Protobuf type {@code greptime.v1.region.RegionRequest}
@@ -230,128 +230,128 @@ public final class Server {
             }
             case 26: {
               io.greptime.v1.region.Server.InsertRequests.Builder subBuilder = null;
-              if (requestCase_ == 3) {
-                subBuilder = ((io.greptime.v1.region.Server.InsertRequests) request_).toBuilder();
+              if (regionRequestBodyCase_ == 3) {
+                subBuilder = ((io.greptime.v1.region.Server.InsertRequests) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.InsertRequests.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.InsertRequests) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.InsertRequests) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 3;
+              regionRequestBodyCase_ = 3;
               break;
             }
             case 34: {
               io.greptime.v1.region.Server.DeleteRequests.Builder subBuilder = null;
-              if (requestCase_ == 4) {
-                subBuilder = ((io.greptime.v1.region.Server.DeleteRequests) request_).toBuilder();
+              if (regionRequestBodyCase_ == 4) {
+                subBuilder = ((io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.DeleteRequests.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.DeleteRequests) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 4;
+              regionRequestBodyCase_ = 4;
               break;
             }
             case 42: {
               io.greptime.v1.region.Server.CreateRequest.Builder subBuilder = null;
-              if (requestCase_ == 5) {
-                subBuilder = ((io.greptime.v1.region.Server.CreateRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 5) {
+                subBuilder = ((io.greptime.v1.region.Server.CreateRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.CreateRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.CreateRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.CreateRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 5;
+              regionRequestBodyCase_ = 5;
               break;
             }
             case 50: {
               io.greptime.v1.region.Server.DropRequest.Builder subBuilder = null;
-              if (requestCase_ == 6) {
-                subBuilder = ((io.greptime.v1.region.Server.DropRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 6) {
+                subBuilder = ((io.greptime.v1.region.Server.DropRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.DropRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.DropRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.DropRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 6;
+              regionRequestBodyCase_ = 6;
               break;
             }
             case 58: {
               io.greptime.v1.region.Server.OpenRequest.Builder subBuilder = null;
-              if (requestCase_ == 7) {
-                subBuilder = ((io.greptime.v1.region.Server.OpenRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 7) {
+                subBuilder = ((io.greptime.v1.region.Server.OpenRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.OpenRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.OpenRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.OpenRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 7;
+              regionRequestBodyCase_ = 7;
               break;
             }
             case 66: {
               io.greptime.v1.region.Server.CloseRequest.Builder subBuilder = null;
-              if (requestCase_ == 8) {
-                subBuilder = ((io.greptime.v1.region.Server.CloseRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 8) {
+                subBuilder = ((io.greptime.v1.region.Server.CloseRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.CloseRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.CloseRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.CloseRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 8;
+              regionRequestBodyCase_ = 8;
               break;
             }
             case 74: {
               io.greptime.v1.region.Server.AlterRequest.Builder subBuilder = null;
-              if (requestCase_ == 9) {
-                subBuilder = ((io.greptime.v1.region.Server.AlterRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 9) {
+                subBuilder = ((io.greptime.v1.region.Server.AlterRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.AlterRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.AlterRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.AlterRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 9;
+              regionRequestBodyCase_ = 9;
               break;
             }
             case 82: {
               io.greptime.v1.region.Server.FlushRequest.Builder subBuilder = null;
-              if (requestCase_ == 10) {
-                subBuilder = ((io.greptime.v1.region.Server.FlushRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 10) {
+                subBuilder = ((io.greptime.v1.region.Server.FlushRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.FlushRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.FlushRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.FlushRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 10;
+              regionRequestBodyCase_ = 10;
               break;
             }
             case 90: {
               io.greptime.v1.region.Server.CompactRequest.Builder subBuilder = null;
-              if (requestCase_ == 11) {
-                subBuilder = ((io.greptime.v1.region.Server.CompactRequest) request_).toBuilder();
+              if (regionRequestBodyCase_ == 11) {
+                subBuilder = ((io.greptime.v1.region.Server.CompactRequest) regionRequestBody_).toBuilder();
               }
-              request_ =
+              regionRequestBody_ =
                   input.readMessage(io.greptime.v1.region.Server.CompactRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.CompactRequest) request_);
-                request_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.CompactRequest) regionRequestBody_);
+                regionRequestBody_ = subBuilder.buildPartial();
               }
-              requestCase_ = 11;
+              regionRequestBodyCase_ = 11;
               break;
             }
             default: {
@@ -388,9 +388,9 @@ public final class Server {
               io.greptime.v1.region.Server.RegionRequest.class, io.greptime.v1.region.Server.RegionRequest.Builder.class);
     }
 
-    private int requestCase_ = 0;
-    private java.lang.Object request_;
-    public enum RequestCase
+    private int regionRequestBodyCase_ = 0;
+    private java.lang.Object regionRequestBody_;
+    public enum RegionRequestBodyCase
         implements com.google.protobuf.Internal.EnumLite,
             com.google.protobuf.AbstractMessage.InternalOneOfEnum {
       INSERTS(3),
@@ -402,9 +402,9 @@ public final class Server {
       ALTER(9),
       FLUSH(10),
       COMPACT(11),
-      REQUEST_NOT_SET(0);
+      REGIONREQUESTBODY_NOT_SET(0);
       private final int value;
-      private RequestCase(int value) {
+      private RegionRequestBodyCase(int value) {
         this.value = value;
       }
       /**
@@ -413,11 +413,11 @@ public final class Server {
        * @deprecated Use {@link #forNumber(int)} instead.
        */
       @java.lang.Deprecated
-      public static RequestCase valueOf(int value) {
+      public static RegionRequestBodyCase valueOf(int value) {
         return forNumber(value);
       }
 
-      public static RequestCase forNumber(int value) {
+      public static RegionRequestBodyCase forNumber(int value) {
         switch (value) {
           case 3: return INSERTS;
           case 4: return DELETES;
@@ -428,7 +428,7 @@ public final class Server {
           case 9: return ALTER;
           case 10: return FLUSH;
           case 11: return COMPACT;
-          case 0: return REQUEST_NOT_SET;
+          case 0: return REGIONREQUESTBODY_NOT_SET;
           default: return null;
         }
       }
@@ -437,10 +437,10 @@ public final class Server {
       }
     };
 
-    public RequestCase
-    getRequestCase() {
-      return RequestCase.forNumber(
-          requestCase_);
+    public RegionRequestBodyCase
+    getRegionRequestBodyCase() {
+      return RegionRequestBodyCase.forNumber(
+          regionRequestBodyCase_);
     }
 
     public static final int HEADER_FIELD_NUMBER = 1;
@@ -476,7 +476,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasInserts() {
-      return requestCase_ == 3;
+      return regionRequestBodyCase_ == 3;
     }
     /**
      * <code>.greptime.v1.region.InsertRequests inserts = 3;</code>
@@ -484,8 +484,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.InsertRequests getInserts() {
-      if (requestCase_ == 3) {
-         return (io.greptime.v1.region.Server.InsertRequests) request_;
+      if (regionRequestBodyCase_ == 3) {
+         return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
     }
@@ -494,8 +494,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.InsertRequestsOrBuilder getInsertsOrBuilder() {
-      if (requestCase_ == 3) {
-         return (io.greptime.v1.region.Server.InsertRequests) request_;
+      if (regionRequestBodyCase_ == 3) {
+         return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
     }
@@ -507,7 +507,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasDeletes() {
-      return requestCase_ == 4;
+      return regionRequestBodyCase_ == 4;
     }
     /**
      * <code>.greptime.v1.region.DeleteRequests deletes = 4;</code>
@@ -515,8 +515,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DeleteRequests getDeletes() {
-      if (requestCase_ == 4) {
-         return (io.greptime.v1.region.Server.DeleteRequests) request_;
+      if (regionRequestBodyCase_ == 4) {
+         return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
     }
@@ -525,8 +525,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DeleteRequestsOrBuilder getDeletesOrBuilder() {
-      if (requestCase_ == 4) {
-         return (io.greptime.v1.region.Server.DeleteRequests) request_;
+      if (regionRequestBodyCase_ == 4) {
+         return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
     }
@@ -538,7 +538,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasCreate() {
-      return requestCase_ == 5;
+      return regionRequestBodyCase_ == 5;
     }
     /**
      * <code>.greptime.v1.region.CreateRequest create = 5;</code>
@@ -546,8 +546,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CreateRequest getCreate() {
-      if (requestCase_ == 5) {
-         return (io.greptime.v1.region.Server.CreateRequest) request_;
+      if (regionRequestBodyCase_ == 5) {
+         return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
     }
@@ -556,8 +556,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CreateRequestOrBuilder getCreateOrBuilder() {
-      if (requestCase_ == 5) {
-         return (io.greptime.v1.region.Server.CreateRequest) request_;
+      if (regionRequestBodyCase_ == 5) {
+         return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
     }
@@ -569,7 +569,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasDrop() {
-      return requestCase_ == 6;
+      return regionRequestBodyCase_ == 6;
     }
     /**
      * <code>.greptime.v1.region.DropRequest drop = 6;</code>
@@ -577,8 +577,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DropRequest getDrop() {
-      if (requestCase_ == 6) {
-         return (io.greptime.v1.region.Server.DropRequest) request_;
+      if (regionRequestBodyCase_ == 6) {
+         return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
     }
@@ -587,8 +587,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DropRequestOrBuilder getDropOrBuilder() {
-      if (requestCase_ == 6) {
-         return (io.greptime.v1.region.Server.DropRequest) request_;
+      if (regionRequestBodyCase_ == 6) {
+         return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
     }
@@ -600,7 +600,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasOpen() {
-      return requestCase_ == 7;
+      return regionRequestBodyCase_ == 7;
     }
     /**
      * <code>.greptime.v1.region.OpenRequest open = 7;</code>
@@ -608,8 +608,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.OpenRequest getOpen() {
-      if (requestCase_ == 7) {
-         return (io.greptime.v1.region.Server.OpenRequest) request_;
+      if (regionRequestBodyCase_ == 7) {
+         return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
     }
@@ -618,8 +618,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.OpenRequestOrBuilder getOpenOrBuilder() {
-      if (requestCase_ == 7) {
-         return (io.greptime.v1.region.Server.OpenRequest) request_;
+      if (regionRequestBodyCase_ == 7) {
+         return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
     }
@@ -631,7 +631,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasClose() {
-      return requestCase_ == 8;
+      return regionRequestBodyCase_ == 8;
     }
     /**
      * <code>.greptime.v1.region.CloseRequest close = 8;</code>
@@ -639,8 +639,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CloseRequest getClose() {
-      if (requestCase_ == 8) {
-         return (io.greptime.v1.region.Server.CloseRequest) request_;
+      if (regionRequestBodyCase_ == 8) {
+         return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
     }
@@ -649,8 +649,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CloseRequestOrBuilder getCloseOrBuilder() {
-      if (requestCase_ == 8) {
-         return (io.greptime.v1.region.Server.CloseRequest) request_;
+      if (regionRequestBodyCase_ == 8) {
+         return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
     }
@@ -662,7 +662,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasAlter() {
-      return requestCase_ == 9;
+      return regionRequestBodyCase_ == 9;
     }
     /**
      * <code>.greptime.v1.region.AlterRequest alter = 9;</code>
@@ -670,8 +670,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.AlterRequest getAlter() {
-      if (requestCase_ == 9) {
-         return (io.greptime.v1.region.Server.AlterRequest) request_;
+      if (regionRequestBodyCase_ == 9) {
+         return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
     }
@@ -680,8 +680,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.AlterRequestOrBuilder getAlterOrBuilder() {
-      if (requestCase_ == 9) {
-         return (io.greptime.v1.region.Server.AlterRequest) request_;
+      if (regionRequestBodyCase_ == 9) {
+         return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
     }
@@ -693,7 +693,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasFlush() {
-      return requestCase_ == 10;
+      return regionRequestBodyCase_ == 10;
     }
     /**
      * <code>.greptime.v1.region.FlushRequest flush = 10;</code>
@@ -701,8 +701,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.FlushRequest getFlush() {
-      if (requestCase_ == 10) {
-         return (io.greptime.v1.region.Server.FlushRequest) request_;
+      if (regionRequestBodyCase_ == 10) {
+         return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
     }
@@ -711,8 +711,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.FlushRequestOrBuilder getFlushOrBuilder() {
-      if (requestCase_ == 10) {
-         return (io.greptime.v1.region.Server.FlushRequest) request_;
+      if (regionRequestBodyCase_ == 10) {
+         return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
     }
@@ -724,7 +724,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasCompact() {
-      return requestCase_ == 11;
+      return regionRequestBodyCase_ == 11;
     }
     /**
      * <code>.greptime.v1.region.CompactRequest compact = 11;</code>
@@ -732,8 +732,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CompactRequest getCompact() {
-      if (requestCase_ == 11) {
-         return (io.greptime.v1.region.Server.CompactRequest) request_;
+      if (regionRequestBodyCase_ == 11) {
+         return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
     }
@@ -742,8 +742,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CompactRequestOrBuilder getCompactOrBuilder() {
-      if (requestCase_ == 11) {
-         return (io.greptime.v1.region.Server.CompactRequest) request_;
+      if (regionRequestBodyCase_ == 11) {
+         return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
       }
       return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
     }
@@ -765,32 +765,32 @@ public final class Server {
       if (header_ != null) {
         output.writeMessage(1, getHeader());
       }
-      if (requestCase_ == 3) {
-        output.writeMessage(3, (io.greptime.v1.region.Server.InsertRequests) request_);
+      if (regionRequestBodyCase_ == 3) {
+        output.writeMessage(3, (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_);
       }
-      if (requestCase_ == 4) {
-        output.writeMessage(4, (io.greptime.v1.region.Server.DeleteRequests) request_);
+      if (regionRequestBodyCase_ == 4) {
+        output.writeMessage(4, (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_);
       }
-      if (requestCase_ == 5) {
-        output.writeMessage(5, (io.greptime.v1.region.Server.CreateRequest) request_);
+      if (regionRequestBodyCase_ == 5) {
+        output.writeMessage(5, (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_);
       }
-      if (requestCase_ == 6) {
-        output.writeMessage(6, (io.greptime.v1.region.Server.DropRequest) request_);
+      if (regionRequestBodyCase_ == 6) {
+        output.writeMessage(6, (io.greptime.v1.region.Server.DropRequest) regionRequestBody_);
       }
-      if (requestCase_ == 7) {
-        output.writeMessage(7, (io.greptime.v1.region.Server.OpenRequest) request_);
+      if (regionRequestBodyCase_ == 7) {
+        output.writeMessage(7, (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_);
       }
-      if (requestCase_ == 8) {
-        output.writeMessage(8, (io.greptime.v1.region.Server.CloseRequest) request_);
+      if (regionRequestBodyCase_ == 8) {
+        output.writeMessage(8, (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_);
       }
-      if (requestCase_ == 9) {
-        output.writeMessage(9, (io.greptime.v1.region.Server.AlterRequest) request_);
+      if (regionRequestBodyCase_ == 9) {
+        output.writeMessage(9, (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_);
       }
-      if (requestCase_ == 10) {
-        output.writeMessage(10, (io.greptime.v1.region.Server.FlushRequest) request_);
+      if (regionRequestBodyCase_ == 10) {
+        output.writeMessage(10, (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_);
       }
-      if (requestCase_ == 11) {
-        output.writeMessage(11, (io.greptime.v1.region.Server.CompactRequest) request_);
+      if (regionRequestBodyCase_ == 11) {
+        output.writeMessage(11, (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_);
       }
       unknownFields.writeTo(output);
     }
@@ -805,41 +805,41 @@ public final class Server {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getHeader());
       }
-      if (requestCase_ == 3) {
+      if (regionRequestBodyCase_ == 3) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, (io.greptime.v1.region.Server.InsertRequests) request_);
+          .computeMessageSize(3, (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_);
       }
-      if (requestCase_ == 4) {
+      if (regionRequestBodyCase_ == 4) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, (io.greptime.v1.region.Server.DeleteRequests) request_);
+          .computeMessageSize(4, (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_);
       }
-      if (requestCase_ == 5) {
+      if (regionRequestBodyCase_ == 5) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(5, (io.greptime.v1.region.Server.CreateRequest) request_);
+          .computeMessageSize(5, (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_);
       }
-      if (requestCase_ == 6) {
+      if (regionRequestBodyCase_ == 6) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(6, (io.greptime.v1.region.Server.DropRequest) request_);
+          .computeMessageSize(6, (io.greptime.v1.region.Server.DropRequest) regionRequestBody_);
       }
-      if (requestCase_ == 7) {
+      if (regionRequestBodyCase_ == 7) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(7, (io.greptime.v1.region.Server.OpenRequest) request_);
+          .computeMessageSize(7, (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_);
       }
-      if (requestCase_ == 8) {
+      if (regionRequestBodyCase_ == 8) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(8, (io.greptime.v1.region.Server.CloseRequest) request_);
+          .computeMessageSize(8, (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_);
       }
-      if (requestCase_ == 9) {
+      if (regionRequestBodyCase_ == 9) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(9, (io.greptime.v1.region.Server.AlterRequest) request_);
+          .computeMessageSize(9, (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_);
       }
-      if (requestCase_ == 10) {
+      if (regionRequestBodyCase_ == 10) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(10, (io.greptime.v1.region.Server.FlushRequest) request_);
+          .computeMessageSize(10, (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_);
       }
-      if (requestCase_ == 11) {
+      if (regionRequestBodyCase_ == 11) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(11, (io.greptime.v1.region.Server.CompactRequest) request_);
+          .computeMessageSize(11, (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -861,8 +861,8 @@ public final class Server {
         if (!getHeader()
             .equals(other.getHeader())) return false;
       }
-      if (!getRequestCase().equals(other.getRequestCase())) return false;
-      switch (requestCase_) {
+      if (!getRegionRequestBodyCase().equals(other.getRegionRequestBodyCase())) return false;
+      switch (regionRequestBodyCase_) {
         case 3:
           if (!getInserts()
               .equals(other.getInserts())) return false;
@@ -917,7 +917,7 @@ public final class Server {
         hash = (37 * hash) + HEADER_FIELD_NUMBER;
         hash = (53 * hash) + getHeader().hashCode();
       }
-      switch (requestCase_) {
+      switch (regionRequestBodyCase_) {
         case 3:
           hash = (37 * hash) + INSERTS_FIELD_NUMBER;
           hash = (53 * hash) + getInserts().hashCode();
@@ -1096,8 +1096,8 @@ public final class Server {
           header_ = null;
           headerBuilder_ = null;
         }
-        requestCase_ = 0;
-        request_ = null;
+        regionRequestBodyCase_ = 0;
+        regionRequestBody_ = null;
         return this;
       }
 
@@ -1129,70 +1129,70 @@ public final class Server {
         } else {
           result.header_ = headerBuilder_.build();
         }
-        if (requestCase_ == 3) {
+        if (regionRequestBodyCase_ == 3) {
           if (insertsBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = insertsBuilder_.build();
+            result.regionRequestBody_ = insertsBuilder_.build();
           }
         }
-        if (requestCase_ == 4) {
+        if (regionRequestBodyCase_ == 4) {
           if (deletesBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = deletesBuilder_.build();
+            result.regionRequestBody_ = deletesBuilder_.build();
           }
         }
-        if (requestCase_ == 5) {
+        if (regionRequestBodyCase_ == 5) {
           if (createBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = createBuilder_.build();
+            result.regionRequestBody_ = createBuilder_.build();
           }
         }
-        if (requestCase_ == 6) {
+        if (regionRequestBodyCase_ == 6) {
           if (dropBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = dropBuilder_.build();
+            result.regionRequestBody_ = dropBuilder_.build();
           }
         }
-        if (requestCase_ == 7) {
+        if (regionRequestBodyCase_ == 7) {
           if (openBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = openBuilder_.build();
+            result.regionRequestBody_ = openBuilder_.build();
           }
         }
-        if (requestCase_ == 8) {
+        if (regionRequestBodyCase_ == 8) {
           if (closeBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = closeBuilder_.build();
+            result.regionRequestBody_ = closeBuilder_.build();
           }
         }
-        if (requestCase_ == 9) {
+        if (regionRequestBodyCase_ == 9) {
           if (alterBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = alterBuilder_.build();
+            result.regionRequestBody_ = alterBuilder_.build();
           }
         }
-        if (requestCase_ == 10) {
+        if (regionRequestBodyCase_ == 10) {
           if (flushBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = flushBuilder_.build();
+            result.regionRequestBody_ = flushBuilder_.build();
           }
         }
-        if (requestCase_ == 11) {
+        if (regionRequestBodyCase_ == 11) {
           if (compactBuilder_ == null) {
-            result.request_ = request_;
+            result.regionRequestBody_ = regionRequestBody_;
           } else {
-            result.request_ = compactBuilder_.build();
+            result.regionRequestBody_ = compactBuilder_.build();
           }
         }
-        result.requestCase_ = requestCase_;
+        result.regionRequestBodyCase_ = regionRequestBodyCase_;
         onBuilt();
         return result;
       }
@@ -1244,7 +1244,7 @@ public final class Server {
         if (other.hasHeader()) {
           mergeHeader(other.getHeader());
         }
-        switch (other.getRequestCase()) {
+        switch (other.getRegionRequestBodyCase()) {
           case INSERTS: {
             mergeInserts(other.getInserts());
             break;
@@ -1281,7 +1281,7 @@ public final class Server {
             mergeCompact(other.getCompact());
             break;
           }
-          case REQUEST_NOT_SET: {
+          case REGIONREQUESTBODY_NOT_SET: {
             break;
           }
         }
@@ -1313,17 +1313,17 @@ public final class Server {
         }
         return this;
       }
-      private int requestCase_ = 0;
-      private java.lang.Object request_;
-      public RequestCase
-          getRequestCase() {
-        return RequestCase.forNumber(
-            requestCase_);
+      private int regionRequestBodyCase_ = 0;
+      private java.lang.Object regionRequestBody_;
+      public RegionRequestBodyCase
+          getRegionRequestBodyCase() {
+        return RegionRequestBodyCase.forNumber(
+            regionRequestBodyCase_);
       }
 
-      public Builder clearRequest() {
-        requestCase_ = 0;
-        request_ = null;
+      public Builder clearRegionRequestBody() {
+        regionRequestBodyCase_ = 0;
+        regionRequestBody_ = null;
         onChanged();
         return this;
       }
@@ -1456,7 +1456,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasInserts() {
-        return requestCase_ == 3;
+        return regionRequestBodyCase_ == 3;
       }
       /**
        * <code>.greptime.v1.region.InsertRequests inserts = 3;</code>
@@ -1465,12 +1465,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.InsertRequests getInserts() {
         if (insertsBuilder_ == null) {
-          if (requestCase_ == 3) {
-            return (io.greptime.v1.region.Server.InsertRequests) request_;
+          if (regionRequestBodyCase_ == 3) {
+            return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
         } else {
-          if (requestCase_ == 3) {
+          if (regionRequestBodyCase_ == 3) {
             return insertsBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
@@ -1484,12 +1484,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           insertsBuilder_.setMessage(value);
         }
-        requestCase_ = 3;
+        regionRequestBodyCase_ = 3;
         return this;
       }
       /**
@@ -1498,12 +1498,12 @@ public final class Server {
       public Builder setInserts(
           io.greptime.v1.region.Server.InsertRequests.Builder builderForValue) {
         if (insertsBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           insertsBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 3;
+        regionRequestBodyCase_ = 3;
         return this;
       }
       /**
@@ -1511,22 +1511,22 @@ public final class Server {
        */
       public Builder mergeInserts(io.greptime.v1.region.Server.InsertRequests value) {
         if (insertsBuilder_ == null) {
-          if (requestCase_ == 3 &&
-              request_ != io.greptime.v1.region.Server.InsertRequests.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.InsertRequests.newBuilder((io.greptime.v1.region.Server.InsertRequests) request_)
+          if (regionRequestBodyCase_ == 3 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.InsertRequests.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.InsertRequests.newBuilder((io.greptime.v1.region.Server.InsertRequests) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 3) {
+          if (regionRequestBodyCase_ == 3) {
             insertsBuilder_.mergeFrom(value);
           } else {
             insertsBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 3;
+        regionRequestBodyCase_ = 3;
         return this;
       }
       /**
@@ -1534,15 +1534,15 @@ public final class Server {
        */
       public Builder clearInserts() {
         if (insertsBuilder_ == null) {
-          if (requestCase_ == 3) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 3) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 3) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 3) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           insertsBuilder_.clear();
         }
@@ -1559,11 +1559,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.InsertRequestsOrBuilder getInsertsOrBuilder() {
-        if ((requestCase_ == 3) && (insertsBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 3) && (insertsBuilder_ != null)) {
           return insertsBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 3) {
-            return (io.greptime.v1.region.Server.InsertRequests) request_;
+          if (regionRequestBodyCase_ == 3) {
+            return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
         }
@@ -1575,17 +1575,17 @@ public final class Server {
           io.greptime.v1.region.Server.InsertRequests, io.greptime.v1.region.Server.InsertRequests.Builder, io.greptime.v1.region.Server.InsertRequestsOrBuilder> 
           getInsertsFieldBuilder() {
         if (insertsBuilder_ == null) {
-          if (!(requestCase_ == 3)) {
-            request_ = io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 3)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
           }
           insertsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.InsertRequests, io.greptime.v1.region.Server.InsertRequests.Builder, io.greptime.v1.region.Server.InsertRequestsOrBuilder>(
-                  (io.greptime.v1.region.Server.InsertRequests) request_,
+                  (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 3;
+        regionRequestBodyCase_ = 3;
         onChanged();;
         return insertsBuilder_;
       }
@@ -1598,7 +1598,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasDeletes() {
-        return requestCase_ == 4;
+        return regionRequestBodyCase_ == 4;
       }
       /**
        * <code>.greptime.v1.region.DeleteRequests deletes = 4;</code>
@@ -1607,12 +1607,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.DeleteRequests getDeletes() {
         if (deletesBuilder_ == null) {
-          if (requestCase_ == 4) {
-            return (io.greptime.v1.region.Server.DeleteRequests) request_;
+          if (regionRequestBodyCase_ == 4) {
+            return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
         } else {
-          if (requestCase_ == 4) {
+          if (regionRequestBodyCase_ == 4) {
             return deletesBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
@@ -1626,12 +1626,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           deletesBuilder_.setMessage(value);
         }
-        requestCase_ = 4;
+        regionRequestBodyCase_ = 4;
         return this;
       }
       /**
@@ -1640,12 +1640,12 @@ public final class Server {
       public Builder setDeletes(
           io.greptime.v1.region.Server.DeleteRequests.Builder builderForValue) {
         if (deletesBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           deletesBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 4;
+        regionRequestBodyCase_ = 4;
         return this;
       }
       /**
@@ -1653,22 +1653,22 @@ public final class Server {
        */
       public Builder mergeDeletes(io.greptime.v1.region.Server.DeleteRequests value) {
         if (deletesBuilder_ == null) {
-          if (requestCase_ == 4 &&
-              request_ != io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.DeleteRequests.newBuilder((io.greptime.v1.region.Server.DeleteRequests) request_)
+          if (regionRequestBodyCase_ == 4 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.DeleteRequests.newBuilder((io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 4) {
+          if (regionRequestBodyCase_ == 4) {
             deletesBuilder_.mergeFrom(value);
           } else {
             deletesBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 4;
+        regionRequestBodyCase_ = 4;
         return this;
       }
       /**
@@ -1676,15 +1676,15 @@ public final class Server {
        */
       public Builder clearDeletes() {
         if (deletesBuilder_ == null) {
-          if (requestCase_ == 4) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 4) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 4) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 4) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           deletesBuilder_.clear();
         }
@@ -1701,11 +1701,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.DeleteRequestsOrBuilder getDeletesOrBuilder() {
-        if ((requestCase_ == 4) && (deletesBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 4) && (deletesBuilder_ != null)) {
           return deletesBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 4) {
-            return (io.greptime.v1.region.Server.DeleteRequests) request_;
+          if (regionRequestBodyCase_ == 4) {
+            return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
         }
@@ -1717,17 +1717,17 @@ public final class Server {
           io.greptime.v1.region.Server.DeleteRequests, io.greptime.v1.region.Server.DeleteRequests.Builder, io.greptime.v1.region.Server.DeleteRequestsOrBuilder> 
           getDeletesFieldBuilder() {
         if (deletesBuilder_ == null) {
-          if (!(requestCase_ == 4)) {
-            request_ = io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 4)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
           }
           deletesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.DeleteRequests, io.greptime.v1.region.Server.DeleteRequests.Builder, io.greptime.v1.region.Server.DeleteRequestsOrBuilder>(
-                  (io.greptime.v1.region.Server.DeleteRequests) request_,
+                  (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 4;
+        regionRequestBodyCase_ = 4;
         onChanged();;
         return deletesBuilder_;
       }
@@ -1740,7 +1740,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasCreate() {
-        return requestCase_ == 5;
+        return regionRequestBodyCase_ == 5;
       }
       /**
        * <code>.greptime.v1.region.CreateRequest create = 5;</code>
@@ -1749,12 +1749,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.CreateRequest getCreate() {
         if (createBuilder_ == null) {
-          if (requestCase_ == 5) {
-            return (io.greptime.v1.region.Server.CreateRequest) request_;
+          if (regionRequestBodyCase_ == 5) {
+            return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 5) {
+          if (regionRequestBodyCase_ == 5) {
             return createBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
@@ -1768,12 +1768,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           createBuilder_.setMessage(value);
         }
-        requestCase_ = 5;
+        regionRequestBodyCase_ = 5;
         return this;
       }
       /**
@@ -1782,12 +1782,12 @@ public final class Server {
       public Builder setCreate(
           io.greptime.v1.region.Server.CreateRequest.Builder builderForValue) {
         if (createBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           createBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 5;
+        regionRequestBodyCase_ = 5;
         return this;
       }
       /**
@@ -1795,22 +1795,22 @@ public final class Server {
        */
       public Builder mergeCreate(io.greptime.v1.region.Server.CreateRequest value) {
         if (createBuilder_ == null) {
-          if (requestCase_ == 5 &&
-              request_ != io.greptime.v1.region.Server.CreateRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.CreateRequest.newBuilder((io.greptime.v1.region.Server.CreateRequest) request_)
+          if (regionRequestBodyCase_ == 5 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.CreateRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.CreateRequest.newBuilder((io.greptime.v1.region.Server.CreateRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 5) {
+          if (regionRequestBodyCase_ == 5) {
             createBuilder_.mergeFrom(value);
           } else {
             createBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 5;
+        regionRequestBodyCase_ = 5;
         return this;
       }
       /**
@@ -1818,15 +1818,15 @@ public final class Server {
        */
       public Builder clearCreate() {
         if (createBuilder_ == null) {
-          if (requestCase_ == 5) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 5) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 5) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 5) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           createBuilder_.clear();
         }
@@ -1843,11 +1843,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.CreateRequestOrBuilder getCreateOrBuilder() {
-        if ((requestCase_ == 5) && (createBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 5) && (createBuilder_ != null)) {
           return createBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 5) {
-            return (io.greptime.v1.region.Server.CreateRequest) request_;
+          if (regionRequestBodyCase_ == 5) {
+            return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
         }
@@ -1859,17 +1859,17 @@ public final class Server {
           io.greptime.v1.region.Server.CreateRequest, io.greptime.v1.region.Server.CreateRequest.Builder, io.greptime.v1.region.Server.CreateRequestOrBuilder> 
           getCreateFieldBuilder() {
         if (createBuilder_ == null) {
-          if (!(requestCase_ == 5)) {
-            request_ = io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 5)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
           }
           createBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.CreateRequest, io.greptime.v1.region.Server.CreateRequest.Builder, io.greptime.v1.region.Server.CreateRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.CreateRequest) request_,
+                  (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 5;
+        regionRequestBodyCase_ = 5;
         onChanged();;
         return createBuilder_;
       }
@@ -1882,7 +1882,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasDrop() {
-        return requestCase_ == 6;
+        return regionRequestBodyCase_ == 6;
       }
       /**
        * <code>.greptime.v1.region.DropRequest drop = 6;</code>
@@ -1891,12 +1891,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.DropRequest getDrop() {
         if (dropBuilder_ == null) {
-          if (requestCase_ == 6) {
-            return (io.greptime.v1.region.Server.DropRequest) request_;
+          if (regionRequestBodyCase_ == 6) {
+            return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 6) {
+          if (regionRequestBodyCase_ == 6) {
             return dropBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
@@ -1910,12 +1910,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           dropBuilder_.setMessage(value);
         }
-        requestCase_ = 6;
+        regionRequestBodyCase_ = 6;
         return this;
       }
       /**
@@ -1924,12 +1924,12 @@ public final class Server {
       public Builder setDrop(
           io.greptime.v1.region.Server.DropRequest.Builder builderForValue) {
         if (dropBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           dropBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 6;
+        regionRequestBodyCase_ = 6;
         return this;
       }
       /**
@@ -1937,22 +1937,22 @@ public final class Server {
        */
       public Builder mergeDrop(io.greptime.v1.region.Server.DropRequest value) {
         if (dropBuilder_ == null) {
-          if (requestCase_ == 6 &&
-              request_ != io.greptime.v1.region.Server.DropRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.DropRequest.newBuilder((io.greptime.v1.region.Server.DropRequest) request_)
+          if (regionRequestBodyCase_ == 6 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.DropRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.DropRequest.newBuilder((io.greptime.v1.region.Server.DropRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 6) {
+          if (regionRequestBodyCase_ == 6) {
             dropBuilder_.mergeFrom(value);
           } else {
             dropBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 6;
+        regionRequestBodyCase_ = 6;
         return this;
       }
       /**
@@ -1960,15 +1960,15 @@ public final class Server {
        */
       public Builder clearDrop() {
         if (dropBuilder_ == null) {
-          if (requestCase_ == 6) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 6) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 6) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 6) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           dropBuilder_.clear();
         }
@@ -1985,11 +1985,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.DropRequestOrBuilder getDropOrBuilder() {
-        if ((requestCase_ == 6) && (dropBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 6) && (dropBuilder_ != null)) {
           return dropBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 6) {
-            return (io.greptime.v1.region.Server.DropRequest) request_;
+          if (regionRequestBodyCase_ == 6) {
+            return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
         }
@@ -2001,17 +2001,17 @@ public final class Server {
           io.greptime.v1.region.Server.DropRequest, io.greptime.v1.region.Server.DropRequest.Builder, io.greptime.v1.region.Server.DropRequestOrBuilder> 
           getDropFieldBuilder() {
         if (dropBuilder_ == null) {
-          if (!(requestCase_ == 6)) {
-            request_ = io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 6)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
           }
           dropBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.DropRequest, io.greptime.v1.region.Server.DropRequest.Builder, io.greptime.v1.region.Server.DropRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.DropRequest) request_,
+                  (io.greptime.v1.region.Server.DropRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 6;
+        regionRequestBodyCase_ = 6;
         onChanged();;
         return dropBuilder_;
       }
@@ -2024,7 +2024,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasOpen() {
-        return requestCase_ == 7;
+        return regionRequestBodyCase_ == 7;
       }
       /**
        * <code>.greptime.v1.region.OpenRequest open = 7;</code>
@@ -2033,12 +2033,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.OpenRequest getOpen() {
         if (openBuilder_ == null) {
-          if (requestCase_ == 7) {
-            return (io.greptime.v1.region.Server.OpenRequest) request_;
+          if (regionRequestBodyCase_ == 7) {
+            return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 7) {
+          if (regionRequestBodyCase_ == 7) {
             return openBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
@@ -2052,12 +2052,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           openBuilder_.setMessage(value);
         }
-        requestCase_ = 7;
+        regionRequestBodyCase_ = 7;
         return this;
       }
       /**
@@ -2066,12 +2066,12 @@ public final class Server {
       public Builder setOpen(
           io.greptime.v1.region.Server.OpenRequest.Builder builderForValue) {
         if (openBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           openBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 7;
+        regionRequestBodyCase_ = 7;
         return this;
       }
       /**
@@ -2079,22 +2079,22 @@ public final class Server {
        */
       public Builder mergeOpen(io.greptime.v1.region.Server.OpenRequest value) {
         if (openBuilder_ == null) {
-          if (requestCase_ == 7 &&
-              request_ != io.greptime.v1.region.Server.OpenRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.OpenRequest.newBuilder((io.greptime.v1.region.Server.OpenRequest) request_)
+          if (regionRequestBodyCase_ == 7 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.OpenRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.OpenRequest.newBuilder((io.greptime.v1.region.Server.OpenRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 7) {
+          if (regionRequestBodyCase_ == 7) {
             openBuilder_.mergeFrom(value);
           } else {
             openBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 7;
+        regionRequestBodyCase_ = 7;
         return this;
       }
       /**
@@ -2102,15 +2102,15 @@ public final class Server {
        */
       public Builder clearOpen() {
         if (openBuilder_ == null) {
-          if (requestCase_ == 7) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 7) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 7) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 7) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           openBuilder_.clear();
         }
@@ -2127,11 +2127,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.OpenRequestOrBuilder getOpenOrBuilder() {
-        if ((requestCase_ == 7) && (openBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 7) && (openBuilder_ != null)) {
           return openBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 7) {
-            return (io.greptime.v1.region.Server.OpenRequest) request_;
+          if (regionRequestBodyCase_ == 7) {
+            return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
         }
@@ -2143,17 +2143,17 @@ public final class Server {
           io.greptime.v1.region.Server.OpenRequest, io.greptime.v1.region.Server.OpenRequest.Builder, io.greptime.v1.region.Server.OpenRequestOrBuilder> 
           getOpenFieldBuilder() {
         if (openBuilder_ == null) {
-          if (!(requestCase_ == 7)) {
-            request_ = io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 7)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
           }
           openBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.OpenRequest, io.greptime.v1.region.Server.OpenRequest.Builder, io.greptime.v1.region.Server.OpenRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.OpenRequest) request_,
+                  (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 7;
+        regionRequestBodyCase_ = 7;
         onChanged();;
         return openBuilder_;
       }
@@ -2166,7 +2166,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasClose() {
-        return requestCase_ == 8;
+        return regionRequestBodyCase_ == 8;
       }
       /**
        * <code>.greptime.v1.region.CloseRequest close = 8;</code>
@@ -2175,12 +2175,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.CloseRequest getClose() {
         if (closeBuilder_ == null) {
-          if (requestCase_ == 8) {
-            return (io.greptime.v1.region.Server.CloseRequest) request_;
+          if (regionRequestBodyCase_ == 8) {
+            return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 8) {
+          if (regionRequestBodyCase_ == 8) {
             return closeBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
@@ -2194,12 +2194,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           closeBuilder_.setMessage(value);
         }
-        requestCase_ = 8;
+        regionRequestBodyCase_ = 8;
         return this;
       }
       /**
@@ -2208,12 +2208,12 @@ public final class Server {
       public Builder setClose(
           io.greptime.v1.region.Server.CloseRequest.Builder builderForValue) {
         if (closeBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           closeBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 8;
+        regionRequestBodyCase_ = 8;
         return this;
       }
       /**
@@ -2221,22 +2221,22 @@ public final class Server {
        */
       public Builder mergeClose(io.greptime.v1.region.Server.CloseRequest value) {
         if (closeBuilder_ == null) {
-          if (requestCase_ == 8 &&
-              request_ != io.greptime.v1.region.Server.CloseRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.CloseRequest.newBuilder((io.greptime.v1.region.Server.CloseRequest) request_)
+          if (regionRequestBodyCase_ == 8 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.CloseRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.CloseRequest.newBuilder((io.greptime.v1.region.Server.CloseRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 8) {
+          if (regionRequestBodyCase_ == 8) {
             closeBuilder_.mergeFrom(value);
           } else {
             closeBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 8;
+        regionRequestBodyCase_ = 8;
         return this;
       }
       /**
@@ -2244,15 +2244,15 @@ public final class Server {
        */
       public Builder clearClose() {
         if (closeBuilder_ == null) {
-          if (requestCase_ == 8) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 8) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 8) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 8) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           closeBuilder_.clear();
         }
@@ -2269,11 +2269,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.CloseRequestOrBuilder getCloseOrBuilder() {
-        if ((requestCase_ == 8) && (closeBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 8) && (closeBuilder_ != null)) {
           return closeBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 8) {
-            return (io.greptime.v1.region.Server.CloseRequest) request_;
+          if (regionRequestBodyCase_ == 8) {
+            return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
         }
@@ -2285,17 +2285,17 @@ public final class Server {
           io.greptime.v1.region.Server.CloseRequest, io.greptime.v1.region.Server.CloseRequest.Builder, io.greptime.v1.region.Server.CloseRequestOrBuilder> 
           getCloseFieldBuilder() {
         if (closeBuilder_ == null) {
-          if (!(requestCase_ == 8)) {
-            request_ = io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 8)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
           }
           closeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.CloseRequest, io.greptime.v1.region.Server.CloseRequest.Builder, io.greptime.v1.region.Server.CloseRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.CloseRequest) request_,
+                  (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 8;
+        regionRequestBodyCase_ = 8;
         onChanged();;
         return closeBuilder_;
       }
@@ -2308,7 +2308,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasAlter() {
-        return requestCase_ == 9;
+        return regionRequestBodyCase_ == 9;
       }
       /**
        * <code>.greptime.v1.region.AlterRequest alter = 9;</code>
@@ -2317,12 +2317,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.AlterRequest getAlter() {
         if (alterBuilder_ == null) {
-          if (requestCase_ == 9) {
-            return (io.greptime.v1.region.Server.AlterRequest) request_;
+          if (regionRequestBodyCase_ == 9) {
+            return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 9) {
+          if (regionRequestBodyCase_ == 9) {
             return alterBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
@@ -2336,12 +2336,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           alterBuilder_.setMessage(value);
         }
-        requestCase_ = 9;
+        regionRequestBodyCase_ = 9;
         return this;
       }
       /**
@@ -2350,12 +2350,12 @@ public final class Server {
       public Builder setAlter(
           io.greptime.v1.region.Server.AlterRequest.Builder builderForValue) {
         if (alterBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           alterBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 9;
+        regionRequestBodyCase_ = 9;
         return this;
       }
       /**
@@ -2363,22 +2363,22 @@ public final class Server {
        */
       public Builder mergeAlter(io.greptime.v1.region.Server.AlterRequest value) {
         if (alterBuilder_ == null) {
-          if (requestCase_ == 9 &&
-              request_ != io.greptime.v1.region.Server.AlterRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.AlterRequest.newBuilder((io.greptime.v1.region.Server.AlterRequest) request_)
+          if (regionRequestBodyCase_ == 9 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.AlterRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.AlterRequest.newBuilder((io.greptime.v1.region.Server.AlterRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 9) {
+          if (regionRequestBodyCase_ == 9) {
             alterBuilder_.mergeFrom(value);
           } else {
             alterBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 9;
+        regionRequestBodyCase_ = 9;
         return this;
       }
       /**
@@ -2386,15 +2386,15 @@ public final class Server {
        */
       public Builder clearAlter() {
         if (alterBuilder_ == null) {
-          if (requestCase_ == 9) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 9) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 9) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 9) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           alterBuilder_.clear();
         }
@@ -2411,11 +2411,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.AlterRequestOrBuilder getAlterOrBuilder() {
-        if ((requestCase_ == 9) && (alterBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 9) && (alterBuilder_ != null)) {
           return alterBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 9) {
-            return (io.greptime.v1.region.Server.AlterRequest) request_;
+          if (regionRequestBodyCase_ == 9) {
+            return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
         }
@@ -2427,17 +2427,17 @@ public final class Server {
           io.greptime.v1.region.Server.AlterRequest, io.greptime.v1.region.Server.AlterRequest.Builder, io.greptime.v1.region.Server.AlterRequestOrBuilder> 
           getAlterFieldBuilder() {
         if (alterBuilder_ == null) {
-          if (!(requestCase_ == 9)) {
-            request_ = io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 9)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
           }
           alterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.AlterRequest, io.greptime.v1.region.Server.AlterRequest.Builder, io.greptime.v1.region.Server.AlterRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.AlterRequest) request_,
+                  (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 9;
+        regionRequestBodyCase_ = 9;
         onChanged();;
         return alterBuilder_;
       }
@@ -2450,7 +2450,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasFlush() {
-        return requestCase_ == 10;
+        return regionRequestBodyCase_ == 10;
       }
       /**
        * <code>.greptime.v1.region.FlushRequest flush = 10;</code>
@@ -2459,12 +2459,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.FlushRequest getFlush() {
         if (flushBuilder_ == null) {
-          if (requestCase_ == 10) {
-            return (io.greptime.v1.region.Server.FlushRequest) request_;
+          if (regionRequestBodyCase_ == 10) {
+            return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 10) {
+          if (regionRequestBodyCase_ == 10) {
             return flushBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
@@ -2478,12 +2478,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           flushBuilder_.setMessage(value);
         }
-        requestCase_ = 10;
+        regionRequestBodyCase_ = 10;
         return this;
       }
       /**
@@ -2492,12 +2492,12 @@ public final class Server {
       public Builder setFlush(
           io.greptime.v1.region.Server.FlushRequest.Builder builderForValue) {
         if (flushBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           flushBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 10;
+        regionRequestBodyCase_ = 10;
         return this;
       }
       /**
@@ -2505,22 +2505,22 @@ public final class Server {
        */
       public Builder mergeFlush(io.greptime.v1.region.Server.FlushRequest value) {
         if (flushBuilder_ == null) {
-          if (requestCase_ == 10 &&
-              request_ != io.greptime.v1.region.Server.FlushRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.FlushRequest.newBuilder((io.greptime.v1.region.Server.FlushRequest) request_)
+          if (regionRequestBodyCase_ == 10 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.FlushRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.FlushRequest.newBuilder((io.greptime.v1.region.Server.FlushRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 10) {
+          if (regionRequestBodyCase_ == 10) {
             flushBuilder_.mergeFrom(value);
           } else {
             flushBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 10;
+        regionRequestBodyCase_ = 10;
         return this;
       }
       /**
@@ -2528,15 +2528,15 @@ public final class Server {
        */
       public Builder clearFlush() {
         if (flushBuilder_ == null) {
-          if (requestCase_ == 10) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 10) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 10) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 10) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           flushBuilder_.clear();
         }
@@ -2553,11 +2553,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.FlushRequestOrBuilder getFlushOrBuilder() {
-        if ((requestCase_ == 10) && (flushBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 10) && (flushBuilder_ != null)) {
           return flushBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 10) {
-            return (io.greptime.v1.region.Server.FlushRequest) request_;
+          if (regionRequestBodyCase_ == 10) {
+            return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
         }
@@ -2569,17 +2569,17 @@ public final class Server {
           io.greptime.v1.region.Server.FlushRequest, io.greptime.v1.region.Server.FlushRequest.Builder, io.greptime.v1.region.Server.FlushRequestOrBuilder> 
           getFlushFieldBuilder() {
         if (flushBuilder_ == null) {
-          if (!(requestCase_ == 10)) {
-            request_ = io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 10)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
           }
           flushBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.FlushRequest, io.greptime.v1.region.Server.FlushRequest.Builder, io.greptime.v1.region.Server.FlushRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.FlushRequest) request_,
+                  (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 10;
+        regionRequestBodyCase_ = 10;
         onChanged();;
         return flushBuilder_;
       }
@@ -2592,7 +2592,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasCompact() {
-        return requestCase_ == 11;
+        return regionRequestBodyCase_ == 11;
       }
       /**
        * <code>.greptime.v1.region.CompactRequest compact = 11;</code>
@@ -2601,12 +2601,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.CompactRequest getCompact() {
         if (compactBuilder_ == null) {
-          if (requestCase_ == 11) {
-            return (io.greptime.v1.region.Server.CompactRequest) request_;
+          if (regionRequestBodyCase_ == 11) {
+            return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
         } else {
-          if (requestCase_ == 11) {
+          if (regionRequestBodyCase_ == 11) {
             return compactBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
@@ -2620,12 +2620,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          request_ = value;
+          regionRequestBody_ = value;
           onChanged();
         } else {
           compactBuilder_.setMessage(value);
         }
-        requestCase_ = 11;
+        regionRequestBodyCase_ = 11;
         return this;
       }
       /**
@@ -2634,12 +2634,12 @@ public final class Server {
       public Builder setCompact(
           io.greptime.v1.region.Server.CompactRequest.Builder builderForValue) {
         if (compactBuilder_ == null) {
-          request_ = builderForValue.build();
+          regionRequestBody_ = builderForValue.build();
           onChanged();
         } else {
           compactBuilder_.setMessage(builderForValue.build());
         }
-        requestCase_ = 11;
+        regionRequestBodyCase_ = 11;
         return this;
       }
       /**
@@ -2647,22 +2647,22 @@ public final class Server {
        */
       public Builder mergeCompact(io.greptime.v1.region.Server.CompactRequest value) {
         if (compactBuilder_ == null) {
-          if (requestCase_ == 11 &&
-              request_ != io.greptime.v1.region.Server.CompactRequest.getDefaultInstance()) {
-            request_ = io.greptime.v1.region.Server.CompactRequest.newBuilder((io.greptime.v1.region.Server.CompactRequest) request_)
+          if (regionRequestBodyCase_ == 11 &&
+              regionRequestBody_ != io.greptime.v1.region.Server.CompactRequest.getDefaultInstance()) {
+            regionRequestBody_ = io.greptime.v1.region.Server.CompactRequest.newBuilder((io.greptime.v1.region.Server.CompactRequest) regionRequestBody_)
                 .mergeFrom(value).buildPartial();
           } else {
-            request_ = value;
+            regionRequestBody_ = value;
           }
           onChanged();
         } else {
-          if (requestCase_ == 11) {
+          if (regionRequestBodyCase_ == 11) {
             compactBuilder_.mergeFrom(value);
           } else {
             compactBuilder_.setMessage(value);
           }
         }
-        requestCase_ = 11;
+        regionRequestBodyCase_ = 11;
         return this;
       }
       /**
@@ -2670,15 +2670,15 @@ public final class Server {
        */
       public Builder clearCompact() {
         if (compactBuilder_ == null) {
-          if (requestCase_ == 11) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 11) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
             onChanged();
           }
         } else {
-          if (requestCase_ == 11) {
-            requestCase_ = 0;
-            request_ = null;
+          if (regionRequestBodyCase_ == 11) {
+            regionRequestBodyCase_ = 0;
+            regionRequestBody_ = null;
           }
           compactBuilder_.clear();
         }
@@ -2695,11 +2695,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.CompactRequestOrBuilder getCompactOrBuilder() {
-        if ((requestCase_ == 11) && (compactBuilder_ != null)) {
+        if ((regionRequestBodyCase_ == 11) && (compactBuilder_ != null)) {
           return compactBuilder_.getMessageOrBuilder();
         } else {
-          if (requestCase_ == 11) {
-            return (io.greptime.v1.region.Server.CompactRequest) request_;
+          if (regionRequestBodyCase_ == 11) {
+            return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
           }
           return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
         }
@@ -2711,17 +2711,17 @@ public final class Server {
           io.greptime.v1.region.Server.CompactRequest, io.greptime.v1.region.Server.CompactRequest.Builder, io.greptime.v1.region.Server.CompactRequestOrBuilder> 
           getCompactFieldBuilder() {
         if (compactBuilder_ == null) {
-          if (!(requestCase_ == 11)) {
-            request_ = io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
+          if (!(regionRequestBodyCase_ == 11)) {
+            regionRequestBody_ = io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
           }
           compactBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.CompactRequest, io.greptime.v1.region.Server.CompactRequest.Builder, io.greptime.v1.region.Server.CompactRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.CompactRequest) request_,
+                  (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_,
                   getParentForChildren(),
                   isClean());
-          request_ = null;
+          regionRequestBody_ = null;
         }
-        requestCase_ = 11;
+        regionRequestBodyCase_ = 11;
         onChanged();;
         return compactBuilder_;
       }
@@ -14271,7 +14271,7 @@ java.lang.String defaultValue);
     java.lang.String[] descriptorData = {
       "\n\037greptime/v1/region/server.proto\022\022grept" +
       "ime.v1.region\032\030greptime/v1/common.proto\032" +
-      "\025greptime/v1/row.proto\"\233\004\n\rRegionRequest" +
+      "\025greptime/v1/row.proto\"\247\004\n\rRegionRequest" +
       "\022*\n\006header\030\001 \001(\0132\032.greptime.v1.RequestHe" +
       "ader\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regi" +
       "on.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".g" +
@@ -14284,44 +14284,44 @@ java.lang.String defaultValue);
       "alter\030\t \001(\0132 .greptime.v1.region.AlterRe" +
       "questH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.reg" +
       "ion.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gr" +
-      "eptime.v1.region.CompactRequestH\000B\t\n\007req" +
-      "uest\"T\n\016RegionResponse\022+\n\006header\030\001 \001(\0132\033" +
-      ".greptime.v1.ResponseHeader\022\025\n\raffacted_" +
-      "rows\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requests" +
-      "\030\001 \003(\0132!.greptime.v1.region.InsertReques" +
-      "t\"E\n\016DeleteRequests\0223\n\010requests\030\001 \003(\0132!." +
-      "greptime.v1.region.DeleteRequest\"B\n\rInse" +
-      "rtRequest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003" +
-      "(\0132\020.greptime.v1.Row\"B\n\rDeleteRequest\022\021\n" +
-      "\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003(\0132\020.greptim" +
-      "e.v1.Row\"/\n\014QueryRequest\022\021\n\tregion_id\030\001 " +
-      "\001(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tr" +
-      "egion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column" +
-      "_defs\030\003 \003(\0132\035.greptime.v1.region.ColumnD" +
-      "ef\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024create_if_not" +
-      "_exists\030\005 \001(\010\022\022\n\nregion_dir\030\006 \001(\t\022?\n\007opt" +
-      "ions\030\007 \003(\0132..greptime.v1.region.CreateRe" +
-      "quest.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003ke" +
-      "y\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropReques" +
-      "t\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\t" +
-      "region_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregio" +
-      "n_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,.greptime." +
-      "v1.region.OpenRequest.OptionsEntry\032.\n\014Op" +
-      "tionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002" +
-      "8\001\"!\n\014CloseRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n" +
-      "\014AlterRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014Flus" +
-      "hRequest\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactRe" +
-      "quest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014" +
-      "\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010datat" +
-      "ype\030\003 \001(\0162\033.greptime.v1.ColumnDataType\022\023" +
-      "\n\013is_nullable\030\004 \001(\010\022\032\n\022default_constrain" +
-      "t\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001(\0162\031.greptim" +
-      "e.v1.SemanticType2_\n\014RegionServer\022O\n\006Han" +
-      "dle\022!.greptime.v1.region.RegionRequest\032\"" +
-      ".greptime.v1.region.RegionResponseB]\n\025io" +
-      ".greptime.v1.regionB\006ServerZ<github.com/" +
-      "GreptimeTeam/greptime-proto/go/greptime/" +
-      "v1/regionb\006proto3"
+      "eptime.v1.region.CompactRequestH\000B\025\n\023reg" +
+      "ion_request_body\"T\n\016RegionResponse\022+\n\006he" +
+      "ader\030\001 \001(\0132\033.greptime.v1.ResponseHeader\022" +
+      "\025\n\raffacted_rows\030\002 \001(\004\"E\n\016InsertRequests" +
+      "\0223\n\010requests\030\001 \003(\0132!.greptime.v1.region." +
+      "InsertRequest\"E\n\016DeleteRequests\0223\n\010reque" +
+      "sts\030\001 \003(\0132!.greptime.v1.region.DeleteReq" +
+      "uest\"B\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(\004" +
+      "\022\036\n\004rows\030\002 \003(\0132\020.greptime.v1.Row\"B\n\rDele" +
+      "teRequest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003" +
+      "(\0132\020.greptime.v1.Row\"/\n\014QueryRequest\022\021\n\t" +
+      "region_id\030\001 \001(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreate" +
+      "Request\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001" +
+      "(\t\0222\n\013column_defs\030\003 \003(\0132\035.greptime.v1.re" +
+      "gion.ColumnDef\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024c" +
+      "reate_if_not_exists\030\005 \001(\010\022\022\n\nregion_dir\030" +
+      "\006 \001(\t\022?\n\007options\030\007 \003(\0132..greptime.v1.reg" +
+      "ion.CreateRequest.OptionsEntry\032.\n\014Option" +
+      "sEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" " +
+      "\n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013Ope" +
+      "nRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 " +
+      "\001(\t\022\022\n\nregion_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\013" +
+      "2,.greptime.v1.region.OpenRequest.Option" +
+      "sEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v" +
+      "alue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion" +
+      "_id\030\001 \001(\004\"!\n\014AlterRequest\022\021\n\tregion_id\030\001" +
+      " \001(\004\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\"" +
+      "#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n" +
+      "\tColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 " +
+      "\001(\r\022-\n\010datatype\030\003 \001(\0162\033.greptime.v1.Colu" +
+      "mnDataType\022\023\n\013is_nullable\030\004 \001(\010\022\032\n\022defau" +
+      "lt_constraint\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001" +
+      "(\0162\031.greptime.v1.SemanticType2Y\n\006Region\022" +
+      "O\n\006Handle\022!.greptime.v1.region.RegionReq" +
+      "uest\032\".greptime.v1.region.RegionResponse" +
+      "B]\n\025io.greptime.v1.regionB\006ServerZ<githu" +
+      "b.com/GreptimeTeam/greptime-proto/go/gre" +
+      "ptime/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -14334,7 +14334,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_RegionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequest_descriptor,
-        new java.lang.String[] { "Header", "Inserts", "Deletes", "Create", "Drop", "Open", "Close", "Alter", "Flush", "Compact", "Request", });
+        new java.lang.String[] { "Header", "Inserts", "Deletes", "Create", "Drop", "Open", "Close", "Alter", "Flush", "Compact", "RegionRequestBody", });
     internal_static_greptime_v1_region_RegionResponse_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_greptime_v1_region_RegionResponse_fieldAccessorTable = new

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -168,7 +168,7 @@ public final class Server {
      */
     io.greptime.v1.region.Server.CompactRequestOrBuilder getCompactOrBuilder();
 
-    public io.greptime.v1.region.Server.RegionRequest.RegionRequestBodyCase getRegionRequestBodyCase();
+    public io.greptime.v1.region.Server.RegionRequest.BodyCase getBodyCase();
   }
   /**
    * Protobuf type {@code greptime.v1.region.RegionRequest}
@@ -230,128 +230,128 @@ public final class Server {
             }
             case 26: {
               io.greptime.v1.region.Server.InsertRequests.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 3) {
-                subBuilder = ((io.greptime.v1.region.Server.InsertRequests) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 3) {
+                subBuilder = ((io.greptime.v1.region.Server.InsertRequests) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.InsertRequests.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.InsertRequests) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.InsertRequests) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 3;
+              bodyCase_ = 3;
               break;
             }
             case 34: {
               io.greptime.v1.region.Server.DeleteRequests.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 4) {
-                subBuilder = ((io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 4) {
+                subBuilder = ((io.greptime.v1.region.Server.DeleteRequests) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.DeleteRequests.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.DeleteRequests) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 4;
+              bodyCase_ = 4;
               break;
             }
             case 42: {
               io.greptime.v1.region.Server.CreateRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 5) {
-                subBuilder = ((io.greptime.v1.region.Server.CreateRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 5) {
+                subBuilder = ((io.greptime.v1.region.Server.CreateRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.CreateRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.CreateRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.CreateRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 5;
+              bodyCase_ = 5;
               break;
             }
             case 50: {
               io.greptime.v1.region.Server.DropRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 6) {
-                subBuilder = ((io.greptime.v1.region.Server.DropRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 6) {
+                subBuilder = ((io.greptime.v1.region.Server.DropRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.DropRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.DropRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.DropRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 6;
+              bodyCase_ = 6;
               break;
             }
             case 58: {
               io.greptime.v1.region.Server.OpenRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 7) {
-                subBuilder = ((io.greptime.v1.region.Server.OpenRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 7) {
+                subBuilder = ((io.greptime.v1.region.Server.OpenRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.OpenRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.OpenRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.OpenRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 7;
+              bodyCase_ = 7;
               break;
             }
             case 66: {
               io.greptime.v1.region.Server.CloseRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 8) {
-                subBuilder = ((io.greptime.v1.region.Server.CloseRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 8) {
+                subBuilder = ((io.greptime.v1.region.Server.CloseRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.CloseRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.CloseRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.CloseRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 8;
+              bodyCase_ = 8;
               break;
             }
             case 74: {
               io.greptime.v1.region.Server.AlterRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 9) {
-                subBuilder = ((io.greptime.v1.region.Server.AlterRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 9) {
+                subBuilder = ((io.greptime.v1.region.Server.AlterRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.AlterRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.AlterRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.AlterRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 9;
+              bodyCase_ = 9;
               break;
             }
             case 82: {
               io.greptime.v1.region.Server.FlushRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 10) {
-                subBuilder = ((io.greptime.v1.region.Server.FlushRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 10) {
+                subBuilder = ((io.greptime.v1.region.Server.FlushRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.FlushRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.FlushRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.FlushRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 10;
+              bodyCase_ = 10;
               break;
             }
             case 90: {
               io.greptime.v1.region.Server.CompactRequest.Builder subBuilder = null;
-              if (regionRequestBodyCase_ == 11) {
-                subBuilder = ((io.greptime.v1.region.Server.CompactRequest) regionRequestBody_).toBuilder();
+              if (bodyCase_ == 11) {
+                subBuilder = ((io.greptime.v1.region.Server.CompactRequest) body_).toBuilder();
               }
-              regionRequestBody_ =
+              body_ =
                   input.readMessage(io.greptime.v1.region.Server.CompactRequest.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom((io.greptime.v1.region.Server.CompactRequest) regionRequestBody_);
-                regionRequestBody_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.CompactRequest) body_);
+                body_ = subBuilder.buildPartial();
               }
-              regionRequestBodyCase_ = 11;
+              bodyCase_ = 11;
               break;
             }
             default: {
@@ -388,9 +388,9 @@ public final class Server {
               io.greptime.v1.region.Server.RegionRequest.class, io.greptime.v1.region.Server.RegionRequest.Builder.class);
     }
 
-    private int regionRequestBodyCase_ = 0;
-    private java.lang.Object regionRequestBody_;
-    public enum RegionRequestBodyCase
+    private int bodyCase_ = 0;
+    private java.lang.Object body_;
+    public enum BodyCase
         implements com.google.protobuf.Internal.EnumLite,
             com.google.protobuf.AbstractMessage.InternalOneOfEnum {
       INSERTS(3),
@@ -402,9 +402,9 @@ public final class Server {
       ALTER(9),
       FLUSH(10),
       COMPACT(11),
-      REGIONREQUESTBODY_NOT_SET(0);
+      BODY_NOT_SET(0);
       private final int value;
-      private RegionRequestBodyCase(int value) {
+      private BodyCase(int value) {
         this.value = value;
       }
       /**
@@ -413,11 +413,11 @@ public final class Server {
        * @deprecated Use {@link #forNumber(int)} instead.
        */
       @java.lang.Deprecated
-      public static RegionRequestBodyCase valueOf(int value) {
+      public static BodyCase valueOf(int value) {
         return forNumber(value);
       }
 
-      public static RegionRequestBodyCase forNumber(int value) {
+      public static BodyCase forNumber(int value) {
         switch (value) {
           case 3: return INSERTS;
           case 4: return DELETES;
@@ -428,7 +428,7 @@ public final class Server {
           case 9: return ALTER;
           case 10: return FLUSH;
           case 11: return COMPACT;
-          case 0: return REGIONREQUESTBODY_NOT_SET;
+          case 0: return BODY_NOT_SET;
           default: return null;
         }
       }
@@ -437,10 +437,10 @@ public final class Server {
       }
     };
 
-    public RegionRequestBodyCase
-    getRegionRequestBodyCase() {
-      return RegionRequestBodyCase.forNumber(
-          regionRequestBodyCase_);
+    public BodyCase
+    getBodyCase() {
+      return BodyCase.forNumber(
+          bodyCase_);
     }
 
     public static final int HEADER_FIELD_NUMBER = 1;
@@ -476,7 +476,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasInserts() {
-      return regionRequestBodyCase_ == 3;
+      return bodyCase_ == 3;
     }
     /**
      * <code>.greptime.v1.region.InsertRequests inserts = 3;</code>
@@ -484,8 +484,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.InsertRequests getInserts() {
-      if (regionRequestBodyCase_ == 3) {
-         return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
+      if (bodyCase_ == 3) {
+         return (io.greptime.v1.region.Server.InsertRequests) body_;
       }
       return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
     }
@@ -494,8 +494,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.InsertRequestsOrBuilder getInsertsOrBuilder() {
-      if (regionRequestBodyCase_ == 3) {
-         return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
+      if (bodyCase_ == 3) {
+         return (io.greptime.v1.region.Server.InsertRequests) body_;
       }
       return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
     }
@@ -507,7 +507,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasDeletes() {
-      return regionRequestBodyCase_ == 4;
+      return bodyCase_ == 4;
     }
     /**
      * <code>.greptime.v1.region.DeleteRequests deletes = 4;</code>
@@ -515,8 +515,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DeleteRequests getDeletes() {
-      if (regionRequestBodyCase_ == 4) {
-         return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
+      if (bodyCase_ == 4) {
+         return (io.greptime.v1.region.Server.DeleteRequests) body_;
       }
       return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
     }
@@ -525,8 +525,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DeleteRequestsOrBuilder getDeletesOrBuilder() {
-      if (regionRequestBodyCase_ == 4) {
-         return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
+      if (bodyCase_ == 4) {
+         return (io.greptime.v1.region.Server.DeleteRequests) body_;
       }
       return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
     }
@@ -538,7 +538,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasCreate() {
-      return regionRequestBodyCase_ == 5;
+      return bodyCase_ == 5;
     }
     /**
      * <code>.greptime.v1.region.CreateRequest create = 5;</code>
@@ -546,8 +546,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CreateRequest getCreate() {
-      if (regionRequestBodyCase_ == 5) {
-         return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
+      if (bodyCase_ == 5) {
+         return (io.greptime.v1.region.Server.CreateRequest) body_;
       }
       return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
     }
@@ -556,8 +556,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CreateRequestOrBuilder getCreateOrBuilder() {
-      if (regionRequestBodyCase_ == 5) {
-         return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
+      if (bodyCase_ == 5) {
+         return (io.greptime.v1.region.Server.CreateRequest) body_;
       }
       return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
     }
@@ -569,7 +569,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasDrop() {
-      return regionRequestBodyCase_ == 6;
+      return bodyCase_ == 6;
     }
     /**
      * <code>.greptime.v1.region.DropRequest drop = 6;</code>
@@ -577,8 +577,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DropRequest getDrop() {
-      if (regionRequestBodyCase_ == 6) {
-         return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
+      if (bodyCase_ == 6) {
+         return (io.greptime.v1.region.Server.DropRequest) body_;
       }
       return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
     }
@@ -587,8 +587,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.DropRequestOrBuilder getDropOrBuilder() {
-      if (regionRequestBodyCase_ == 6) {
-         return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
+      if (bodyCase_ == 6) {
+         return (io.greptime.v1.region.Server.DropRequest) body_;
       }
       return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
     }
@@ -600,7 +600,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasOpen() {
-      return regionRequestBodyCase_ == 7;
+      return bodyCase_ == 7;
     }
     /**
      * <code>.greptime.v1.region.OpenRequest open = 7;</code>
@@ -608,8 +608,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.OpenRequest getOpen() {
-      if (regionRequestBodyCase_ == 7) {
-         return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
+      if (bodyCase_ == 7) {
+         return (io.greptime.v1.region.Server.OpenRequest) body_;
       }
       return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
     }
@@ -618,8 +618,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.OpenRequestOrBuilder getOpenOrBuilder() {
-      if (regionRequestBodyCase_ == 7) {
-         return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
+      if (bodyCase_ == 7) {
+         return (io.greptime.v1.region.Server.OpenRequest) body_;
       }
       return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
     }
@@ -631,7 +631,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasClose() {
-      return regionRequestBodyCase_ == 8;
+      return bodyCase_ == 8;
     }
     /**
      * <code>.greptime.v1.region.CloseRequest close = 8;</code>
@@ -639,8 +639,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CloseRequest getClose() {
-      if (regionRequestBodyCase_ == 8) {
-         return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
+      if (bodyCase_ == 8) {
+         return (io.greptime.v1.region.Server.CloseRequest) body_;
       }
       return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
     }
@@ -649,8 +649,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CloseRequestOrBuilder getCloseOrBuilder() {
-      if (regionRequestBodyCase_ == 8) {
-         return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
+      if (bodyCase_ == 8) {
+         return (io.greptime.v1.region.Server.CloseRequest) body_;
       }
       return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
     }
@@ -662,7 +662,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasAlter() {
-      return regionRequestBodyCase_ == 9;
+      return bodyCase_ == 9;
     }
     /**
      * <code>.greptime.v1.region.AlterRequest alter = 9;</code>
@@ -670,8 +670,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.AlterRequest getAlter() {
-      if (regionRequestBodyCase_ == 9) {
-         return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
+      if (bodyCase_ == 9) {
+         return (io.greptime.v1.region.Server.AlterRequest) body_;
       }
       return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
     }
@@ -680,8 +680,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.AlterRequestOrBuilder getAlterOrBuilder() {
-      if (regionRequestBodyCase_ == 9) {
-         return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
+      if (bodyCase_ == 9) {
+         return (io.greptime.v1.region.Server.AlterRequest) body_;
       }
       return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
     }
@@ -693,7 +693,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasFlush() {
-      return regionRequestBodyCase_ == 10;
+      return bodyCase_ == 10;
     }
     /**
      * <code>.greptime.v1.region.FlushRequest flush = 10;</code>
@@ -701,8 +701,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.FlushRequest getFlush() {
-      if (regionRequestBodyCase_ == 10) {
-         return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
+      if (bodyCase_ == 10) {
+         return (io.greptime.v1.region.Server.FlushRequest) body_;
       }
       return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
     }
@@ -711,8 +711,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.FlushRequestOrBuilder getFlushOrBuilder() {
-      if (regionRequestBodyCase_ == 10) {
-         return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
+      if (bodyCase_ == 10) {
+         return (io.greptime.v1.region.Server.FlushRequest) body_;
       }
       return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
     }
@@ -724,7 +724,7 @@ public final class Server {
      */
     @java.lang.Override
     public boolean hasCompact() {
-      return regionRequestBodyCase_ == 11;
+      return bodyCase_ == 11;
     }
     /**
      * <code>.greptime.v1.region.CompactRequest compact = 11;</code>
@@ -732,8 +732,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CompactRequest getCompact() {
-      if (regionRequestBodyCase_ == 11) {
-         return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
+      if (bodyCase_ == 11) {
+         return (io.greptime.v1.region.Server.CompactRequest) body_;
       }
       return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
     }
@@ -742,8 +742,8 @@ public final class Server {
      */
     @java.lang.Override
     public io.greptime.v1.region.Server.CompactRequestOrBuilder getCompactOrBuilder() {
-      if (regionRequestBodyCase_ == 11) {
-         return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
+      if (bodyCase_ == 11) {
+         return (io.greptime.v1.region.Server.CompactRequest) body_;
       }
       return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
     }
@@ -765,32 +765,32 @@ public final class Server {
       if (header_ != null) {
         output.writeMessage(1, getHeader());
       }
-      if (regionRequestBodyCase_ == 3) {
-        output.writeMessage(3, (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_);
+      if (bodyCase_ == 3) {
+        output.writeMessage(3, (io.greptime.v1.region.Server.InsertRequests) body_);
       }
-      if (regionRequestBodyCase_ == 4) {
-        output.writeMessage(4, (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_);
+      if (bodyCase_ == 4) {
+        output.writeMessage(4, (io.greptime.v1.region.Server.DeleteRequests) body_);
       }
-      if (regionRequestBodyCase_ == 5) {
-        output.writeMessage(5, (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_);
+      if (bodyCase_ == 5) {
+        output.writeMessage(5, (io.greptime.v1.region.Server.CreateRequest) body_);
       }
-      if (regionRequestBodyCase_ == 6) {
-        output.writeMessage(6, (io.greptime.v1.region.Server.DropRequest) regionRequestBody_);
+      if (bodyCase_ == 6) {
+        output.writeMessage(6, (io.greptime.v1.region.Server.DropRequest) body_);
       }
-      if (regionRequestBodyCase_ == 7) {
-        output.writeMessage(7, (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_);
+      if (bodyCase_ == 7) {
+        output.writeMessage(7, (io.greptime.v1.region.Server.OpenRequest) body_);
       }
-      if (regionRequestBodyCase_ == 8) {
-        output.writeMessage(8, (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_);
+      if (bodyCase_ == 8) {
+        output.writeMessage(8, (io.greptime.v1.region.Server.CloseRequest) body_);
       }
-      if (regionRequestBodyCase_ == 9) {
-        output.writeMessage(9, (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_);
+      if (bodyCase_ == 9) {
+        output.writeMessage(9, (io.greptime.v1.region.Server.AlterRequest) body_);
       }
-      if (regionRequestBodyCase_ == 10) {
-        output.writeMessage(10, (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_);
+      if (bodyCase_ == 10) {
+        output.writeMessage(10, (io.greptime.v1.region.Server.FlushRequest) body_);
       }
-      if (regionRequestBodyCase_ == 11) {
-        output.writeMessage(11, (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_);
+      if (bodyCase_ == 11) {
+        output.writeMessage(11, (io.greptime.v1.region.Server.CompactRequest) body_);
       }
       unknownFields.writeTo(output);
     }
@@ -805,41 +805,41 @@ public final class Server {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getHeader());
       }
-      if (regionRequestBodyCase_ == 3) {
+      if (bodyCase_ == 3) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_);
+          .computeMessageSize(3, (io.greptime.v1.region.Server.InsertRequests) body_);
       }
-      if (regionRequestBodyCase_ == 4) {
+      if (bodyCase_ == 4) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_);
+          .computeMessageSize(4, (io.greptime.v1.region.Server.DeleteRequests) body_);
       }
-      if (regionRequestBodyCase_ == 5) {
+      if (bodyCase_ == 5) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(5, (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_);
+          .computeMessageSize(5, (io.greptime.v1.region.Server.CreateRequest) body_);
       }
-      if (regionRequestBodyCase_ == 6) {
+      if (bodyCase_ == 6) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(6, (io.greptime.v1.region.Server.DropRequest) regionRequestBody_);
+          .computeMessageSize(6, (io.greptime.v1.region.Server.DropRequest) body_);
       }
-      if (regionRequestBodyCase_ == 7) {
+      if (bodyCase_ == 7) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(7, (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_);
+          .computeMessageSize(7, (io.greptime.v1.region.Server.OpenRequest) body_);
       }
-      if (regionRequestBodyCase_ == 8) {
+      if (bodyCase_ == 8) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(8, (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_);
+          .computeMessageSize(8, (io.greptime.v1.region.Server.CloseRequest) body_);
       }
-      if (regionRequestBodyCase_ == 9) {
+      if (bodyCase_ == 9) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(9, (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_);
+          .computeMessageSize(9, (io.greptime.v1.region.Server.AlterRequest) body_);
       }
-      if (regionRequestBodyCase_ == 10) {
+      if (bodyCase_ == 10) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(10, (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_);
+          .computeMessageSize(10, (io.greptime.v1.region.Server.FlushRequest) body_);
       }
-      if (regionRequestBodyCase_ == 11) {
+      if (bodyCase_ == 11) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(11, (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_);
+          .computeMessageSize(11, (io.greptime.v1.region.Server.CompactRequest) body_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -861,8 +861,8 @@ public final class Server {
         if (!getHeader()
             .equals(other.getHeader())) return false;
       }
-      if (!getRegionRequestBodyCase().equals(other.getRegionRequestBodyCase())) return false;
-      switch (regionRequestBodyCase_) {
+      if (!getBodyCase().equals(other.getBodyCase())) return false;
+      switch (bodyCase_) {
         case 3:
           if (!getInserts()
               .equals(other.getInserts())) return false;
@@ -917,7 +917,7 @@ public final class Server {
         hash = (37 * hash) + HEADER_FIELD_NUMBER;
         hash = (53 * hash) + getHeader().hashCode();
       }
-      switch (regionRequestBodyCase_) {
+      switch (bodyCase_) {
         case 3:
           hash = (37 * hash) + INSERTS_FIELD_NUMBER;
           hash = (53 * hash) + getInserts().hashCode();
@@ -1096,8 +1096,8 @@ public final class Server {
           header_ = null;
           headerBuilder_ = null;
         }
-        regionRequestBodyCase_ = 0;
-        regionRequestBody_ = null;
+        bodyCase_ = 0;
+        body_ = null;
         return this;
       }
 
@@ -1129,70 +1129,70 @@ public final class Server {
         } else {
           result.header_ = headerBuilder_.build();
         }
-        if (regionRequestBodyCase_ == 3) {
+        if (bodyCase_ == 3) {
           if (insertsBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = insertsBuilder_.build();
+            result.body_ = insertsBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 4) {
+        if (bodyCase_ == 4) {
           if (deletesBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = deletesBuilder_.build();
+            result.body_ = deletesBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 5) {
+        if (bodyCase_ == 5) {
           if (createBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = createBuilder_.build();
+            result.body_ = createBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 6) {
+        if (bodyCase_ == 6) {
           if (dropBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = dropBuilder_.build();
+            result.body_ = dropBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 7) {
+        if (bodyCase_ == 7) {
           if (openBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = openBuilder_.build();
+            result.body_ = openBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 8) {
+        if (bodyCase_ == 8) {
           if (closeBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = closeBuilder_.build();
+            result.body_ = closeBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 9) {
+        if (bodyCase_ == 9) {
           if (alterBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = alterBuilder_.build();
+            result.body_ = alterBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 10) {
+        if (bodyCase_ == 10) {
           if (flushBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = flushBuilder_.build();
+            result.body_ = flushBuilder_.build();
           }
         }
-        if (regionRequestBodyCase_ == 11) {
+        if (bodyCase_ == 11) {
           if (compactBuilder_ == null) {
-            result.regionRequestBody_ = regionRequestBody_;
+            result.body_ = body_;
           } else {
-            result.regionRequestBody_ = compactBuilder_.build();
+            result.body_ = compactBuilder_.build();
           }
         }
-        result.regionRequestBodyCase_ = regionRequestBodyCase_;
+        result.bodyCase_ = bodyCase_;
         onBuilt();
         return result;
       }
@@ -1244,7 +1244,7 @@ public final class Server {
         if (other.hasHeader()) {
           mergeHeader(other.getHeader());
         }
-        switch (other.getRegionRequestBodyCase()) {
+        switch (other.getBodyCase()) {
           case INSERTS: {
             mergeInserts(other.getInserts());
             break;
@@ -1281,7 +1281,7 @@ public final class Server {
             mergeCompact(other.getCompact());
             break;
           }
-          case REGIONREQUESTBODY_NOT_SET: {
+          case BODY_NOT_SET: {
             break;
           }
         }
@@ -1313,17 +1313,17 @@ public final class Server {
         }
         return this;
       }
-      private int regionRequestBodyCase_ = 0;
-      private java.lang.Object regionRequestBody_;
-      public RegionRequestBodyCase
-          getRegionRequestBodyCase() {
-        return RegionRequestBodyCase.forNumber(
-            regionRequestBodyCase_);
+      private int bodyCase_ = 0;
+      private java.lang.Object body_;
+      public BodyCase
+          getBodyCase() {
+        return BodyCase.forNumber(
+            bodyCase_);
       }
 
-      public Builder clearRegionRequestBody() {
-        regionRequestBodyCase_ = 0;
-        regionRequestBody_ = null;
+      public Builder clearBody() {
+        bodyCase_ = 0;
+        body_ = null;
         onChanged();
         return this;
       }
@@ -1456,7 +1456,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasInserts() {
-        return regionRequestBodyCase_ == 3;
+        return bodyCase_ == 3;
       }
       /**
        * <code>.greptime.v1.region.InsertRequests inserts = 3;</code>
@@ -1465,12 +1465,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.InsertRequests getInserts() {
         if (insertsBuilder_ == null) {
-          if (regionRequestBodyCase_ == 3) {
-            return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
+          if (bodyCase_ == 3) {
+            return (io.greptime.v1.region.Server.InsertRequests) body_;
           }
           return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 3) {
+          if (bodyCase_ == 3) {
             return insertsBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
@@ -1484,12 +1484,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           insertsBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 3;
+        bodyCase_ = 3;
         return this;
       }
       /**
@@ -1498,12 +1498,12 @@ public final class Server {
       public Builder setInserts(
           io.greptime.v1.region.Server.InsertRequests.Builder builderForValue) {
         if (insertsBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           insertsBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 3;
+        bodyCase_ = 3;
         return this;
       }
       /**
@@ -1511,22 +1511,22 @@ public final class Server {
        */
       public Builder mergeInserts(io.greptime.v1.region.Server.InsertRequests value) {
         if (insertsBuilder_ == null) {
-          if (regionRequestBodyCase_ == 3 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.InsertRequests.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.InsertRequests.newBuilder((io.greptime.v1.region.Server.InsertRequests) regionRequestBody_)
+          if (bodyCase_ == 3 &&
+              body_ != io.greptime.v1.region.Server.InsertRequests.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.InsertRequests.newBuilder((io.greptime.v1.region.Server.InsertRequests) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 3) {
+          if (bodyCase_ == 3) {
             insertsBuilder_.mergeFrom(value);
           } else {
             insertsBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 3;
+        bodyCase_ = 3;
         return this;
       }
       /**
@@ -1534,15 +1534,15 @@ public final class Server {
        */
       public Builder clearInserts() {
         if (insertsBuilder_ == null) {
-          if (regionRequestBodyCase_ == 3) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 3) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 3) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 3) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           insertsBuilder_.clear();
         }
@@ -1559,11 +1559,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.InsertRequestsOrBuilder getInsertsOrBuilder() {
-        if ((regionRequestBodyCase_ == 3) && (insertsBuilder_ != null)) {
+        if ((bodyCase_ == 3) && (insertsBuilder_ != null)) {
           return insertsBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 3) {
-            return (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_;
+          if (bodyCase_ == 3) {
+            return (io.greptime.v1.region.Server.InsertRequests) body_;
           }
           return io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
         }
@@ -1575,17 +1575,17 @@ public final class Server {
           io.greptime.v1.region.Server.InsertRequests, io.greptime.v1.region.Server.InsertRequests.Builder, io.greptime.v1.region.Server.InsertRequestsOrBuilder> 
           getInsertsFieldBuilder() {
         if (insertsBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 3)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
+          if (!(bodyCase_ == 3)) {
+            body_ = io.greptime.v1.region.Server.InsertRequests.getDefaultInstance();
           }
           insertsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.InsertRequests, io.greptime.v1.region.Server.InsertRequests.Builder, io.greptime.v1.region.Server.InsertRequestsOrBuilder>(
-                  (io.greptime.v1.region.Server.InsertRequests) regionRequestBody_,
+                  (io.greptime.v1.region.Server.InsertRequests) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 3;
+        bodyCase_ = 3;
         onChanged();;
         return insertsBuilder_;
       }
@@ -1598,7 +1598,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasDeletes() {
-        return regionRequestBodyCase_ == 4;
+        return bodyCase_ == 4;
       }
       /**
        * <code>.greptime.v1.region.DeleteRequests deletes = 4;</code>
@@ -1607,12 +1607,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.DeleteRequests getDeletes() {
         if (deletesBuilder_ == null) {
-          if (regionRequestBodyCase_ == 4) {
-            return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
+          if (bodyCase_ == 4) {
+            return (io.greptime.v1.region.Server.DeleteRequests) body_;
           }
           return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 4) {
+          if (bodyCase_ == 4) {
             return deletesBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
@@ -1626,12 +1626,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           deletesBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 4;
+        bodyCase_ = 4;
         return this;
       }
       /**
@@ -1640,12 +1640,12 @@ public final class Server {
       public Builder setDeletes(
           io.greptime.v1.region.Server.DeleteRequests.Builder builderForValue) {
         if (deletesBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           deletesBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 4;
+        bodyCase_ = 4;
         return this;
       }
       /**
@@ -1653,22 +1653,22 @@ public final class Server {
        */
       public Builder mergeDeletes(io.greptime.v1.region.Server.DeleteRequests value) {
         if (deletesBuilder_ == null) {
-          if (regionRequestBodyCase_ == 4 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.DeleteRequests.newBuilder((io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_)
+          if (bodyCase_ == 4 &&
+              body_ != io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.DeleteRequests.newBuilder((io.greptime.v1.region.Server.DeleteRequests) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 4) {
+          if (bodyCase_ == 4) {
             deletesBuilder_.mergeFrom(value);
           } else {
             deletesBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 4;
+        bodyCase_ = 4;
         return this;
       }
       /**
@@ -1676,15 +1676,15 @@ public final class Server {
        */
       public Builder clearDeletes() {
         if (deletesBuilder_ == null) {
-          if (regionRequestBodyCase_ == 4) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 4) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 4) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 4) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           deletesBuilder_.clear();
         }
@@ -1701,11 +1701,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.DeleteRequestsOrBuilder getDeletesOrBuilder() {
-        if ((regionRequestBodyCase_ == 4) && (deletesBuilder_ != null)) {
+        if ((bodyCase_ == 4) && (deletesBuilder_ != null)) {
           return deletesBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 4) {
-            return (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_;
+          if (bodyCase_ == 4) {
+            return (io.greptime.v1.region.Server.DeleteRequests) body_;
           }
           return io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
         }
@@ -1717,17 +1717,17 @@ public final class Server {
           io.greptime.v1.region.Server.DeleteRequests, io.greptime.v1.region.Server.DeleteRequests.Builder, io.greptime.v1.region.Server.DeleteRequestsOrBuilder> 
           getDeletesFieldBuilder() {
         if (deletesBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 4)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
+          if (!(bodyCase_ == 4)) {
+            body_ = io.greptime.v1.region.Server.DeleteRequests.getDefaultInstance();
           }
           deletesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.DeleteRequests, io.greptime.v1.region.Server.DeleteRequests.Builder, io.greptime.v1.region.Server.DeleteRequestsOrBuilder>(
-                  (io.greptime.v1.region.Server.DeleteRequests) regionRequestBody_,
+                  (io.greptime.v1.region.Server.DeleteRequests) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 4;
+        bodyCase_ = 4;
         onChanged();;
         return deletesBuilder_;
       }
@@ -1740,7 +1740,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasCreate() {
-        return regionRequestBodyCase_ == 5;
+        return bodyCase_ == 5;
       }
       /**
        * <code>.greptime.v1.region.CreateRequest create = 5;</code>
@@ -1749,12 +1749,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.CreateRequest getCreate() {
         if (createBuilder_ == null) {
-          if (regionRequestBodyCase_ == 5) {
-            return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
+          if (bodyCase_ == 5) {
+            return (io.greptime.v1.region.Server.CreateRequest) body_;
           }
           return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 5) {
+          if (bodyCase_ == 5) {
             return createBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
@@ -1768,12 +1768,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           createBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 5;
+        bodyCase_ = 5;
         return this;
       }
       /**
@@ -1782,12 +1782,12 @@ public final class Server {
       public Builder setCreate(
           io.greptime.v1.region.Server.CreateRequest.Builder builderForValue) {
         if (createBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           createBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 5;
+        bodyCase_ = 5;
         return this;
       }
       /**
@@ -1795,22 +1795,22 @@ public final class Server {
        */
       public Builder mergeCreate(io.greptime.v1.region.Server.CreateRequest value) {
         if (createBuilder_ == null) {
-          if (regionRequestBodyCase_ == 5 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.CreateRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.CreateRequest.newBuilder((io.greptime.v1.region.Server.CreateRequest) regionRequestBody_)
+          if (bodyCase_ == 5 &&
+              body_ != io.greptime.v1.region.Server.CreateRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.CreateRequest.newBuilder((io.greptime.v1.region.Server.CreateRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 5) {
+          if (bodyCase_ == 5) {
             createBuilder_.mergeFrom(value);
           } else {
             createBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 5;
+        bodyCase_ = 5;
         return this;
       }
       /**
@@ -1818,15 +1818,15 @@ public final class Server {
        */
       public Builder clearCreate() {
         if (createBuilder_ == null) {
-          if (regionRequestBodyCase_ == 5) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 5) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 5) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 5) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           createBuilder_.clear();
         }
@@ -1843,11 +1843,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.CreateRequestOrBuilder getCreateOrBuilder() {
-        if ((regionRequestBodyCase_ == 5) && (createBuilder_ != null)) {
+        if ((bodyCase_ == 5) && (createBuilder_ != null)) {
           return createBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 5) {
-            return (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_;
+          if (bodyCase_ == 5) {
+            return (io.greptime.v1.region.Server.CreateRequest) body_;
           }
           return io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
         }
@@ -1859,17 +1859,17 @@ public final class Server {
           io.greptime.v1.region.Server.CreateRequest, io.greptime.v1.region.Server.CreateRequest.Builder, io.greptime.v1.region.Server.CreateRequestOrBuilder> 
           getCreateFieldBuilder() {
         if (createBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 5)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
+          if (!(bodyCase_ == 5)) {
+            body_ = io.greptime.v1.region.Server.CreateRequest.getDefaultInstance();
           }
           createBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.CreateRequest, io.greptime.v1.region.Server.CreateRequest.Builder, io.greptime.v1.region.Server.CreateRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.CreateRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.CreateRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 5;
+        bodyCase_ = 5;
         onChanged();;
         return createBuilder_;
       }
@@ -1882,7 +1882,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasDrop() {
-        return regionRequestBodyCase_ == 6;
+        return bodyCase_ == 6;
       }
       /**
        * <code>.greptime.v1.region.DropRequest drop = 6;</code>
@@ -1891,12 +1891,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.DropRequest getDrop() {
         if (dropBuilder_ == null) {
-          if (regionRequestBodyCase_ == 6) {
-            return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
+          if (bodyCase_ == 6) {
+            return (io.greptime.v1.region.Server.DropRequest) body_;
           }
           return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 6) {
+          if (bodyCase_ == 6) {
             return dropBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
@@ -1910,12 +1910,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           dropBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 6;
+        bodyCase_ = 6;
         return this;
       }
       /**
@@ -1924,12 +1924,12 @@ public final class Server {
       public Builder setDrop(
           io.greptime.v1.region.Server.DropRequest.Builder builderForValue) {
         if (dropBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           dropBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 6;
+        bodyCase_ = 6;
         return this;
       }
       /**
@@ -1937,22 +1937,22 @@ public final class Server {
        */
       public Builder mergeDrop(io.greptime.v1.region.Server.DropRequest value) {
         if (dropBuilder_ == null) {
-          if (regionRequestBodyCase_ == 6 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.DropRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.DropRequest.newBuilder((io.greptime.v1.region.Server.DropRequest) regionRequestBody_)
+          if (bodyCase_ == 6 &&
+              body_ != io.greptime.v1.region.Server.DropRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.DropRequest.newBuilder((io.greptime.v1.region.Server.DropRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 6) {
+          if (bodyCase_ == 6) {
             dropBuilder_.mergeFrom(value);
           } else {
             dropBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 6;
+        bodyCase_ = 6;
         return this;
       }
       /**
@@ -1960,15 +1960,15 @@ public final class Server {
        */
       public Builder clearDrop() {
         if (dropBuilder_ == null) {
-          if (regionRequestBodyCase_ == 6) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 6) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 6) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 6) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           dropBuilder_.clear();
         }
@@ -1985,11 +1985,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.DropRequestOrBuilder getDropOrBuilder() {
-        if ((regionRequestBodyCase_ == 6) && (dropBuilder_ != null)) {
+        if ((bodyCase_ == 6) && (dropBuilder_ != null)) {
           return dropBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 6) {
-            return (io.greptime.v1.region.Server.DropRequest) regionRequestBody_;
+          if (bodyCase_ == 6) {
+            return (io.greptime.v1.region.Server.DropRequest) body_;
           }
           return io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
         }
@@ -2001,17 +2001,17 @@ public final class Server {
           io.greptime.v1.region.Server.DropRequest, io.greptime.v1.region.Server.DropRequest.Builder, io.greptime.v1.region.Server.DropRequestOrBuilder> 
           getDropFieldBuilder() {
         if (dropBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 6)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
+          if (!(bodyCase_ == 6)) {
+            body_ = io.greptime.v1.region.Server.DropRequest.getDefaultInstance();
           }
           dropBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.DropRequest, io.greptime.v1.region.Server.DropRequest.Builder, io.greptime.v1.region.Server.DropRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.DropRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.DropRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 6;
+        bodyCase_ = 6;
         onChanged();;
         return dropBuilder_;
       }
@@ -2024,7 +2024,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasOpen() {
-        return regionRequestBodyCase_ == 7;
+        return bodyCase_ == 7;
       }
       /**
        * <code>.greptime.v1.region.OpenRequest open = 7;</code>
@@ -2033,12 +2033,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.OpenRequest getOpen() {
         if (openBuilder_ == null) {
-          if (regionRequestBodyCase_ == 7) {
-            return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
+          if (bodyCase_ == 7) {
+            return (io.greptime.v1.region.Server.OpenRequest) body_;
           }
           return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 7) {
+          if (bodyCase_ == 7) {
             return openBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
@@ -2052,12 +2052,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           openBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 7;
+        bodyCase_ = 7;
         return this;
       }
       /**
@@ -2066,12 +2066,12 @@ public final class Server {
       public Builder setOpen(
           io.greptime.v1.region.Server.OpenRequest.Builder builderForValue) {
         if (openBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           openBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 7;
+        bodyCase_ = 7;
         return this;
       }
       /**
@@ -2079,22 +2079,22 @@ public final class Server {
        */
       public Builder mergeOpen(io.greptime.v1.region.Server.OpenRequest value) {
         if (openBuilder_ == null) {
-          if (regionRequestBodyCase_ == 7 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.OpenRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.OpenRequest.newBuilder((io.greptime.v1.region.Server.OpenRequest) regionRequestBody_)
+          if (bodyCase_ == 7 &&
+              body_ != io.greptime.v1.region.Server.OpenRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.OpenRequest.newBuilder((io.greptime.v1.region.Server.OpenRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 7) {
+          if (bodyCase_ == 7) {
             openBuilder_.mergeFrom(value);
           } else {
             openBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 7;
+        bodyCase_ = 7;
         return this;
       }
       /**
@@ -2102,15 +2102,15 @@ public final class Server {
        */
       public Builder clearOpen() {
         if (openBuilder_ == null) {
-          if (regionRequestBodyCase_ == 7) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 7) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 7) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 7) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           openBuilder_.clear();
         }
@@ -2127,11 +2127,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.OpenRequestOrBuilder getOpenOrBuilder() {
-        if ((regionRequestBodyCase_ == 7) && (openBuilder_ != null)) {
+        if ((bodyCase_ == 7) && (openBuilder_ != null)) {
           return openBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 7) {
-            return (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_;
+          if (bodyCase_ == 7) {
+            return (io.greptime.v1.region.Server.OpenRequest) body_;
           }
           return io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
         }
@@ -2143,17 +2143,17 @@ public final class Server {
           io.greptime.v1.region.Server.OpenRequest, io.greptime.v1.region.Server.OpenRequest.Builder, io.greptime.v1.region.Server.OpenRequestOrBuilder> 
           getOpenFieldBuilder() {
         if (openBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 7)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
+          if (!(bodyCase_ == 7)) {
+            body_ = io.greptime.v1.region.Server.OpenRequest.getDefaultInstance();
           }
           openBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.OpenRequest, io.greptime.v1.region.Server.OpenRequest.Builder, io.greptime.v1.region.Server.OpenRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.OpenRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.OpenRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 7;
+        bodyCase_ = 7;
         onChanged();;
         return openBuilder_;
       }
@@ -2166,7 +2166,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasClose() {
-        return regionRequestBodyCase_ == 8;
+        return bodyCase_ == 8;
       }
       /**
        * <code>.greptime.v1.region.CloseRequest close = 8;</code>
@@ -2175,12 +2175,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.CloseRequest getClose() {
         if (closeBuilder_ == null) {
-          if (regionRequestBodyCase_ == 8) {
-            return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
+          if (bodyCase_ == 8) {
+            return (io.greptime.v1.region.Server.CloseRequest) body_;
           }
           return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 8) {
+          if (bodyCase_ == 8) {
             return closeBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
@@ -2194,12 +2194,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           closeBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 8;
+        bodyCase_ = 8;
         return this;
       }
       /**
@@ -2208,12 +2208,12 @@ public final class Server {
       public Builder setClose(
           io.greptime.v1.region.Server.CloseRequest.Builder builderForValue) {
         if (closeBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           closeBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 8;
+        bodyCase_ = 8;
         return this;
       }
       /**
@@ -2221,22 +2221,22 @@ public final class Server {
        */
       public Builder mergeClose(io.greptime.v1.region.Server.CloseRequest value) {
         if (closeBuilder_ == null) {
-          if (regionRequestBodyCase_ == 8 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.CloseRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.CloseRequest.newBuilder((io.greptime.v1.region.Server.CloseRequest) regionRequestBody_)
+          if (bodyCase_ == 8 &&
+              body_ != io.greptime.v1.region.Server.CloseRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.CloseRequest.newBuilder((io.greptime.v1.region.Server.CloseRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 8) {
+          if (bodyCase_ == 8) {
             closeBuilder_.mergeFrom(value);
           } else {
             closeBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 8;
+        bodyCase_ = 8;
         return this;
       }
       /**
@@ -2244,15 +2244,15 @@ public final class Server {
        */
       public Builder clearClose() {
         if (closeBuilder_ == null) {
-          if (regionRequestBodyCase_ == 8) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 8) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 8) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 8) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           closeBuilder_.clear();
         }
@@ -2269,11 +2269,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.CloseRequestOrBuilder getCloseOrBuilder() {
-        if ((regionRequestBodyCase_ == 8) && (closeBuilder_ != null)) {
+        if ((bodyCase_ == 8) && (closeBuilder_ != null)) {
           return closeBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 8) {
-            return (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_;
+          if (bodyCase_ == 8) {
+            return (io.greptime.v1.region.Server.CloseRequest) body_;
           }
           return io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
         }
@@ -2285,17 +2285,17 @@ public final class Server {
           io.greptime.v1.region.Server.CloseRequest, io.greptime.v1.region.Server.CloseRequest.Builder, io.greptime.v1.region.Server.CloseRequestOrBuilder> 
           getCloseFieldBuilder() {
         if (closeBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 8)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
+          if (!(bodyCase_ == 8)) {
+            body_ = io.greptime.v1.region.Server.CloseRequest.getDefaultInstance();
           }
           closeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.CloseRequest, io.greptime.v1.region.Server.CloseRequest.Builder, io.greptime.v1.region.Server.CloseRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.CloseRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.CloseRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 8;
+        bodyCase_ = 8;
         onChanged();;
         return closeBuilder_;
       }
@@ -2308,7 +2308,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasAlter() {
-        return regionRequestBodyCase_ == 9;
+        return bodyCase_ == 9;
       }
       /**
        * <code>.greptime.v1.region.AlterRequest alter = 9;</code>
@@ -2317,12 +2317,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.AlterRequest getAlter() {
         if (alterBuilder_ == null) {
-          if (regionRequestBodyCase_ == 9) {
-            return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
+          if (bodyCase_ == 9) {
+            return (io.greptime.v1.region.Server.AlterRequest) body_;
           }
           return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 9) {
+          if (bodyCase_ == 9) {
             return alterBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
@@ -2336,12 +2336,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           alterBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 9;
+        bodyCase_ = 9;
         return this;
       }
       /**
@@ -2350,12 +2350,12 @@ public final class Server {
       public Builder setAlter(
           io.greptime.v1.region.Server.AlterRequest.Builder builderForValue) {
         if (alterBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           alterBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 9;
+        bodyCase_ = 9;
         return this;
       }
       /**
@@ -2363,22 +2363,22 @@ public final class Server {
        */
       public Builder mergeAlter(io.greptime.v1.region.Server.AlterRequest value) {
         if (alterBuilder_ == null) {
-          if (regionRequestBodyCase_ == 9 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.AlterRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.AlterRequest.newBuilder((io.greptime.v1.region.Server.AlterRequest) regionRequestBody_)
+          if (bodyCase_ == 9 &&
+              body_ != io.greptime.v1.region.Server.AlterRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.AlterRequest.newBuilder((io.greptime.v1.region.Server.AlterRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 9) {
+          if (bodyCase_ == 9) {
             alterBuilder_.mergeFrom(value);
           } else {
             alterBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 9;
+        bodyCase_ = 9;
         return this;
       }
       /**
@@ -2386,15 +2386,15 @@ public final class Server {
        */
       public Builder clearAlter() {
         if (alterBuilder_ == null) {
-          if (regionRequestBodyCase_ == 9) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 9) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 9) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 9) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           alterBuilder_.clear();
         }
@@ -2411,11 +2411,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.AlterRequestOrBuilder getAlterOrBuilder() {
-        if ((regionRequestBodyCase_ == 9) && (alterBuilder_ != null)) {
+        if ((bodyCase_ == 9) && (alterBuilder_ != null)) {
           return alterBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 9) {
-            return (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_;
+          if (bodyCase_ == 9) {
+            return (io.greptime.v1.region.Server.AlterRequest) body_;
           }
           return io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
         }
@@ -2427,17 +2427,17 @@ public final class Server {
           io.greptime.v1.region.Server.AlterRequest, io.greptime.v1.region.Server.AlterRequest.Builder, io.greptime.v1.region.Server.AlterRequestOrBuilder> 
           getAlterFieldBuilder() {
         if (alterBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 9)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
+          if (!(bodyCase_ == 9)) {
+            body_ = io.greptime.v1.region.Server.AlterRequest.getDefaultInstance();
           }
           alterBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.AlterRequest, io.greptime.v1.region.Server.AlterRequest.Builder, io.greptime.v1.region.Server.AlterRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.AlterRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.AlterRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 9;
+        bodyCase_ = 9;
         onChanged();;
         return alterBuilder_;
       }
@@ -2450,7 +2450,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasFlush() {
-        return regionRequestBodyCase_ == 10;
+        return bodyCase_ == 10;
       }
       /**
        * <code>.greptime.v1.region.FlushRequest flush = 10;</code>
@@ -2459,12 +2459,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.FlushRequest getFlush() {
         if (flushBuilder_ == null) {
-          if (regionRequestBodyCase_ == 10) {
-            return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
+          if (bodyCase_ == 10) {
+            return (io.greptime.v1.region.Server.FlushRequest) body_;
           }
           return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 10) {
+          if (bodyCase_ == 10) {
             return flushBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
@@ -2478,12 +2478,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           flushBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 10;
+        bodyCase_ = 10;
         return this;
       }
       /**
@@ -2492,12 +2492,12 @@ public final class Server {
       public Builder setFlush(
           io.greptime.v1.region.Server.FlushRequest.Builder builderForValue) {
         if (flushBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           flushBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 10;
+        bodyCase_ = 10;
         return this;
       }
       /**
@@ -2505,22 +2505,22 @@ public final class Server {
        */
       public Builder mergeFlush(io.greptime.v1.region.Server.FlushRequest value) {
         if (flushBuilder_ == null) {
-          if (regionRequestBodyCase_ == 10 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.FlushRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.FlushRequest.newBuilder((io.greptime.v1.region.Server.FlushRequest) regionRequestBody_)
+          if (bodyCase_ == 10 &&
+              body_ != io.greptime.v1.region.Server.FlushRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.FlushRequest.newBuilder((io.greptime.v1.region.Server.FlushRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 10) {
+          if (bodyCase_ == 10) {
             flushBuilder_.mergeFrom(value);
           } else {
             flushBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 10;
+        bodyCase_ = 10;
         return this;
       }
       /**
@@ -2528,15 +2528,15 @@ public final class Server {
        */
       public Builder clearFlush() {
         if (flushBuilder_ == null) {
-          if (regionRequestBodyCase_ == 10) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 10) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 10) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 10) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           flushBuilder_.clear();
         }
@@ -2553,11 +2553,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.FlushRequestOrBuilder getFlushOrBuilder() {
-        if ((regionRequestBodyCase_ == 10) && (flushBuilder_ != null)) {
+        if ((bodyCase_ == 10) && (flushBuilder_ != null)) {
           return flushBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 10) {
-            return (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_;
+          if (bodyCase_ == 10) {
+            return (io.greptime.v1.region.Server.FlushRequest) body_;
           }
           return io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
         }
@@ -2569,17 +2569,17 @@ public final class Server {
           io.greptime.v1.region.Server.FlushRequest, io.greptime.v1.region.Server.FlushRequest.Builder, io.greptime.v1.region.Server.FlushRequestOrBuilder> 
           getFlushFieldBuilder() {
         if (flushBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 10)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
+          if (!(bodyCase_ == 10)) {
+            body_ = io.greptime.v1.region.Server.FlushRequest.getDefaultInstance();
           }
           flushBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.FlushRequest, io.greptime.v1.region.Server.FlushRequest.Builder, io.greptime.v1.region.Server.FlushRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.FlushRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.FlushRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 10;
+        bodyCase_ = 10;
         onChanged();;
         return flushBuilder_;
       }
@@ -2592,7 +2592,7 @@ public final class Server {
        */
       @java.lang.Override
       public boolean hasCompact() {
-        return regionRequestBodyCase_ == 11;
+        return bodyCase_ == 11;
       }
       /**
        * <code>.greptime.v1.region.CompactRequest compact = 11;</code>
@@ -2601,12 +2601,12 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.CompactRequest getCompact() {
         if (compactBuilder_ == null) {
-          if (regionRequestBodyCase_ == 11) {
-            return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
+          if (bodyCase_ == 11) {
+            return (io.greptime.v1.region.Server.CompactRequest) body_;
           }
           return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
         } else {
-          if (regionRequestBodyCase_ == 11) {
+          if (bodyCase_ == 11) {
             return compactBuilder_.getMessage();
           }
           return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
@@ -2620,12 +2620,12 @@ public final class Server {
           if (value == null) {
             throw new NullPointerException();
           }
-          regionRequestBody_ = value;
+          body_ = value;
           onChanged();
         } else {
           compactBuilder_.setMessage(value);
         }
-        regionRequestBodyCase_ = 11;
+        bodyCase_ = 11;
         return this;
       }
       /**
@@ -2634,12 +2634,12 @@ public final class Server {
       public Builder setCompact(
           io.greptime.v1.region.Server.CompactRequest.Builder builderForValue) {
         if (compactBuilder_ == null) {
-          regionRequestBody_ = builderForValue.build();
+          body_ = builderForValue.build();
           onChanged();
         } else {
           compactBuilder_.setMessage(builderForValue.build());
         }
-        regionRequestBodyCase_ = 11;
+        bodyCase_ = 11;
         return this;
       }
       /**
@@ -2647,22 +2647,22 @@ public final class Server {
        */
       public Builder mergeCompact(io.greptime.v1.region.Server.CompactRequest value) {
         if (compactBuilder_ == null) {
-          if (regionRequestBodyCase_ == 11 &&
-              regionRequestBody_ != io.greptime.v1.region.Server.CompactRequest.getDefaultInstance()) {
-            regionRequestBody_ = io.greptime.v1.region.Server.CompactRequest.newBuilder((io.greptime.v1.region.Server.CompactRequest) regionRequestBody_)
+          if (bodyCase_ == 11 &&
+              body_ != io.greptime.v1.region.Server.CompactRequest.getDefaultInstance()) {
+            body_ = io.greptime.v1.region.Server.CompactRequest.newBuilder((io.greptime.v1.region.Server.CompactRequest) body_)
                 .mergeFrom(value).buildPartial();
           } else {
-            regionRequestBody_ = value;
+            body_ = value;
           }
           onChanged();
         } else {
-          if (regionRequestBodyCase_ == 11) {
+          if (bodyCase_ == 11) {
             compactBuilder_.mergeFrom(value);
           } else {
             compactBuilder_.setMessage(value);
           }
         }
-        regionRequestBodyCase_ = 11;
+        bodyCase_ = 11;
         return this;
       }
       /**
@@ -2670,15 +2670,15 @@ public final class Server {
        */
       public Builder clearCompact() {
         if (compactBuilder_ == null) {
-          if (regionRequestBodyCase_ == 11) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 11) {
+            bodyCase_ = 0;
+            body_ = null;
             onChanged();
           }
         } else {
-          if (regionRequestBodyCase_ == 11) {
-            regionRequestBodyCase_ = 0;
-            regionRequestBody_ = null;
+          if (bodyCase_ == 11) {
+            bodyCase_ = 0;
+            body_ = null;
           }
           compactBuilder_.clear();
         }
@@ -2695,11 +2695,11 @@ public final class Server {
        */
       @java.lang.Override
       public io.greptime.v1.region.Server.CompactRequestOrBuilder getCompactOrBuilder() {
-        if ((regionRequestBodyCase_ == 11) && (compactBuilder_ != null)) {
+        if ((bodyCase_ == 11) && (compactBuilder_ != null)) {
           return compactBuilder_.getMessageOrBuilder();
         } else {
-          if (regionRequestBodyCase_ == 11) {
-            return (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_;
+          if (bodyCase_ == 11) {
+            return (io.greptime.v1.region.Server.CompactRequest) body_;
           }
           return io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
         }
@@ -2711,17 +2711,17 @@ public final class Server {
           io.greptime.v1.region.Server.CompactRequest, io.greptime.v1.region.Server.CompactRequest.Builder, io.greptime.v1.region.Server.CompactRequestOrBuilder> 
           getCompactFieldBuilder() {
         if (compactBuilder_ == null) {
-          if (!(regionRequestBodyCase_ == 11)) {
-            regionRequestBody_ = io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
+          if (!(bodyCase_ == 11)) {
+            body_ = io.greptime.v1.region.Server.CompactRequest.getDefaultInstance();
           }
           compactBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               io.greptime.v1.region.Server.CompactRequest, io.greptime.v1.region.Server.CompactRequest.Builder, io.greptime.v1.region.Server.CompactRequestOrBuilder>(
-                  (io.greptime.v1.region.Server.CompactRequest) regionRequestBody_,
+                  (io.greptime.v1.region.Server.CompactRequest) body_,
                   getParentForChildren(),
                   isClean());
-          regionRequestBody_ = null;
+          body_ = null;
         }
-        regionRequestBodyCase_ = 11;
+        bodyCase_ = 11;
         onChanged();;
         return compactBuilder_;
       }
@@ -14271,7 +14271,7 @@ java.lang.String defaultValue);
     java.lang.String[] descriptorData = {
       "\n\037greptime/v1/region/server.proto\022\022grept" +
       "ime.v1.region\032\030greptime/v1/common.proto\032" +
-      "\025greptime/v1/row.proto\"\247\004\n\rRegionRequest" +
+      "\025greptime/v1/row.proto\"\230\004\n\rRegionRequest" +
       "\022*\n\006header\030\001 \001(\0132\032.greptime.v1.RequestHe" +
       "ader\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regi" +
       "on.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".g" +
@@ -14284,44 +14284,46 @@ java.lang.String defaultValue);
       "alter\030\t \001(\0132 .greptime.v1.region.AlterRe" +
       "questH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.reg" +
       "ion.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gr" +
-      "eptime.v1.region.CompactRequestH\000B\025\n\023reg" +
-      "ion_request_body\"T\n\016RegionResponse\022+\n\006he" +
-      "ader\030\001 \001(\0132\033.greptime.v1.ResponseHeader\022" +
-      "\025\n\raffacted_rows\030\002 \001(\004\"E\n\016InsertRequests" +
-      "\0223\n\010requests\030\001 \003(\0132!.greptime.v1.region." +
-      "InsertRequest\"E\n\016DeleteRequests\0223\n\010reque" +
-      "sts\030\001 \003(\0132!.greptime.v1.region.DeleteReq" +
-      "uest\"B\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(\004" +
-      "\022\036\n\004rows\030\002 \003(\0132\020.greptime.v1.Row\"B\n\rDele" +
-      "teRequest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003" +
-      "(\0132\020.greptime.v1.Row\"/\n\014QueryRequest\022\021\n\t" +
-      "region_id\030\001 \001(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreate" +
-      "Request\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001" +
-      "(\t\0222\n\013column_defs\030\003 \003(\0132\035.greptime.v1.re" +
-      "gion.ColumnDef\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024c" +
-      "reate_if_not_exists\030\005 \001(\010\022\022\n\nregion_dir\030" +
-      "\006 \001(\t\022?\n\007options\030\007 \003(\0132..greptime.v1.reg" +
-      "ion.CreateRequest.OptionsEntry\032.\n\014Option" +
-      "sEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" " +
-      "\n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013Ope" +
-      "nRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 " +
-      "\001(\t\022\022\n\nregion_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\013" +
-      "2,.greptime.v1.region.OpenRequest.Option" +
-      "sEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005v" +
-      "alue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion" +
-      "_id\030\001 \001(\004\"!\n\014AlterRequest\022\021\n\tregion_id\030\001" +
-      " \001(\004\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\"" +
-      "#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n" +
-      "\tColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 " +
-      "\001(\r\022-\n\010datatype\030\003 \001(\0162\033.greptime.v1.Colu" +
-      "mnDataType\022\023\n\013is_nullable\030\004 \001(\010\022\032\n\022defau" +
-      "lt_constraint\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001" +
-      "(\0162\031.greptime.v1.SemanticType2Y\n\006Region\022" +
-      "O\n\006Handle\022!.greptime.v1.region.RegionReq" +
-      "uest\032\".greptime.v1.region.RegionResponse" +
-      "B]\n\025io.greptime.v1.regionB\006ServerZ<githu" +
-      "b.com/GreptimeTeam/greptime-proto/go/gre" +
-      "ptime/v1/regionb\006proto3"
+      "eptime.v1.region.CompactRequestH\000B\006\n\004bod" +
+      "y\"T\n\016RegionResponse\022+\n\006header\030\001 \001(\0132\033.gr" +
+      "eptime.v1.ResponseHeader\022\025\n\raffacted_row" +
+      "s\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requests\030\001 " +
+      "\003(\0132!.greptime.v1.region.InsertRequest\"E" +
+      "\n\016DeleteRequests\0223\n\010requests\030\001 \003(\0132!.gre" +
+      "ptime.v1.region.DeleteRequest\"B\n\rInsertR" +
+      "equest\022\021\n\tregion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003(\0132" +
+      "\020.greptime.v1.Row\"B\n\rDeleteRequest\022\021\n\tre" +
+      "gion_id\030\001 \001(\004\022\036\n\004rows\030\002 \003(\0132\020.greptime.v" +
+      "1.Row\"/\n\014QueryRequest\022\021\n\tregion_id\030\001 \001(\004" +
+      "\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tregi" +
+      "on_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column_de" +
+      "fs\030\003 \003(\0132\035.greptime.v1.region.ColumnDef\022" +
+      "\023\n\013primary_key\030\004 \003(\r\022\034\n\024create_if_not_ex" +
+      "ists\030\005 \001(\010\022\022\n\nregion_dir\030\006 \001(\t\022?\n\007option" +
+      "s\030\007 \003(\0132..greptime.v1.region.CreateReque" +
+      "st.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001" +
+      " \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021" +
+      "\n\tregion_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\treg" +
+      "ion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion_d" +
+      "ir\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,.greptime.v1." +
+      "region.OpenRequest.OptionsEntry\032.\n\014Optio" +
+      "nsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"" +
+      "!\n\014CloseRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014Al" +
+      "terRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014FlushRe" +
+      "quest\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactReque" +
+      "st\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n\004n" +
+      "ame\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010datatype" +
+      "\030\003 \001(\0162\033.greptime.v1.ColumnDataType\022\023\n\013i" +
+      "s_nullable\030\004 \001(\010\022\032\n\022default_constraint\030\005" +
+      " \001(\014\0220\n\rsemantic_type\030\006 \001(\0162\031.greptime.v" +
+      "1.SemanticType2\264\001\n\006Region\022O\n\006Handle\022!.gr" +
+      "eptime.v1.region.RegionRequest\032\".greptim" +
+      "e.v1.region.RegionResponse\022Y\n\016HandleRequ" +
+      "ests\022!.greptime.v1.region.RegionRequest\032" +
+      "\".greptime.v1.region.RegionResponse(\001B]\n" +
+      "\025io.greptime.v1.regionB\006ServerZ<github.c" +
+      "om/GreptimeTeam/greptime-proto/go/grepti" +
+      "me/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -14334,7 +14336,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_RegionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequest_descriptor,
-        new java.lang.String[] { "Header", "Inserts", "Deletes", "Create", "Drop", "Open", "Close", "Alter", "Flush", "Compact", "RegionRequestBody", });
+        new java.lang.String[] { "Header", "Inserts", "Deletes", "Create", "Drop", "Open", "Close", "Alter", "Flush", "Compact", "Body", });
     internal_static_greptime_v1_region_RegionResponse_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_greptime_v1_region_RegionResponse_fieldAccessorTable = new

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -25,13 +25,14 @@ import "greptime/v1/row.proto";
 
 service Region {
   rpc Handle(RegionRequest) returns (RegionResponse);
-  // TODO: add stream API
+
+  rpc HandleRequests(stream RegionRequest) returns (RegionResponse);
 }
 
 message RegionRequest {
   RequestHeader header = 1;
   // query request is handled in flight services.
-  oneof region_request_body {
+  oneof body {
     InsertRequests inserts = 3;
     DeleteRequests deletes = 4;
     CreateRequest create = 5;

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -23,7 +23,7 @@ option go_package = "github.com/GreptimeTeam/greptime-proto/go/greptime/v1/regio
 import "greptime/v1/common.proto";
 import "greptime/v1/row.proto";
 
-service RegionServer {
+service Region {
   rpc Handle(RegionRequest) returns (RegionResponse);
   // TODO: add stream API
 }
@@ -31,7 +31,7 @@ service RegionServer {
 message RegionRequest {
   RequestHeader header = 1;
   // query request is handled in flight services.
-  oneof request {
+  oneof region_request_body {
     InsertRequests inserts = 3;
     DeleteRequests deletes = 4;
     CreateRequest create = 5;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- rename `RegionServer` to `Region`, to avoid generating structs like `RegionServerServer` and `RegionServerService`
- rename `request` to `region_request_body`, to make it more distinguishable

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
