### PR TITLE
feat: make region request derive strum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "Apache-2.0"
 prost = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+strum = "0.25"
+strum_macros = "0.25"
 tonic = "0.9"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,10 @@ fn main() {
             "SemanticType",
             "#[derive(::serde::Serialize, ::serde::Deserialize)]",
         )
+        .enum_attribute(
+            "region.RegionRequest.request",
+            "#[derive(strum_macros::AsRefStr)]",
+        )
         .compile(
             &[
                 "proto/greptime/v1/database.proto",

--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn main() {
             "#[derive(::serde::Serialize, ::serde::Deserialize)]",
         )
         .enum_attribute(
-            "region.RegionRequest.request",
+            "region.RegionRequest.body",
             "#[derive(strum_macros::AsRefStr)]",
         )
         .compile(

--- a/src/v1/region.rs
+++ b/src/v1/region.rs
@@ -16,7 +16,7 @@ tonic::include_proto!("greptime.v1.region");
 
 #[cfg(test)]
 mod test {
-    use crate::v1::region::region_request::Request as RegionRequest;
+    use crate::v1::region::region_request::Body as RegionRequest;
     use crate::v1::region::InsertRequests;
 
     #[test]

--- a/src/v1/region.rs
+++ b/src/v1/region.rs
@@ -13,3 +13,15 @@
 // limitations under the License.
 
 tonic::include_proto!("greptime.v1.region");
+
+#[cfg(test)]
+mod test {
+    use crate::v1::region::region_request::Request as RegionRequest;
+    use crate::v1::region::InsertRequests;
+
+    #[test]
+    fn test_region_request_name() {
+        let request = RegionRequest::Inserts(InsertRequests { requests: vec![] });
+        assert_eq!("Inserts", request.as_ref());
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

To make the request types to-string-able.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
