### PR TITLE
feat: define header for region request

### DIFF
--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -23,6 +23,21 @@ namespace _pbi = _pb::internal;
 namespace greptime {
 namespace v1 {
 namespace region {
+PROTOBUF_CONSTEXPR RegionRequestHeader::RegionRequestHeader(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.trace_id_)*/uint64_t{0u}
+  , /*decltype(_impl_.span_id_)*/uint64_t{0u}} {}
+struct RegionRequestHeaderDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RegionRequestHeaderDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RegionRequestHeaderDefaultTypeInternal() {}
+  union {
+    RegionRequestHeader _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RegionRequestHeaderDefaultTypeInternal _RegionRequestHeader_default_instance_;
 PROTOBUF_CONSTEXPR RegionRequest::RegionRequest(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.header_)*/nullptr
@@ -264,11 +279,21 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace region
 }  // namespace v1
 }  // namespace greptime
-static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[17];
+static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[18];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 
 const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.trace_id_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.span_id_),
+  0,
+  1,
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -424,26 +449,28 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::ColumnDef, _impl_.semantic_type_),
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
-  { 17, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
-  { 25, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
-  { 32, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
-  { 39, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
-  { 47, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
-  { 55, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
-  { 63, 71, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
-  { 73, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
-  { 86, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
-  { 93, 101, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
-  { 103, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
-  { 113, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
-  { 120, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
-  { 127, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
-  { 134, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
-  { 141, -1, -1, sizeof(::greptime::v1::region::ColumnDef)},
+  { 0, 8, -1, sizeof(::greptime::v1::region::RegionRequestHeader)},
+  { 10, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
+  { 27, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
+  { 35, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
+  { 42, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
+  { 49, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
+  { 57, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
+  { 65, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
+  { 73, 81, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
+  { 83, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
+  { 96, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
+  { 103, 111, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
+  { 113, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
+  { 123, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
+  { 130, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
+  { 137, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
+  { 144, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
+  { 151, -1, -1, sizeof(::greptime::v1::region::ColumnDef)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
+  &::greptime::v1::region::_RegionRequestHeader_default_instance_._instance,
   &::greptime::v1::region::_RegionRequest_default_instance_._instance,
   &::greptime::v1::region::_RegionResponse_default_instance_._instance,
   &::greptime::v1::region::_InsertRequests_default_instance_._instance,
@@ -466,57 +493,59 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\037greptime/v1/region/server.proto\022\022grept"
   "ime.v1.region\032\030greptime/v1/common.proto\032"
-  "\025greptime/v1/row.proto\"\230\004\n\rRegionRequest"
-  "\022*\n\006header\030\001 \001(\0132\032.greptime.v1.RequestHe"
-  "ader\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regi"
-  "on.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".g"
-  "reptime.v1.region.DeleteRequestsH\000\0223\n\006cr"
-  "eate\030\005 \001(\0132!.greptime.v1.region.CreateRe"
-  "questH\000\022/\n\004drop\030\006 \001(\0132\037.greptime.v1.regi"
-  "on.DropRequestH\000\022/\n\004open\030\007 \001(\0132\037.greptim"
-  "e.v1.region.OpenRequestH\000\0221\n\005close\030\010 \001(\013"
-  "2 .greptime.v1.region.CloseRequestH\000\0221\n\005"
-  "alter\030\t \001(\0132 .greptime.v1.region.AlterRe"
-  "questH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.reg"
-  "ion.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gr"
-  "eptime.v1.region.CompactRequestH\000B\006\n\004bod"
-  "y\"T\n\016RegionResponse\022+\n\006header\030\001 \001(\0132\033.gr"
-  "eptime.v1.ResponseHeader\022\025\n\raffected_row"
-  "s\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requests\030\001 "
-  "\003(\0132!.greptime.v1.region.InsertRequest\"E"
-  "\n\016DeleteRequests\0223\n\010requests\030\001 \003(\0132!.gre"
-  "ptime.v1.region.DeleteRequest\"C\n\rInsertR"
-  "equest\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132"
-  "\021.greptime.v1.Rows\"C\n\rDeleteRequest\022\021\n\tr"
-  "egion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime."
-  "v1.Rows\"/\n\014QueryRequest\022\021\n\tregion_id\030\001 \001"
-  "(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tre"
-  "gion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column_"
-  "defs\030\003 \003(\0132\035.greptime.v1.region.ColumnDe"
-  "f\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024create_if_not_"
-  "exists\030\005 \001(\010\022\022\n\nregion_dir\030\006 \001(\t\022\?\n\007opti"
-  "ons\030\007 \003(\0132..greptime.v1.region.CreateReq"
-  "uest.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003key"
-  "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest"
-  "\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\tr"
-  "egion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion"
-  "_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,.greptime.v"
-  "1.region.OpenRequest.OptionsEntry\032.\n\014Opt"
-  "ionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028"
-  "\001\"!\n\014CloseRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014"
-  "AlterRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014Flush"
-  "Request\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactReq"
-  "uest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n"
-  "\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010dataty"
-  "pe\030\003 \001(\0162\033.greptime.v1.ColumnDataType\022\023\n"
-  "\013is_nullable\030\004 \001(\010\022\032\n\022default_constraint"
-  "\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001(\0162\031.greptime"
-  ".v1.SemanticType2Y\n\006Region\022O\n\006Handle\022!.g"
-  "reptime.v1.region.RegionRequest\032\".grepti"
-  "me.v1.region.RegionResponseB]\n\025io.grepti"
-  "me.v1.regionB\006ServerZ<github.com/Greptim"
-  "eTeam/greptime-proto/go/greptime/v1/regi"
-  "onb\006proto3"
+  "\025greptime/v1/row.proto\"[\n\023RegionRequestH"
+  "eader\022\025\n\010trace_id\030\001 \001(\004H\000\210\001\001\022\024\n\007span_id\030"
+  "\002 \001(\004H\001\210\001\001B\013\n\t_trace_idB\n\n\010_span_id\"\245\004\n\r"
+  "RegionRequest\0227\n\006header\030\001 \001(\0132\'.greptime"
+  ".v1.region.RegionRequestHeader\0225\n\007insert"
+  "s\030\003 \001(\0132\".greptime.v1.region.InsertReque"
+  "stsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v1.reg"
+  "ion.DeleteRequestsH\000\0223\n\006create\030\005 \001(\0132!.g"
+  "reptime.v1.region.CreateRequestH\000\022/\n\004dro"
+  "p\030\006 \001(\0132\037.greptime.v1.region.DropRequest"
+  "H\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.region.Op"
+  "enRequestH\000\0221\n\005close\030\010 \001(\0132 .greptime.v1"
+  ".region.CloseRequestH\000\0221\n\005alter\030\t \001(\0132 ."
+  "greptime.v1.region.AlterRequestH\000\0221\n\005flu"
+  "sh\030\n \001(\0132 .greptime.v1.region.FlushReque"
+  "stH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1.regi"
+  "on.CompactRequestH\000B\006\n\004body\"T\n\016RegionRes"
+  "ponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1.Resp"
+  "onseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E\n\016Ins"
+  "ertRequests\0223\n\010requests\030\001 \003(\0132!.greptime"
+  ".v1.region.InsertRequest\"E\n\016DeleteReques"
+  "ts\0223\n\010requests\030\001 \003(\0132!.greptime.v1.regio"
+  "n.DeleteRequest\"C\n\rInsertRequest\022\021\n\tregi"
+  "on_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1."
+  "Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030\001 \001(\004"
+  "\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"/\n\014Que"
+  "ryRequest\022\021\n\tregion_id\030\001 \001(\004\022\014\n\004plan\030\002 \001"
+  "(\014\"\236\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022"
+  "\016\n\006engine\030\002 \001(\t\0222\n\013column_defs\030\003 \003(\0132\035.g"
+  "reptime.v1.region.ColumnDef\022\023\n\013primary_k"
+  "ey\030\004 \003(\r\022\034\n\024create_if_not_exists\030\005 \001(\010\022\022"
+  "\n\nregion_dir\030\006 \001(\t\022\?\n\007options\030\007 \003(\0132..gr"
+  "eptime.v1.region.CreateRequest.OptionsEn"
+  "try\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu"
+  "e\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021\n\tregion_id\030"
+  "\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004"
+  "\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion_dir\030\003 \001(\t\022=\n\007"
+  "options\030\004 \003(\0132,.greptime.v1.region.OpenR"
+  "equest.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003k"
+  "ey\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"!\n\014CloseRequ"
+  "est\022\021\n\tregion_id\030\001 \001(\004\"!\n\014AlterRequest\022\021"
+  "\n\tregion_id\030\001 \001(\004\"!\n\014FlushRequest\022\021\n\treg"
+  "ion_id\030\001 \001(\004\"#\n\016CompactRequest\022\021\n\tregion"
+  "_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n"
+  "\tcolumn_id\030\002 \001(\r\022-\n\010datatype\030\003 \001(\0162\033.gre"
+  "ptime.v1.ColumnDataType\022\023\n\013is_nullable\030\004"
+  " \001(\010\022\032\n\022default_constraint\030\005 \001(\014\0220\n\rsema"
+  "ntic_type\030\006 \001(\0162\031.greptime.v1.SemanticTy"
+  "pe2Y\n\006Region\022O\n\006Handle\022!.greptime.v1.reg"
+  "ion.RegionRequest\032\".greptime.v1.region.R"
+  "egionResponseB]\n\025io.greptime.v1.regionB\006"
+  "ServerZ<github.com/GreptimeTeam/greptime"
+  "-proto/go/greptime/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[2] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -524,9 +553,9 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 2090, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 2196, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
-    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 2, 17,
+    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 2, 18,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
     file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto, file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
     file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
@@ -543,9 +572,245 @@ namespace region {
 
 // ===================================================================
 
+class RegionRequestHeader::_Internal {
+ public:
+  using HasBits = decltype(std::declval<RegionRequestHeader>()._impl_._has_bits_);
+  static void set_has_trace_id(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_span_id(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+RegionRequestHeader::RegionRequestHeader(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:greptime.v1.region.RegionRequestHeader)
+}
+RegionRequestHeader::RegionRequestHeader(const RegionRequestHeader& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  RegionRequestHeader* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.trace_id_){}
+    , decltype(_impl_.span_id_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&_impl_.trace_id_, &from._impl_.trace_id_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.span_id_) -
+    reinterpret_cast<char*>(&_impl_.trace_id_)) + sizeof(_impl_.span_id_));
+  // @@protoc_insertion_point(copy_constructor:greptime.v1.region.RegionRequestHeader)
+}
+
+inline void RegionRequestHeader::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.trace_id_){uint64_t{0u}}
+    , decltype(_impl_.span_id_){uint64_t{0u}}
+  };
+}
+
+RegionRequestHeader::~RegionRequestHeader() {
+  // @@protoc_insertion_point(destructor:greptime.v1.region.RegionRequestHeader)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void RegionRequestHeader::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void RegionRequestHeader::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void RegionRequestHeader::Clear() {
+// @@protoc_insertion_point(message_clear_start:greptime.v1.region.RegionRequestHeader)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    ::memset(&_impl_.trace_id_, 0, static_cast<size_t>(
+        reinterpret_cast<char*>(&_impl_.span_id_) -
+        reinterpret_cast<char*>(&_impl_.trace_id_)) + sizeof(_impl_.span_id_));
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RegionRequestHeader::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // optional uint64 trace_id = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _Internal::set_has_trace_id(&has_bits);
+          _impl_.trace_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint64 span_id = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _Internal::set_has_span_id(&has_bits);
+          _impl_.span_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* RegionRequestHeader::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:greptime.v1.region.RegionRequestHeader)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // optional uint64 trace_id = 1;
+  if (_internal_has_trace_id()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(1, this->_internal_trace_id(), target);
+  }
+
+  // optional uint64 span_id = 2;
+  if (_internal_has_span_id()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(2, this->_internal_span_id(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:greptime.v1.region.RegionRequestHeader)
+  return target;
+}
+
+size_t RegionRequestHeader::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:greptime.v1.region.RegionRequestHeader)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional uint64 trace_id = 1;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_trace_id());
+    }
+
+    // optional uint64 span_id = 2;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_span_id());
+    }
+
+  }
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData RegionRequestHeader::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    RegionRequestHeader::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*RegionRequestHeader::GetClassData() const { return &_class_data_; }
+
+
+void RegionRequestHeader::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<RegionRequestHeader*>(&to_msg);
+  auto& from = static_cast<const RegionRequestHeader&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:greptime.v1.region.RegionRequestHeader)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_impl_.trace_id_ = from._impl_.trace_id_;
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_impl_.span_id_ = from._impl_.span_id_;
+    }
+    _this->_impl_._has_bits_[0] |= cached_has_bits;
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RegionRequestHeader::CopyFrom(const RegionRequestHeader& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:greptime.v1.region.RegionRequestHeader)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RegionRequestHeader::IsInitialized() const {
+  return true;
+}
+
+void RegionRequestHeader::InternalSwap(RegionRequestHeader* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(RegionRequestHeader, _impl_.span_id_)
+      + sizeof(RegionRequestHeader::_impl_.span_id_)
+      - PROTOBUF_FIELD_OFFSET(RegionRequestHeader, _impl_.trace_id_)>(
+          reinterpret_cast<char*>(&_impl_.trace_id_),
+          reinterpret_cast<char*>(&other->_impl_.trace_id_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RegionRequestHeader::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[0]);
+}
+
+// ===================================================================
+
 class RegionRequest::_Internal {
  public:
-  static const ::greptime::v1::RequestHeader& header(const RegionRequest* msg);
+  static const ::greptime::v1::region::RegionRequestHeader& header(const RegionRequest* msg);
   static const ::greptime::v1::region::InsertRequests& inserts(const RegionRequest* msg);
   static const ::greptime::v1::region::DeleteRequests& deletes(const RegionRequest* msg);
   static const ::greptime::v1::region::CreateRequest& create(const RegionRequest* msg);
@@ -557,7 +822,7 @@ class RegionRequest::_Internal {
   static const ::greptime::v1::region::CompactRequest& compact(const RegionRequest* msg);
 };
 
-const ::greptime::v1::RequestHeader&
+const ::greptime::v1::region::RegionRequestHeader&
 RegionRequest::_Internal::header(const RegionRequest* msg) {
   return *msg->_impl_.header_;
 }
@@ -596,12 +861,6 @@ RegionRequest::_Internal::flush(const RegionRequest* msg) {
 const ::greptime::v1::region::CompactRequest&
 RegionRequest::_Internal::compact(const RegionRequest* msg) {
   return *msg->_impl_.body_.compact_;
-}
-void RegionRequest::clear_header() {
-  if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
-    delete _impl_.header_;
-  }
-  _impl_.header_ = nullptr;
 }
 void RegionRequest::set_allocated_inserts(::greptime::v1::region::InsertRequests* inserts) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
@@ -755,7 +1014,7 @@ RegionRequest::RegionRequest(const RegionRequest& from)
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   if (from._internal_has_header()) {
-    _this->_impl_.header_ = new ::greptime::v1::RequestHeader(*from._impl_.header_);
+    _this->_impl_.header_ = new ::greptime::v1::region::RegionRequestHeader(*from._impl_.header_);
   }
   clear_has_body();
   switch (from.body_case()) {
@@ -930,7 +1189,7 @@ const char* RegionRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext*
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .greptime.v1.RequestHeader header = 1;
+      // .greptime.v1.region.RegionRequestHeader header = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
           ptr = ctx->ParseMessage(_internal_mutable_header(), ptr);
@@ -1039,7 +1298,7 @@ uint8_t* RegionRequest::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .greptime.v1.RequestHeader header = 1;
+  // .greptime.v1.region.RegionRequestHeader header = 1;
   if (this->_internal_has_header()) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(1, _Internal::header(this),
@@ -1125,7 +1384,7 @@ size_t RegionRequest::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .greptime.v1.RequestHeader header = 1;
+  // .greptime.v1.region.RegionRequestHeader header = 1;
   if (this->_internal_has_header()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -1219,7 +1478,7 @@ void RegionRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
   (void) cached_has_bits;
 
   if (from._internal_has_header()) {
-    _this->_internal_mutable_header()->::greptime::v1::RequestHeader::MergeFrom(
+    _this->_internal_mutable_header()->::greptime::v1::region::RegionRequestHeader::MergeFrom(
         from._internal_header());
   }
   switch (from.body_case()) {
@@ -1297,7 +1556,7 @@ void RegionRequest::InternalSwap(RegionRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[0]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[1]);
 }
 
 // ===================================================================
@@ -1527,7 +1786,7 @@ void RegionResponse::InternalSwap(RegionResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[1]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[2]);
 }
 
 // ===================================================================
@@ -1712,7 +1971,7 @@ void InsertRequests::InternalSwap(InsertRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InsertRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[2]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[3]);
 }
 
 // ===================================================================
@@ -1897,7 +2156,7 @@ void DeleteRequests::InternalSwap(DeleteRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DeleteRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[3]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[4]);
 }
 
 // ===================================================================
@@ -2127,7 +2386,7 @@ void InsertRequest::InternalSwap(InsertRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InsertRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[4]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[5]);
 }
 
 // ===================================================================
@@ -2357,7 +2616,7 @@ void DeleteRequest::InternalSwap(DeleteRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DeleteRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[5]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[6]);
 }
 
 // ===================================================================
@@ -2582,7 +2841,7 @@ void QueryRequest::InternalSwap(QueryRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata QueryRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[6]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[7]);
 }
 
 // ===================================================================
@@ -2596,7 +2855,7 @@ void CreateRequest_OptionsEntry_DoNotUse::MergeFrom(const CreateRequest_OptionsE
 ::PROTOBUF_NAMESPACE_ID::Metadata CreateRequest_OptionsEntry_DoNotUse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[7]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[8]);
 }
 
 // ===================================================================
@@ -3053,7 +3312,7 @@ void CreateRequest::InternalSwap(CreateRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CreateRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[8]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[9]);
 }
 
 // ===================================================================
@@ -3231,7 +3490,7 @@ void DropRequest::InternalSwap(DropRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DropRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[9]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[10]);
 }
 
 // ===================================================================
@@ -3245,7 +3504,7 @@ void OpenRequest_OptionsEntry_DoNotUse::MergeFrom(const OpenRequest_OptionsEntry
 ::PROTOBUF_NAMESPACE_ID::Metadata OpenRequest_OptionsEntry_DoNotUse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[10]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[11]);
 }
 
 // ===================================================================
@@ -3593,7 +3852,7 @@ void OpenRequest::InternalSwap(OpenRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata OpenRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[11]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[12]);
 }
 
 // ===================================================================
@@ -3771,7 +4030,7 @@ void CloseRequest::InternalSwap(CloseRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CloseRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[12]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[13]);
 }
 
 // ===================================================================
@@ -3949,7 +4208,7 @@ void AlterRequest::InternalSwap(AlterRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AlterRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[13]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[14]);
 }
 
 // ===================================================================
@@ -4127,7 +4386,7 @@ void FlushRequest::InternalSwap(FlushRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata FlushRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[14]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[15]);
 }
 
 // ===================================================================
@@ -4305,7 +4564,7 @@ void CompactRequest::InternalSwap(CompactRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CompactRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[15]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[16]);
 }
 
 // ===================================================================
@@ -4667,7 +4926,7 @@ void ColumnDef::InternalSwap(ColumnDef* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ColumnDef::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[16]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[17]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -4675,6 +4934,10 @@ void ColumnDef::InternalSwap(ColumnDef* other) {
 }  // namespace v1
 }  // namespace greptime
 PROTOBUF_NAMESPACE_OPEN
+template<> PROTOBUF_NOINLINE ::greptime::v1::region::RegionRequestHeader*
+Arena::CreateMaybeMessage< ::greptime::v1::region::RegionRequestHeader >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::region::RegionRequestHeader >(arena);
+}
 template<> PROTOBUF_NOINLINE ::greptime::v1::region::RegionRequest*
 Arena::CreateMaybeMessage< ::greptime::v1::region::RegionRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::greptime::v1::region::RegionRequest >(arena);

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -100,6 +100,9 @@ extern QueryRequestDefaultTypeInternal _QueryRequest_default_instance_;
 class RegionRequest;
 struct RegionRequestDefaultTypeInternal;
 extern RegionRequestDefaultTypeInternal _RegionRequest_default_instance_;
+class RegionRequestHeader;
+struct RegionRequestHeaderDefaultTypeInternal;
+extern RegionRequestHeaderDefaultTypeInternal _RegionRequestHeader_default_instance_;
 class RegionResponse;
 struct RegionResponseDefaultTypeInternal;
 extern RegionResponseDefaultTypeInternal _RegionResponse_default_instance_;
@@ -123,6 +126,7 @@ template<> ::greptime::v1::region::OpenRequest* Arena::CreateMaybeMessage<::grep
 template<> ::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse* Arena::CreateMaybeMessage<::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse>(Arena*);
 template<> ::greptime::v1::region::QueryRequest* Arena::CreateMaybeMessage<::greptime::v1::region::QueryRequest>(Arena*);
 template<> ::greptime::v1::region::RegionRequest* Arena::CreateMaybeMessage<::greptime::v1::region::RegionRequest>(Arena*);
+template<> ::greptime::v1::region::RegionRequestHeader* Arena::CreateMaybeMessage<::greptime::v1::region::RegionRequestHeader>(Arena*);
 template<> ::greptime::v1::region::RegionResponse* Arena::CreateMaybeMessage<::greptime::v1::region::RegionResponse>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace greptime {
@@ -130,6 +134,174 @@ namespace v1 {
 namespace region {
 
 // ===================================================================
+
+class RegionRequestHeader final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.region.RegionRequestHeader) */ {
+ public:
+  inline RegionRequestHeader() : RegionRequestHeader(nullptr) {}
+  ~RegionRequestHeader() override;
+  explicit PROTOBUF_CONSTEXPR RegionRequestHeader(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  RegionRequestHeader(const RegionRequestHeader& from);
+  RegionRequestHeader(RegionRequestHeader&& from) noexcept
+    : RegionRequestHeader() {
+    *this = ::std::move(from);
+  }
+
+  inline RegionRequestHeader& operator=(const RegionRequestHeader& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RegionRequestHeader& operator=(RegionRequestHeader&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RegionRequestHeader& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RegionRequestHeader* internal_default_instance() {
+    return reinterpret_cast<const RegionRequestHeader*>(
+               &_RegionRequestHeader_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    0;
+
+  friend void swap(RegionRequestHeader& a, RegionRequestHeader& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RegionRequestHeader* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RegionRequestHeader* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RegionRequestHeader* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<RegionRequestHeader>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const RegionRequestHeader& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const RegionRequestHeader& from) {
+    RegionRequestHeader::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RegionRequestHeader* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "greptime.v1.region.RegionRequestHeader";
+  }
+  protected:
+  explicit RegionRequestHeader(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kTraceIdFieldNumber = 1,
+    kSpanIdFieldNumber = 2,
+  };
+  // optional uint64 trace_id = 1;
+  bool has_trace_id() const;
+  private:
+  bool _internal_has_trace_id() const;
+  public:
+  void clear_trace_id();
+  uint64_t trace_id() const;
+  void set_trace_id(uint64_t value);
+  private:
+  uint64_t _internal_trace_id() const;
+  void _internal_set_trace_id(uint64_t value);
+  public:
+
+  // optional uint64 span_id = 2;
+  bool has_span_id() const;
+  private:
+  bool _internal_has_span_id() const;
+  public:
+  void clear_span_id();
+  uint64_t span_id() const;
+  void set_span_id(uint64_t value);
+  private:
+  uint64_t _internal_span_id() const;
+  void _internal_set_span_id(uint64_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionRequestHeader)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    uint64_t trace_id_;
+    uint64_t span_id_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_greptime_2fv1_2fregion_2fserver_2eproto;
+};
+// -------------------------------------------------------------------
 
 class RegionRequest final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.region.RegionRequest) */ {
@@ -192,7 +364,7 @@ class RegionRequest final :
                &_RegionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    0;
+    1;
 
   friend void swap(RegionRequest& a, RegionRequest& b) {
     a.Swap(&b);
@@ -276,23 +448,23 @@ class RegionRequest final :
     kFlushFieldNumber = 10,
     kCompactFieldNumber = 11,
   };
-  // .greptime.v1.RequestHeader header = 1;
+  // .greptime.v1.region.RegionRequestHeader header = 1;
   bool has_header() const;
   private:
   bool _internal_has_header() const;
   public:
   void clear_header();
-  const ::greptime::v1::RequestHeader& header() const;
-  PROTOBUF_NODISCARD ::greptime::v1::RequestHeader* release_header();
-  ::greptime::v1::RequestHeader* mutable_header();
-  void set_allocated_header(::greptime::v1::RequestHeader* header);
+  const ::greptime::v1::region::RegionRequestHeader& header() const;
+  PROTOBUF_NODISCARD ::greptime::v1::region::RegionRequestHeader* release_header();
+  ::greptime::v1::region::RegionRequestHeader* mutable_header();
+  void set_allocated_header(::greptime::v1::region::RegionRequestHeader* header);
   private:
-  const ::greptime::v1::RequestHeader& _internal_header() const;
-  ::greptime::v1::RequestHeader* _internal_mutable_header();
+  const ::greptime::v1::region::RegionRequestHeader& _internal_header() const;
+  ::greptime::v1::region::RegionRequestHeader* _internal_mutable_header();
   public:
   void unsafe_arena_set_allocated_header(
-      ::greptime::v1::RequestHeader* header);
-  ::greptime::v1::RequestHeader* unsafe_arena_release_header();
+      ::greptime::v1::region::RegionRequestHeader* header);
+  ::greptime::v1::region::RegionRequestHeader* unsafe_arena_release_header();
 
   // .greptime.v1.region.InsertRequests inserts = 3;
   bool has_inserts() const;
@@ -478,7 +650,7 @@ class RegionRequest final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::greptime::v1::RequestHeader* header_;
+    ::greptime::v1::region::RegionRequestHeader* header_;
     union BodyUnion {
       constexpr BodyUnion() : _constinit_{} {}
         ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized _constinit_;
@@ -549,7 +721,7 @@ class RegionResponse final :
                &_RegionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    1;
+    2;
 
   friend void swap(RegionResponse& a, RegionResponse& b) {
     a.Swap(&b);
@@ -717,7 +889,7 @@ class InsertRequests final :
                &_InsertRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    3;
 
   friend void swap(InsertRequests& a, InsertRequests& b) {
     a.Swap(&b);
@@ -874,7 +1046,7 @@ class DeleteRequests final :
                &_DeleteRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    4;
 
   friend void swap(DeleteRequests& a, DeleteRequests& b) {
     a.Swap(&b);
@@ -1031,7 +1203,7 @@ class InsertRequest final :
                &_InsertRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    5;
 
   friend void swap(InsertRequest& a, InsertRequest& b) {
     a.Swap(&b);
@@ -1199,7 +1371,7 @@ class DeleteRequest final :
                &_DeleteRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    6;
 
   friend void swap(DeleteRequest& a, DeleteRequest& b) {
     a.Swap(&b);
@@ -1367,7 +1539,7 @@ class QueryRequest final :
                &_QueryRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    7;
 
   friend void swap(QueryRequest& a, QueryRequest& b) {
     a.Swap(&b);
@@ -1559,7 +1731,7 @@ class CreateRequest final :
                &_CreateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    9;
 
   friend void swap(CreateRequest& a, CreateRequest& b) {
     a.Swap(&b);
@@ -1821,7 +1993,7 @@ class DropRequest final :
                &_DropRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    10;
 
   friend void swap(DropRequest& a, DropRequest& b) {
     a.Swap(&b);
@@ -1997,7 +2169,7 @@ class OpenRequest final :
                &_OpenRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    12;
 
   friend void swap(OpenRequest& a, OpenRequest& b) {
     a.Swap(&b);
@@ -2203,7 +2375,7 @@ class CloseRequest final :
                &_CloseRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    13;
 
   friend void swap(CloseRequest& a, CloseRequest& b) {
     a.Swap(&b);
@@ -2351,7 +2523,7 @@ class AlterRequest final :
                &_AlterRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    14;
 
   friend void swap(AlterRequest& a, AlterRequest& b) {
     a.Swap(&b);
@@ -2499,7 +2671,7 @@ class FlushRequest final :
                &_FlushRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    15;
 
   friend void swap(FlushRequest& a, FlushRequest& b) {
     a.Swap(&b);
@@ -2647,7 +2819,7 @@ class CompactRequest final :
                &_CompactRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    16;
 
   friend void swap(CompactRequest& a, CompactRequest& b) {
     a.Swap(&b);
@@ -2795,7 +2967,7 @@ class ColumnDef final :
                &_ColumnDef_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    17;
 
   friend void swap(ColumnDef& a, ColumnDef& b) {
     a.Swap(&b);
@@ -2967,26 +3139,92 @@ class ColumnDef final :
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
+// RegionRequestHeader
+
+// optional uint64 trace_id = 1;
+inline bool RegionRequestHeader::_internal_has_trace_id() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool RegionRequestHeader::has_trace_id() const {
+  return _internal_has_trace_id();
+}
+inline void RegionRequestHeader::clear_trace_id() {
+  _impl_.trace_id_ = uint64_t{0u};
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline uint64_t RegionRequestHeader::_internal_trace_id() const {
+  return _impl_.trace_id_;
+}
+inline uint64_t RegionRequestHeader::trace_id() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionRequestHeader.trace_id)
+  return _internal_trace_id();
+}
+inline void RegionRequestHeader::_internal_set_trace_id(uint64_t value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.trace_id_ = value;
+}
+inline void RegionRequestHeader::set_trace_id(uint64_t value) {
+  _internal_set_trace_id(value);
+  // @@protoc_insertion_point(field_set:greptime.v1.region.RegionRequestHeader.trace_id)
+}
+
+// optional uint64 span_id = 2;
+inline bool RegionRequestHeader::_internal_has_span_id() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool RegionRequestHeader::has_span_id() const {
+  return _internal_has_span_id();
+}
+inline void RegionRequestHeader::clear_span_id() {
+  _impl_.span_id_ = uint64_t{0u};
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline uint64_t RegionRequestHeader::_internal_span_id() const {
+  return _impl_.span_id_;
+}
+inline uint64_t RegionRequestHeader::span_id() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionRequestHeader.span_id)
+  return _internal_span_id();
+}
+inline void RegionRequestHeader::_internal_set_span_id(uint64_t value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.span_id_ = value;
+}
+inline void RegionRequestHeader::set_span_id(uint64_t value) {
+  _internal_set_span_id(value);
+  // @@protoc_insertion_point(field_set:greptime.v1.region.RegionRequestHeader.span_id)
+}
+
+// -------------------------------------------------------------------
+
 // RegionRequest
 
-// .greptime.v1.RequestHeader header = 1;
+// .greptime.v1.region.RegionRequestHeader header = 1;
 inline bool RegionRequest::_internal_has_header() const {
   return this != internal_default_instance() && _impl_.header_ != nullptr;
 }
 inline bool RegionRequest::has_header() const {
   return _internal_has_header();
 }
-inline const ::greptime::v1::RequestHeader& RegionRequest::_internal_header() const {
-  const ::greptime::v1::RequestHeader* p = _impl_.header_;
-  return p != nullptr ? *p : reinterpret_cast<const ::greptime::v1::RequestHeader&>(
-      ::greptime::v1::_RequestHeader_default_instance_);
+inline void RegionRequest::clear_header() {
+  if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
+    delete _impl_.header_;
+  }
+  _impl_.header_ = nullptr;
 }
-inline const ::greptime::v1::RequestHeader& RegionRequest::header() const {
+inline const ::greptime::v1::region::RegionRequestHeader& RegionRequest::_internal_header() const {
+  const ::greptime::v1::region::RegionRequestHeader* p = _impl_.header_;
+  return p != nullptr ? *p : reinterpret_cast<const ::greptime::v1::region::RegionRequestHeader&>(
+      ::greptime::v1::region::_RegionRequestHeader_default_instance_);
+}
+inline const ::greptime::v1::region::RegionRequestHeader& RegionRequest::header() const {
   // @@protoc_insertion_point(field_get:greptime.v1.region.RegionRequest.header)
   return _internal_header();
 }
 inline void RegionRequest::unsafe_arena_set_allocated_header(
-    ::greptime::v1::RequestHeader* header) {
+    ::greptime::v1::region::RegionRequestHeader* header) {
   if (GetArenaForAllocation() == nullptr) {
     delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.header_);
   }
@@ -2998,9 +3236,9 @@ inline void RegionRequest::unsafe_arena_set_allocated_header(
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequest.header)
 }
-inline ::greptime::v1::RequestHeader* RegionRequest::release_header() {
+inline ::greptime::v1::region::RegionRequestHeader* RegionRequest::release_header() {
   
-  ::greptime::v1::RequestHeader* temp = _impl_.header_;
+  ::greptime::v1::region::RegionRequestHeader* temp = _impl_.header_;
   _impl_.header_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
@@ -3013,35 +3251,34 @@ inline ::greptime::v1::RequestHeader* RegionRequest::release_header() {
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::greptime::v1::RequestHeader* RegionRequest::unsafe_arena_release_header() {
+inline ::greptime::v1::region::RegionRequestHeader* RegionRequest::unsafe_arena_release_header() {
   // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequest.header)
   
-  ::greptime::v1::RequestHeader* temp = _impl_.header_;
+  ::greptime::v1::region::RegionRequestHeader* temp = _impl_.header_;
   _impl_.header_ = nullptr;
   return temp;
 }
-inline ::greptime::v1::RequestHeader* RegionRequest::_internal_mutable_header() {
+inline ::greptime::v1::region::RegionRequestHeader* RegionRequest::_internal_mutable_header() {
   
   if (_impl_.header_ == nullptr) {
-    auto* p = CreateMaybeMessage<::greptime::v1::RequestHeader>(GetArenaForAllocation());
+    auto* p = CreateMaybeMessage<::greptime::v1::region::RegionRequestHeader>(GetArenaForAllocation());
     _impl_.header_ = p;
   }
   return _impl_.header_;
 }
-inline ::greptime::v1::RequestHeader* RegionRequest::mutable_header() {
-  ::greptime::v1::RequestHeader* _msg = _internal_mutable_header();
+inline ::greptime::v1::region::RegionRequestHeader* RegionRequest::mutable_header() {
+  ::greptime::v1::region::RegionRequestHeader* _msg = _internal_mutable_header();
   // @@protoc_insertion_point(field_mutable:greptime.v1.region.RegionRequest.header)
   return _msg;
 }
-inline void RegionRequest::set_allocated_header(::greptime::v1::RequestHeader* header) {
+inline void RegionRequest::set_allocated_header(::greptime::v1::region::RegionRequestHeader* header) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.header_);
+    delete _impl_.header_;
   }
   if (header) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(
-                reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(header));
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(header);
     if (message_arena != submessage_arena) {
       header = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
           message_arena, header, submessage_arena);
@@ -4942,6 +5179,8 @@ inline void ColumnDef::set_semantic_type(::greptime::v1::SemanticType value) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -14,24 +14,714 @@ public final class Server {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
+  public interface RegionRequestHeaderOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:greptime.v1.region.RegionRequestHeader)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * TraceID of request
+     * </pre>
+     *
+     * <code>optional uint64 trace_id = 1;</code>
+     * @return Whether the traceId field is set.
+     */
+    boolean hasTraceId();
+    /**
+     * <pre>
+     * TraceID of request
+     * </pre>
+     *
+     * <code>optional uint64 trace_id = 1;</code>
+     * @return The traceId.
+     */
+    long getTraceId();
+
+    /**
+     * <pre>
+     * SpanID of request
+     * </pre>
+     *
+     * <code>optional uint64 span_id = 2;</code>
+     * @return Whether the spanId field is set.
+     */
+    boolean hasSpanId();
+    /**
+     * <pre>
+     * SpanID of request
+     * </pre>
+     *
+     * <code>optional uint64 span_id = 2;</code>
+     * @return The spanId.
+     */
+    long getSpanId();
+  }
+  /**
+   * Protobuf type {@code greptime.v1.region.RegionRequestHeader}
+   */
+  public static final class RegionRequestHeader extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:greptime.v1.region.RegionRequestHeader)
+      RegionRequestHeaderOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RegionRequestHeader.newBuilder() to construct.
+    private RegionRequestHeader(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RegionRequestHeader() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new RegionRequestHeader();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RegionRequestHeader(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 8: {
+              bitField0_ |= 0x00000001;
+              traceId_ = input.readUInt64();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              spanId_ = input.readUInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionRequestHeader_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.greptime.v1.region.Server.RegionRequestHeader.class, io.greptime.v1.region.Server.RegionRequestHeader.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int TRACE_ID_FIELD_NUMBER = 1;
+    private long traceId_;
+    /**
+     * <pre>
+     * TraceID of request
+     * </pre>
+     *
+     * <code>optional uint64 trace_id = 1;</code>
+     * @return Whether the traceId field is set.
+     */
+    @java.lang.Override
+    public boolean hasTraceId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * TraceID of request
+     * </pre>
+     *
+     * <code>optional uint64 trace_id = 1;</code>
+     * @return The traceId.
+     */
+    @java.lang.Override
+    public long getTraceId() {
+      return traceId_;
+    }
+
+    public static final int SPAN_ID_FIELD_NUMBER = 2;
+    private long spanId_;
+    /**
+     * <pre>
+     * SpanID of request
+     * </pre>
+     *
+     * <code>optional uint64 span_id = 2;</code>
+     * @return Whether the spanId field is set.
+     */
+    @java.lang.Override
+    public boolean hasSpanId() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * SpanID of request
+     * </pre>
+     *
+     * <code>optional uint64 span_id = 2;</code>
+     * @return The spanId.
+     */
+    @java.lang.Override
+    public long getSpanId() {
+      return spanId_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeUInt64(1, traceId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeUInt64(2, spanId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(1, traceId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(2, spanId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.greptime.v1.region.Server.RegionRequestHeader)) {
+        return super.equals(obj);
+      }
+      io.greptime.v1.region.Server.RegionRequestHeader other = (io.greptime.v1.region.Server.RegionRequestHeader) obj;
+
+      if (hasTraceId() != other.hasTraceId()) return false;
+      if (hasTraceId()) {
+        if (getTraceId()
+            != other.getTraceId()) return false;
+      }
+      if (hasSpanId() != other.hasSpanId()) return false;
+      if (hasSpanId()) {
+        if (getSpanId()
+            != other.getSpanId()) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTraceId()) {
+        hash = (37 * hash) + TRACE_ID_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getTraceId());
+      }
+      if (hasSpanId()) {
+        hash = (37 * hash) + SPAN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getSpanId());
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.RegionRequestHeader parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.greptime.v1.region.Server.RegionRequestHeader prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code greptime.v1.region.RegionRequestHeader}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:greptime.v1.region.RegionRequestHeader)
+        io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionRequestHeader_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.greptime.v1.region.Server.RegionRequestHeader.class, io.greptime.v1.region.Server.RegionRequestHeader.Builder.class);
+      }
+
+      // Construct using io.greptime.v1.region.Server.RegionRequestHeader.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        traceId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        spanId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionRequestHeader_descriptor;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RegionRequestHeader getDefaultInstanceForType() {
+        return io.greptime.v1.region.Server.RegionRequestHeader.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RegionRequestHeader build() {
+        io.greptime.v1.region.Server.RegionRequestHeader result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RegionRequestHeader buildPartial() {
+        io.greptime.v1.region.Server.RegionRequestHeader result = new io.greptime.v1.region.Server.RegionRequestHeader(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.traceId_ = traceId_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.spanId_ = spanId_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.greptime.v1.region.Server.RegionRequestHeader) {
+          return mergeFrom((io.greptime.v1.region.Server.RegionRequestHeader)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.greptime.v1.region.Server.RegionRequestHeader other) {
+        if (other == io.greptime.v1.region.Server.RegionRequestHeader.getDefaultInstance()) return this;
+        if (other.hasTraceId()) {
+          setTraceId(other.getTraceId());
+        }
+        if (other.hasSpanId()) {
+          setSpanId(other.getSpanId());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.greptime.v1.region.Server.RegionRequestHeader parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.greptime.v1.region.Server.RegionRequestHeader) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long traceId_ ;
+      /**
+       * <pre>
+       * TraceID of request
+       * </pre>
+       *
+       * <code>optional uint64 trace_id = 1;</code>
+       * @return Whether the traceId field is set.
+       */
+      @java.lang.Override
+      public boolean hasTraceId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * TraceID of request
+       * </pre>
+       *
+       * <code>optional uint64 trace_id = 1;</code>
+       * @return The traceId.
+       */
+      @java.lang.Override
+      public long getTraceId() {
+        return traceId_;
+      }
+      /**
+       * <pre>
+       * TraceID of request
+       * </pre>
+       *
+       * <code>optional uint64 trace_id = 1;</code>
+       * @param value The traceId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTraceId(long value) {
+        bitField0_ |= 0x00000001;
+        traceId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * TraceID of request
+       * </pre>
+       *
+       * <code>optional uint64 trace_id = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTraceId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        traceId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long spanId_ ;
+      /**
+       * <pre>
+       * SpanID of request
+       * </pre>
+       *
+       * <code>optional uint64 span_id = 2;</code>
+       * @return Whether the spanId field is set.
+       */
+      @java.lang.Override
+      public boolean hasSpanId() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * SpanID of request
+       * </pre>
+       *
+       * <code>optional uint64 span_id = 2;</code>
+       * @return The spanId.
+       */
+      @java.lang.Override
+      public long getSpanId() {
+        return spanId_;
+      }
+      /**
+       * <pre>
+       * SpanID of request
+       * </pre>
+       *
+       * <code>optional uint64 span_id = 2;</code>
+       * @param value The spanId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSpanId(long value) {
+        bitField0_ |= 0x00000002;
+        spanId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * SpanID of request
+       * </pre>
+       *
+       * <code>optional uint64 span_id = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSpanId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        spanId_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:greptime.v1.region.RegionRequestHeader)
+    }
+
+    // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionRequestHeader)
+    private static final io.greptime.v1.region.Server.RegionRequestHeader DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.greptime.v1.region.Server.RegionRequestHeader();
+    }
+
+    public static io.greptime.v1.region.Server.RegionRequestHeader getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<RegionRequestHeader>
+        PARSER = new com.google.protobuf.AbstractParser<RegionRequestHeader>() {
+      @java.lang.Override
+      public RegionRequestHeader parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RegionRequestHeader(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RegionRequestHeader> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RegionRequestHeader> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.greptime.v1.region.Server.RegionRequestHeader getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface RegionRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:greptime.v1.region.RegionRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.greptime.v1.RequestHeader header = 1;</code>
+     * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
      * @return Whether the header field is set.
      */
     boolean hasHeader();
     /**
-     * <code>.greptime.v1.RequestHeader header = 1;</code>
+     * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
      * @return The header.
      */
-    io.greptime.v1.Common.RequestHeader getHeader();
+    io.greptime.v1.region.Server.RegionRequestHeader getHeader();
     /**
-     * <code>.greptime.v1.RequestHeader header = 1;</code>
+     * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
      */
-    io.greptime.v1.Common.RequestHeaderOrBuilder getHeaderOrBuilder();
+    io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder getHeaderOrBuilder();
 
     /**
      * <code>.greptime.v1.region.InsertRequests inserts = 3;</code>
@@ -216,11 +906,11 @@ public final class Server {
               done = true;
               break;
             case 10: {
-              io.greptime.v1.Common.RequestHeader.Builder subBuilder = null;
+              io.greptime.v1.region.Server.RegionRequestHeader.Builder subBuilder = null;
               if (header_ != null) {
                 subBuilder = header_.toBuilder();
               }
-              header_ = input.readMessage(io.greptime.v1.Common.RequestHeader.parser(), extensionRegistry);
+              header_ = input.readMessage(io.greptime.v1.region.Server.RegionRequestHeader.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(header_);
                 header_ = subBuilder.buildPartial();
@@ -444,9 +1134,9 @@ public final class Server {
     }
 
     public static final int HEADER_FIELD_NUMBER = 1;
-    private io.greptime.v1.Common.RequestHeader header_;
+    private io.greptime.v1.region.Server.RegionRequestHeader header_;
     /**
-     * <code>.greptime.v1.RequestHeader header = 1;</code>
+     * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
      * @return Whether the header field is set.
      */
     @java.lang.Override
@@ -454,18 +1144,18 @@ public final class Server {
       return header_ != null;
     }
     /**
-     * <code>.greptime.v1.RequestHeader header = 1;</code>
+     * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
      * @return The header.
      */
     @java.lang.Override
-    public io.greptime.v1.Common.RequestHeader getHeader() {
-      return header_ == null ? io.greptime.v1.Common.RequestHeader.getDefaultInstance() : header_;
+    public io.greptime.v1.region.Server.RegionRequestHeader getHeader() {
+      return header_ == null ? io.greptime.v1.region.Server.RegionRequestHeader.getDefaultInstance() : header_;
     }
     /**
-     * <code>.greptime.v1.RequestHeader header = 1;</code>
+     * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
      */
     @java.lang.Override
-    public io.greptime.v1.Common.RequestHeaderOrBuilder getHeaderOrBuilder() {
+    public io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder getHeaderOrBuilder() {
       return getHeader();
     }
 
@@ -1329,31 +2019,31 @@ public final class Server {
       }
 
 
-      private io.greptime.v1.Common.RequestHeader header_;
+      private io.greptime.v1.region.Server.RegionRequestHeader header_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          io.greptime.v1.Common.RequestHeader, io.greptime.v1.Common.RequestHeader.Builder, io.greptime.v1.Common.RequestHeaderOrBuilder> headerBuilder_;
+          io.greptime.v1.region.Server.RegionRequestHeader, io.greptime.v1.region.Server.RegionRequestHeader.Builder, io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder> headerBuilder_;
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        * @return Whether the header field is set.
        */
       public boolean hasHeader() {
         return headerBuilder_ != null || header_ != null;
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        * @return The header.
        */
-      public io.greptime.v1.Common.RequestHeader getHeader() {
+      public io.greptime.v1.region.Server.RegionRequestHeader getHeader() {
         if (headerBuilder_ == null) {
-          return header_ == null ? io.greptime.v1.Common.RequestHeader.getDefaultInstance() : header_;
+          return header_ == null ? io.greptime.v1.region.Server.RegionRequestHeader.getDefaultInstance() : header_;
         } else {
           return headerBuilder_.getMessage();
         }
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
-      public Builder setHeader(io.greptime.v1.Common.RequestHeader value) {
+      public Builder setHeader(io.greptime.v1.region.Server.RegionRequestHeader value) {
         if (headerBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -1367,10 +2057,10 @@ public final class Server {
         return this;
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
       public Builder setHeader(
-          io.greptime.v1.Common.RequestHeader.Builder builderForValue) {
+          io.greptime.v1.region.Server.RegionRequestHeader.Builder builderForValue) {
         if (headerBuilder_ == null) {
           header_ = builderForValue.build();
           onChanged();
@@ -1381,13 +2071,13 @@ public final class Server {
         return this;
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
-      public Builder mergeHeader(io.greptime.v1.Common.RequestHeader value) {
+      public Builder mergeHeader(io.greptime.v1.region.Server.RegionRequestHeader value) {
         if (headerBuilder_ == null) {
           if (header_ != null) {
             header_ =
-              io.greptime.v1.Common.RequestHeader.newBuilder(header_).mergeFrom(value).buildPartial();
+              io.greptime.v1.region.Server.RegionRequestHeader.newBuilder(header_).mergeFrom(value).buildPartial();
           } else {
             header_ = value;
           }
@@ -1399,7 +2089,7 @@ public final class Server {
         return this;
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
       public Builder clearHeader() {
         if (headerBuilder_ == null) {
@@ -1413,33 +2103,33 @@ public final class Server {
         return this;
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
-      public io.greptime.v1.Common.RequestHeader.Builder getHeaderBuilder() {
+      public io.greptime.v1.region.Server.RegionRequestHeader.Builder getHeaderBuilder() {
         
         onChanged();
         return getHeaderFieldBuilder().getBuilder();
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
-      public io.greptime.v1.Common.RequestHeaderOrBuilder getHeaderOrBuilder() {
+      public io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder getHeaderOrBuilder() {
         if (headerBuilder_ != null) {
           return headerBuilder_.getMessageOrBuilder();
         } else {
           return header_ == null ?
-              io.greptime.v1.Common.RequestHeader.getDefaultInstance() : header_;
+              io.greptime.v1.region.Server.RegionRequestHeader.getDefaultInstance() : header_;
         }
       }
       /**
-       * <code>.greptime.v1.RequestHeader header = 1;</code>
+       * <code>.greptime.v1.region.RegionRequestHeader header = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          io.greptime.v1.Common.RequestHeader, io.greptime.v1.Common.RequestHeader.Builder, io.greptime.v1.Common.RequestHeaderOrBuilder> 
+          io.greptime.v1.region.Server.RegionRequestHeader, io.greptime.v1.region.Server.RegionRequestHeader.Builder, io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder> 
           getHeaderFieldBuilder() {
         if (headerBuilder_ == null) {
           headerBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              io.greptime.v1.Common.RequestHeader, io.greptime.v1.Common.RequestHeader.Builder, io.greptime.v1.Common.RequestHeaderOrBuilder>(
+              io.greptime.v1.region.Server.RegionRequestHeader, io.greptime.v1.region.Server.RegionRequestHeader.Builder, io.greptime.v1.region.Server.RegionRequestHeaderOrBuilder>(
                   getHeader(),
                   getParentForChildren(),
                   isClean());
@@ -13832,6 +14522,11 @@ java.lang.String defaultValue);
   }
 
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_region_RegionRequestHeader_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_greptime_v1_region_RegionRequest_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -13927,57 +14622,59 @@ java.lang.String defaultValue);
     java.lang.String[] descriptorData = {
       "\n\037greptime/v1/region/server.proto\022\022grept" +
       "ime.v1.region\032\030greptime/v1/common.proto\032" +
-      "\025greptime/v1/row.proto\"\230\004\n\rRegionRequest" +
-      "\022*\n\006header\030\001 \001(\0132\032.greptime.v1.RequestHe" +
-      "ader\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regi" +
-      "on.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".g" +
-      "reptime.v1.region.DeleteRequestsH\000\0223\n\006cr" +
-      "eate\030\005 \001(\0132!.greptime.v1.region.CreateRe" +
-      "questH\000\022/\n\004drop\030\006 \001(\0132\037.greptime.v1.regi" +
-      "on.DropRequestH\000\022/\n\004open\030\007 \001(\0132\037.greptim" +
-      "e.v1.region.OpenRequestH\000\0221\n\005close\030\010 \001(\013" +
-      "2 .greptime.v1.region.CloseRequestH\000\0221\n\005" +
-      "alter\030\t \001(\0132 .greptime.v1.region.AlterRe" +
-      "questH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.reg" +
-      "ion.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gr" +
-      "eptime.v1.region.CompactRequestH\000B\006\n\004bod" +
-      "y\"T\n\016RegionResponse\022+\n\006header\030\001 \001(\0132\033.gr" +
-      "eptime.v1.ResponseHeader\022\025\n\raffected_row" +
-      "s\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requests\030\001 " +
-      "\003(\0132!.greptime.v1.region.InsertRequest\"E" +
-      "\n\016DeleteRequests\0223\n\010requests\030\001 \003(\0132!.gre" +
-      "ptime.v1.region.DeleteRequest\"C\n\rInsertR" +
-      "equest\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132" +
-      "\021.greptime.v1.Rows\"C\n\rDeleteRequest\022\021\n\tr" +
-      "egion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime." +
-      "v1.Rows\"/\n\014QueryRequest\022\021\n\tregion_id\030\001 \001" +
-      "(\004\022\014\n\004plan\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tre" +
-      "gion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column_" +
-      "defs\030\003 \003(\0132\035.greptime.v1.region.ColumnDe" +
-      "f\022\023\n\013primary_key\030\004 \003(\r\022\034\n\024create_if_not_" +
-      "exists\030\005 \001(\010\022\022\n\nregion_dir\030\006 \001(\t\022?\n\007opti" +
-      "ons\030\007 \003(\0132..greptime.v1.region.CreateReq" +
-      "uest.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003key" +
-      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest" +
-      "\022\021\n\tregion_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\tr" +
-      "egion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion" +
-      "_dir\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,.greptime.v" +
-      "1.region.OpenRequest.OptionsEntry\032.\n\014Opt" +
-      "ionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028" +
-      "\001\"!\n\014CloseRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014" +
-      "AlterRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014Flush" +
-      "Request\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactReq" +
-      "uest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n" +
-      "\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010dataty" +
-      "pe\030\003 \001(\0162\033.greptime.v1.ColumnDataType\022\023\n" +
-      "\013is_nullable\030\004 \001(\010\022\032\n\022default_constraint" +
-      "\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001(\0162\031.greptime" +
-      ".v1.SemanticType2Y\n\006Region\022O\n\006Handle\022!.g" +
-      "reptime.v1.region.RegionRequest\032\".grepti" +
-      "me.v1.region.RegionResponseB]\n\025io.grepti" +
-      "me.v1.regionB\006ServerZ<github.com/Greptim" +
-      "eTeam/greptime-proto/go/greptime/v1/regi" +
-      "onb\006proto3"
+      "\025greptime/v1/row.proto\"[\n\023RegionRequestH" +
+      "eader\022\025\n\010trace_id\030\001 \001(\004H\000\210\001\001\022\024\n\007span_id\030" +
+      "\002 \001(\004H\001\210\001\001B\013\n\t_trace_idB\n\n\010_span_id\"\245\004\n\r" +
+      "RegionRequest\0227\n\006header\030\001 \001(\0132\'.greptime" +
+      ".v1.region.RegionRequestHeader\0225\n\007insert" +
+      "s\030\003 \001(\0132\".greptime.v1.region.InsertReque" +
+      "stsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v1.reg" +
+      "ion.DeleteRequestsH\000\0223\n\006create\030\005 \001(\0132!.g" +
+      "reptime.v1.region.CreateRequestH\000\022/\n\004dro" +
+      "p\030\006 \001(\0132\037.greptime.v1.region.DropRequest" +
+      "H\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.region.Op" +
+      "enRequestH\000\0221\n\005close\030\010 \001(\0132 .greptime.v1" +
+      ".region.CloseRequestH\000\0221\n\005alter\030\t \001(\0132 ." +
+      "greptime.v1.region.AlterRequestH\000\0221\n\005flu" +
+      "sh\030\n \001(\0132 .greptime.v1.region.FlushReque" +
+      "stH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1.regi" +
+      "on.CompactRequestH\000B\006\n\004body\"T\n\016RegionRes" +
+      "ponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1.Resp" +
+      "onseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E\n\016Ins" +
+      "ertRequests\0223\n\010requests\030\001 \003(\0132!.greptime" +
+      ".v1.region.InsertRequest\"E\n\016DeleteReques" +
+      "ts\0223\n\010requests\030\001 \003(\0132!.greptime.v1.regio" +
+      "n.DeleteRequest\"C\n\rInsertRequest\022\021\n\tregi" +
+      "on_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1." +
+      "Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030\001 \001(\004" +
+      "\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"/\n\014Que" +
+      "ryRequest\022\021\n\tregion_id\030\001 \001(\004\022\014\n\004plan\030\002 \001" +
+      "(\014\"\236\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022" +
+      "\016\n\006engine\030\002 \001(\t\0222\n\013column_defs\030\003 \003(\0132\035.g" +
+      "reptime.v1.region.ColumnDef\022\023\n\013primary_k" +
+      "ey\030\004 \003(\r\022\034\n\024create_if_not_exists\030\005 \001(\010\022\022" +
+      "\n\nregion_dir\030\006 \001(\t\022?\n\007options\030\007 \003(\0132..gr" +
+      "eptime.v1.region.CreateRequest.OptionsEn" +
+      "try\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu" +
+      "e\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021\n\tregion_id\030" +
+      "\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004" +
+      "\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion_dir\030\003 \001(\t\022=\n\007" +
+      "options\030\004 \003(\0132,.greptime.v1.region.OpenR" +
+      "equest.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003k" +
+      "ey\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"!\n\014CloseRequ" +
+      "est\022\021\n\tregion_id\030\001 \001(\004\"!\n\014AlterRequest\022\021" +
+      "\n\tregion_id\030\001 \001(\004\"!\n\014FlushRequest\022\021\n\treg" +
+      "ion_id\030\001 \001(\004\"#\n\016CompactRequest\022\021\n\tregion" +
+      "_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n" +
+      "\tcolumn_id\030\002 \001(\r\022-\n\010datatype\030\003 \001(\0162\033.gre" +
+      "ptime.v1.ColumnDataType\022\023\n\013is_nullable\030\004" +
+      " \001(\010\022\032\n\022default_constraint\030\005 \001(\014\0220\n\rsema" +
+      "ntic_type\030\006 \001(\0162\031.greptime.v1.SemanticTy" +
+      "pe2Y\n\006Region\022O\n\006Handle\022!.greptime.v1.reg" +
+      "ion.RegionRequest\032\".greptime.v1.region.R" +
+      "egionResponseB]\n\025io.greptime.v1.regionB\006" +
+      "ServerZ<github.com/GreptimeTeam/greptime" +
+      "-proto/go/greptime/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -13985,50 +14682,56 @@ java.lang.String defaultValue);
           io.greptime.v1.Common.getDescriptor(),
           io.greptime.v1.RowData.getDescriptor(),
         });
-    internal_static_greptime_v1_region_RegionRequest_descriptor =
+    internal_static_greptime_v1_region_RegionRequestHeader_descriptor =
       getDescriptor().getMessageTypes().get(0);
+    internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_region_RegionRequestHeader_descriptor,
+        new java.lang.String[] { "TraceId", "SpanId", "TraceId", "SpanId", });
+    internal_static_greptime_v1_region_RegionRequest_descriptor =
+      getDescriptor().getMessageTypes().get(1);
     internal_static_greptime_v1_region_RegionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequest_descriptor,
         new java.lang.String[] { "Header", "Inserts", "Deletes", "Create", "Drop", "Open", "Close", "Alter", "Flush", "Compact", "Body", });
     internal_static_greptime_v1_region_RegionResponse_descriptor =
-      getDescriptor().getMessageTypes().get(1);
+      getDescriptor().getMessageTypes().get(2);
     internal_static_greptime_v1_region_RegionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionResponse_descriptor,
         new java.lang.String[] { "Header", "AffectedRows", });
     internal_static_greptime_v1_region_InsertRequests_descriptor =
-      getDescriptor().getMessageTypes().get(2);
+      getDescriptor().getMessageTypes().get(3);
     internal_static_greptime_v1_region_InsertRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_InsertRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_DeleteRequests_descriptor =
-      getDescriptor().getMessageTypes().get(3);
+      getDescriptor().getMessageTypes().get(4);
     internal_static_greptime_v1_region_DeleteRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DeleteRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_InsertRequest_descriptor =
-      getDescriptor().getMessageTypes().get(4);
+      getDescriptor().getMessageTypes().get(5);
     internal_static_greptime_v1_region_InsertRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_InsertRequest_descriptor,
         new java.lang.String[] { "RegionId", "Rows", });
     internal_static_greptime_v1_region_DeleteRequest_descriptor =
-      getDescriptor().getMessageTypes().get(5);
+      getDescriptor().getMessageTypes().get(6);
     internal_static_greptime_v1_region_DeleteRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DeleteRequest_descriptor,
         new java.lang.String[] { "RegionId", "Rows", });
     internal_static_greptime_v1_region_QueryRequest_descriptor =
-      getDescriptor().getMessageTypes().get(6);
+      getDescriptor().getMessageTypes().get(7);
     internal_static_greptime_v1_region_QueryRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_QueryRequest_descriptor,
         new java.lang.String[] { "RegionId", "Plan", });
     internal_static_greptime_v1_region_CreateRequest_descriptor =
-      getDescriptor().getMessageTypes().get(7);
+      getDescriptor().getMessageTypes().get(8);
     internal_static_greptime_v1_region_CreateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CreateRequest_descriptor,
@@ -14040,13 +14743,13 @@ java.lang.String defaultValue);
         internal_static_greptime_v1_region_CreateRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_greptime_v1_region_DropRequest_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_greptime_v1_region_DropRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DropRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_OpenRequest_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_greptime_v1_region_OpenRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_OpenRequest_descriptor,
@@ -14058,31 +14761,31 @@ java.lang.String defaultValue);
         internal_static_greptime_v1_region_OpenRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_greptime_v1_region_CloseRequest_descriptor =
-      getDescriptor().getMessageTypes().get(10);
+      getDescriptor().getMessageTypes().get(11);
     internal_static_greptime_v1_region_CloseRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CloseRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_AlterRequest_descriptor =
-      getDescriptor().getMessageTypes().get(11);
+      getDescriptor().getMessageTypes().get(12);
     internal_static_greptime_v1_region_AlterRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_AlterRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_FlushRequest_descriptor =
-      getDescriptor().getMessageTypes().get(12);
+      getDescriptor().getMessageTypes().get(13);
     internal_static_greptime_v1_region_FlushRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_FlushRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_CompactRequest_descriptor =
-      getDescriptor().getMessageTypes().get(13);
+      getDescriptor().getMessageTypes().get(14);
     internal_static_greptime_v1_region_CompactRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CompactRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_ColumnDef_descriptor =
-      getDescriptor().getMessageTypes().get(14);
+      getDescriptor().getMessageTypes().get(15);
     internal_static_greptime_v1_region_ColumnDef_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_ColumnDef_descriptor,

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -25,8 +25,15 @@ import "greptime/v1/row.proto";
 
 service Region { rpc Handle(RegionRequest) returns (RegionResponse); }
 
+message RegionRequestHeader {
+  // TraceID of request
+  optional uint64 trace_id = 1;
+  // SpanID of request
+  optional uint64 span_id = 2;
+}
+
 message RegionRequest {
-  RequestHeader header = 1;
+  RegionRequestHeader header = 1;
   // query request is handled in flight services.
   oneof body {
     InsertRequests inserts = 3;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


The old `RequestHeader` is "a little common", it contains much unneeded info for region servers like `catalog`, `auth` or `db_name`. Thus I define a new header for `RegionRequest`

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
