### PR TITLE
feat: remove storage path in open/create request

### DIFF
--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -25,9 +25,10 @@ namespace v1 {
 namespace region {
 PROTOBUF_CONSTEXPR RegionRequestHeader::RegionRequestHeader(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.trace_id_)*/uint64_t{0u}
-  , /*decltype(_impl_.span_id_)*/uint64_t{0u}
-  , /*decltype(_impl_._cached_size_)*/{}} {}
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.trace_id_)*/uint64_t{0u}
+  , /*decltype(_impl_.span_id_)*/uint64_t{0u}} {}
 struct RegionRequestHeaderDefaultTypeInternal {
   PROTOBUF_CONSTEXPR RegionRequestHeaderDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
@@ -152,7 +153,8 @@ PROTOBUF_CONSTEXPR CreateRequest::CreateRequest(
   , /*decltype(_impl_._primary_key_cached_byte_size_)*/{0}
   , /*decltype(_impl_.options_)*/{::_pbi::ConstantInitialized()}
   , /*decltype(_impl_.engine_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.region_dir_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.catalog_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.schema_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.region_id_)*/uint64_t{0u}
   , /*decltype(_impl_.create_if_not_exists_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
@@ -193,7 +195,8 @@ PROTOBUF_CONSTEXPR OpenRequest::OpenRequest(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.options_)*/{::_pbi::ConstantInitialized()}
   , /*decltype(_impl_.engine_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.region_dir_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.catalog_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.schema_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.region_id_)*/uint64_t{0u}
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct OpenRequestDefaultTypeInternal {
@@ -283,7 +286,7 @@ static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_grept
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 
 const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -291,6 +294,8 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.trace_id_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.span_id_),
+  0,
+  1,
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -375,7 +380,8 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.column_defs_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.primary_key_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.create_if_not_exists_),
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.region_dir_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.catalog_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.schema_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CreateRequest, _impl_.options_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::DropRequest, _internal_metadata_),
@@ -402,7 +408,8 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::OpenRequest, _impl_.region_id_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::OpenRequest, _impl_.engine_),
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::OpenRequest, _impl_.region_dir_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::OpenRequest, _impl_.catalog_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::OpenRequest, _impl_.schema_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::OpenRequest, _impl_.options_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CloseRequest, _internal_metadata_),
@@ -446,24 +453,24 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::ColumnDef, _impl_.semantic_type_),
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, -1, sizeof(::greptime::v1::region::RegionRequestHeader)},
-  { 8, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
-  { 25, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
-  { 33, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
-  { 40, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
-  { 47, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
-  { 55, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
-  { 63, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
-  { 71, 79, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
-  { 81, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
-  { 94, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
-  { 101, 109, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
-  { 111, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
-  { 121, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
-  { 128, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
-  { 135, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
-  { 142, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
-  { 149, -1, -1, sizeof(::greptime::v1::region::ColumnDef)},
+  { 0, 8, -1, sizeof(::greptime::v1::region::RegionRequestHeader)},
+  { 10, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
+  { 27, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
+  { 35, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
+  { 42, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
+  { 49, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
+  { 57, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
+  { 65, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
+  { 73, 81, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
+  { 83, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
+  { 97, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
+  { 104, 112, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
+  { 114, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
+  { 125, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
+  { 132, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
+  { 139, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
+  { 146, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
+  { 153, -1, -1, sizeof(::greptime::v1::region::ColumnDef)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -490,59 +497,60 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\037greptime/v1/region/server.proto\022\022grept"
   "ime.v1.region\032\030greptime/v1/common.proto\032"
-  "\025greptime/v1/row.proto\"8\n\023RegionRequestH"
-  "eader\022\020\n\010trace_id\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004"
-  "\"\245\004\n\rRegionRequest\0227\n\006header\030\001 \001(\0132\'.gre"
-  "ptime.v1.region.RegionRequestHeader\0225\n\007i"
-  "nserts\030\003 \001(\0132\".greptime.v1.region.Insert"
-  "RequestsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v"
-  "1.region.DeleteRequestsH\000\0223\n\006create\030\005 \001("
-  "\0132!.greptime.v1.region.CreateRequestH\000\022/"
-  "\n\004drop\030\006 \001(\0132\037.greptime.v1.region.DropRe"
-  "questH\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.regi"
-  "on.OpenRequestH\000\0221\n\005close\030\010 \001(\0132 .grepti"
-  "me.v1.region.CloseRequestH\000\0221\n\005alter\030\t \001"
-  "(\0132 .greptime.v1.region.AlterRequestH\000\0221"
-  "\n\005flush\030\n \001(\0132 .greptime.v1.region.Flush"
-  "RequestH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1"
-  ".region.CompactRequestH\000B\006\n\004body\"T\n\016Regi"
-  "onResponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1"
-  ".ResponseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E"
-  "\n\016InsertRequests\0223\n\010requests\030\001 \003(\0132!.gre"
-  "ptime.v1.region.InsertRequest\"E\n\016DeleteR"
-  "equests\0223\n\010requests\030\001 \003(\0132!.greptime.v1."
-  "region.DeleteRequest\"C\n\rInsertRequest\022\021\n"
-  "\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptim"
-  "e.v1.Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030"
-  "\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"/"
-  "\n\014QueryRequest\022\021\n\tregion_id\030\001 \001(\004\022\014\n\004pla"
-  "n\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tregion_id\030\001"
-  " \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column_defs\030\003 \003("
-  "\0132\035.greptime.v1.region.ColumnDef\022\023\n\013prim"
-  "ary_key\030\004 \003(\r\022\034\n\024create_if_not_exists\030\005 "
-  "\001(\010\022\022\n\nregion_dir\030\006 \001(\t\022\?\n\007options\030\007 \003(\013"
-  "2..greptime.v1.region.CreateRequest.Opti"
-  "onsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n"
-  "\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021\n\tregio"
-  "n_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\tregion_id\030"
-  "\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion_dir\030\003 \001("
-  "\t\022=\n\007options\030\004 \003(\0132,.greptime.v1.region."
-  "OpenRequest.OptionsEntry\032.\n\014OptionsEntry"
-  "\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"!\n\014Clos"
-  "eRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014AlterRequ"
-  "est\022\021\n\tregion_id\030\001 \001(\004\"!\n\014FlushRequest\022\021"
-  "\n\tregion_id\030\001 \001(\004\"#\n\016CompactRequest\022\021\n\tr"
-  "egion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n\004name\030\001 \001"
-  "(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010datatype\030\003 \001(\0162"
-  "\033.greptime.v1.ColumnDataType\022\023\n\013is_nulla"
-  "ble\030\004 \001(\010\022\032\n\022default_constraint\030\005 \001(\014\0220\n"
-  "\rsemantic_type\030\006 \001(\0162\031.greptime.v1.Seman"
-  "ticType2Y\n\006Region\022O\n\006Handle\022!.greptime.v"
-  "1.region.RegionRequest\032\".greptime.v1.reg"
-  "ion.RegionResponseB]\n\025io.greptime.v1.reg"
-  "ionB\006ServerZ<github.com/GreptimeTeam/gre"
-  "ptime-proto/go/greptime/v1/regionb\006proto"
-  "3"
+  "\025greptime/v1/row.proto\"[\n\023RegionRequestH"
+  "eader\022\025\n\010trace_id\030\001 \001(\004H\000\210\001\001\022\024\n\007span_id\030"
+  "\002 \001(\004H\001\210\001\001B\013\n\t_trace_idB\n\n\010_span_id\"\245\004\n\r"
+  "RegionRequest\0227\n\006header\030\001 \001(\0132\'.greptime"
+  ".v1.region.RegionRequestHeader\0225\n\007insert"
+  "s\030\003 \001(\0132\".greptime.v1.region.InsertReque"
+  "stsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v1.reg"
+  "ion.DeleteRequestsH\000\0223\n\006create\030\005 \001(\0132!.g"
+  "reptime.v1.region.CreateRequestH\000\022/\n\004dro"
+  "p\030\006 \001(\0132\037.greptime.v1.region.DropRequest"
+  "H\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.region.Op"
+  "enRequestH\000\0221\n\005close\030\010 \001(\0132 .greptime.v1"
+  ".region.CloseRequestH\000\0221\n\005alter\030\t \001(\0132 ."
+  "greptime.v1.region.AlterRequestH\000\0221\n\005flu"
+  "sh\030\n \001(\0132 .greptime.v1.region.FlushReque"
+  "stH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1.regi"
+  "on.CompactRequestH\000B\006\n\004body\"T\n\016RegionRes"
+  "ponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1.Resp"
+  "onseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E\n\016Ins"
+  "ertRequests\0223\n\010requests\030\001 \003(\0132!.greptime"
+  ".v1.region.InsertRequest\"E\n\016DeleteReques"
+  "ts\0223\n\010requests\030\001 \003(\0132!.greptime.v1.regio"
+  "n.DeleteRequest\"C\n\rInsertRequest\022\021\n\tregi"
+  "on_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1."
+  "Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030\001 \001(\004"
+  "\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"/\n\014Que"
+  "ryRequest\022\021\n\tregion_id\030\001 \001(\004\022\014\n\004plan\030\002 \001"
+  "(\014\"\253\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022"
+  "\016\n\006engine\030\002 \001(\t\0222\n\013column_defs\030\003 \003(\0132\035.g"
+  "reptime.v1.region.ColumnDef\022\023\n\013primary_k"
+  "ey\030\004 \003(\r\022\034\n\024create_if_not_exists\030\005 \001(\010\022\017"
+  "\n\007catalog\030\006 \001(\t\022\016\n\006schema\030\007 \001(\t\022\?\n\007optio"
+  "ns\030\010 \003(\0132..greptime.v1.region.CreateRequ"
+  "est.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030"
+  "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022"
+  "\021\n\tregion_id\030\001 \001(\004\"\300\001\n\013OpenRequest\022\021\n\tre"
+  "gion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\017\n\007catalog"
+  "\030\003 \001(\t\022\016\n\006schema\030\004 \001(\t\022=\n\007options\030\005 \003(\0132"
+  ",.greptime.v1.region.OpenRequest.Options"
+  "Entry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va"
+  "lue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion_"
+  "id\030\001 \001(\004\"!\n\014AlterRequest\022\021\n\tregion_id\030\001 "
+  "\001(\004\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\"#"
+  "\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\t"
+  "ColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001"
+  "(\r\022-\n\010datatype\030\003 \001(\0162\033.greptime.v1.Colum"
+  "nDataType\022\023\n\013is_nullable\030\004 \001(\010\022\032\n\022defaul"
+  "t_constraint\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001("
+  "\0162\031.greptime.v1.SemanticType2Y\n\006Region\022O"
+  "\n\006Handle\022!.greptime.v1.region.RegionRequ"
+  "est\032\".greptime.v1.region.RegionResponseB"
+  "]\n\025io.greptime.v1.regionB\006ServerZ<github"
+  ".com/GreptimeTeam/greptime-proto/go/grep"
+  "time/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[2] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -550,7 +558,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 2161, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 2222, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
     &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 2, 18,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
@@ -571,6 +579,13 @@ namespace region {
 
 class RegionRequestHeader::_Internal {
  public:
+  using HasBits = decltype(std::declval<RegionRequestHeader>()._impl_._has_bits_);
+  static void set_has_trace_id(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_span_id(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
 };
 
 RegionRequestHeader::RegionRequestHeader(::PROTOBUF_NAMESPACE_ID::Arena* arena,
@@ -583,9 +598,10 @@ RegionRequestHeader::RegionRequestHeader(const RegionRequestHeader& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   RegionRequestHeader* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.trace_id_){}
-    , decltype(_impl_.span_id_){}
-    , /*decltype(_impl_._cached_size_)*/{}};
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.trace_id_){}
+    , decltype(_impl_.span_id_){}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   ::memcpy(&_impl_.trace_id_, &from._impl_.trace_id_,
@@ -599,9 +615,10 @@ inline void RegionRequestHeader::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.trace_id_){uint64_t{0u}}
-    , decltype(_impl_.span_id_){uint64_t{0u}}
+      decltype(_impl_._has_bits_){}
     , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.trace_id_){uint64_t{0u}}
+    , decltype(_impl_.span_id_){uint64_t{0u}}
   };
 }
 
@@ -628,29 +645,36 @@ void RegionRequestHeader::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  ::memset(&_impl_.trace_id_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&_impl_.span_id_) -
-      reinterpret_cast<char*>(&_impl_.trace_id_)) + sizeof(_impl_.span_id_));
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    ::memset(&_impl_.trace_id_, 0, static_cast<size_t>(
+        reinterpret_cast<char*>(&_impl_.span_id_) -
+        reinterpret_cast<char*>(&_impl_.trace_id_)) + sizeof(_impl_.span_id_));
+  }
+  _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
 const char* RegionRequestHeader::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // uint64 trace_id = 1;
+      // optional uint64 trace_id = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _Internal::set_has_trace_id(&has_bits);
           _impl_.trace_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // uint64 span_id = 2;
+      // optional uint64 span_id = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _Internal::set_has_span_id(&has_bits);
           _impl_.span_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else
@@ -672,6 +696,7 @@ const char* RegionRequestHeader::_InternalParse(const char* ptr, ::_pbi::ParseCo
     CHK_(ptr != nullptr);
   }  // while
 message_done:
+  _impl_._has_bits_.Or(has_bits);
   return ptr;
 failure:
   ptr = nullptr;
@@ -685,14 +710,14 @@ uint8_t* RegionRequestHeader::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // uint64 trace_id = 1;
-  if (this->_internal_trace_id() != 0) {
+  // optional uint64 trace_id = 1;
+  if (_internal_has_trace_id()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt64ToArray(1, this->_internal_trace_id(), target);
   }
 
-  // uint64 span_id = 2;
-  if (this->_internal_span_id() != 0) {
+  // optional uint64 span_id = 2;
+  if (_internal_has_span_id()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt64ToArray(2, this->_internal_span_id(), target);
   }
@@ -713,16 +738,19 @@ size_t RegionRequestHeader::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // uint64 trace_id = 1;
-  if (this->_internal_trace_id() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_trace_id());
-  }
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional uint64 trace_id = 1;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_trace_id());
+    }
 
-  // uint64 span_id = 2;
-  if (this->_internal_span_id() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_span_id());
-  }
+    // optional uint64 span_id = 2;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_span_id());
+    }
 
+  }
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
@@ -741,11 +769,15 @@ void RegionRequestHeader::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, co
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_trace_id() != 0) {
-    _this->_internal_set_trace_id(from._internal_trace_id());
-  }
-  if (from._internal_span_id() != 0) {
-    _this->_internal_set_span_id(from._internal_span_id());
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_impl_.trace_id_ = from._impl_.trace_id_;
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_impl_.span_id_ = from._impl_.span_id_;
+    }
+    _this->_impl_._has_bits_[0] |= cached_has_bits;
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -764,6 +796,7 @@ bool RegionRequestHeader::IsInitialized() const {
 void RegionRequestHeader::InternalSwap(RegionRequestHeader* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(RegionRequestHeader, _impl_.span_id_)
       + sizeof(RegionRequestHeader::_impl_.span_id_)
@@ -2854,7 +2887,8 @@ CreateRequest::CreateRequest(const CreateRequest& from)
     , /*decltype(_impl_._primary_key_cached_byte_size_)*/{0}
     , /*decltype(_impl_.options_)*/{}
     , decltype(_impl_.engine_){}
-    , decltype(_impl_.region_dir_){}
+    , decltype(_impl_.catalog_){}
+    , decltype(_impl_.schema_){}
     , decltype(_impl_.region_id_){}
     , decltype(_impl_.create_if_not_exists_){}
     , /*decltype(_impl_._cached_size_)*/{}};
@@ -2869,12 +2903,20 @@ CreateRequest::CreateRequest(const CreateRequest& from)
     _this->_impl_.engine_.Set(from._internal_engine(), 
       _this->GetArenaForAllocation());
   }
-  _impl_.region_dir_.InitDefault();
+  _impl_.catalog_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.region_dir_.Set("", GetArenaForAllocation());
+    _impl_.catalog_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_region_dir().empty()) {
-    _this->_impl_.region_dir_.Set(from._internal_region_dir(), 
+  if (!from._internal_catalog().empty()) {
+    _this->_impl_.catalog_.Set(from._internal_catalog(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.schema_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.schema_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_schema().empty()) {
+    _this->_impl_.schema_.Set(from._internal_schema(), 
       _this->GetArenaForAllocation());
   }
   ::memcpy(&_impl_.region_id_, &from._impl_.region_id_,
@@ -2893,7 +2935,8 @@ inline void CreateRequest::SharedCtor(
     , /*decltype(_impl_._primary_key_cached_byte_size_)*/{0}
     , /*decltype(_impl_.options_)*/{::_pbi::ArenaInitialized(), arena}
     , decltype(_impl_.engine_){}
-    , decltype(_impl_.region_dir_){}
+    , decltype(_impl_.catalog_){}
+    , decltype(_impl_.schema_){}
     , decltype(_impl_.region_id_){uint64_t{0u}}
     , decltype(_impl_.create_if_not_exists_){false}
     , /*decltype(_impl_._cached_size_)*/{}
@@ -2902,9 +2945,13 @@ inline void CreateRequest::SharedCtor(
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
     _impl_.engine_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.region_dir_.InitDefault();
+  _impl_.catalog_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.region_dir_.Set("", GetArenaForAllocation());
+    _impl_.catalog_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.schema_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.schema_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
@@ -2925,7 +2972,8 @@ inline void CreateRequest::SharedDtor() {
   _impl_.options_.Destruct();
   _impl_.options_.~MapField();
   _impl_.engine_.Destroy();
-  _impl_.region_dir_.Destroy();
+  _impl_.catalog_.Destroy();
+  _impl_.schema_.Destroy();
 }
 
 void CreateRequest::ArenaDtor(void* object) {
@@ -2946,7 +2994,8 @@ void CreateRequest::Clear() {
   _impl_.primary_key_.Clear();
   _impl_.options_.Clear();
   _impl_.engine_.ClearToEmpty();
-  _impl_.region_dir_.ClearToEmpty();
+  _impl_.catalog_.ClearToEmpty();
+  _impl_.schema_.ClearToEmpty();
   ::memset(&_impl_.region_id_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&_impl_.create_if_not_exists_) -
       reinterpret_cast<char*>(&_impl_.region_id_)) + sizeof(_impl_.create_if_not_exists_));
@@ -3009,26 +3058,36 @@ const char* CreateRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext*
         } else
           goto handle_unusual;
         continue;
-      // string region_dir = 6;
+      // string catalog = 6;
       case 6:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 50)) {
-          auto str = _internal_mutable_region_dir();
+          auto str = _internal_mutable_catalog();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.CreateRequest.region_dir"));
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.CreateRequest.catalog"));
         } else
           goto handle_unusual;
         continue;
-      // map<string, string> options = 7;
+      // string schema = 7;
       case 7:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 58)) {
+          auto str = _internal_mutable_schema();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.CreateRequest.schema"));
+        } else
+          goto handle_unusual;
+        continue;
+      // map<string, string> options = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 66)) {
           ptr -= 1;
           do {
             ptr += 1;
             ptr = ctx->ParseMessage(&_impl_.options_, ptr);
             CHK_(ptr);
             if (!ctx->DataAvailable(ptr)) break;
-          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<58>(ptr));
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<66>(ptr));
         } else
           goto handle_unusual;
         continue;
@@ -3100,17 +3159,27 @@ uint8_t* CreateRequest::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteBoolToArray(5, this->_internal_create_if_not_exists(), target);
   }
 
-  // string region_dir = 6;
-  if (!this->_internal_region_dir().empty()) {
+  // string catalog = 6;
+  if (!this->_internal_catalog().empty()) {
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_region_dir().data(), static_cast<int>(this->_internal_region_dir().length()),
+      this->_internal_catalog().data(), static_cast<int>(this->_internal_catalog().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "greptime.v1.region.CreateRequest.region_dir");
+      "greptime.v1.region.CreateRequest.catalog");
     target = stream->WriteStringMaybeAliased(
-        6, this->_internal_region_dir(), target);
+        6, this->_internal_catalog(), target);
   }
 
-  // map<string, string> options = 7;
+  // string schema = 7;
+  if (!this->_internal_schema().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_schema().data(), static_cast<int>(this->_internal_schema().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.region.CreateRequest.schema");
+    target = stream->WriteStringMaybeAliased(
+        7, this->_internal_schema(), target);
+  }
+
+  // map<string, string> options = 8;
   if (!this->_internal_options().empty()) {
     using MapType = ::_pb::Map<std::string, std::string>;
     using WireHelper = CreateRequest_OptionsEntry_DoNotUse::Funcs;
@@ -3129,12 +3198,12 @@ uint8_t* CreateRequest::_InternalSerialize(
 
     if (stream->IsSerializationDeterministic() && map_field.size() > 1) {
       for (const auto& entry : ::_pbi::MapSorterPtr<MapType>(map_field)) {
-        target = WireHelper::InternalSerialize(7, entry.first, entry.second, target, stream);
+        target = WireHelper::InternalSerialize(8, entry.first, entry.second, target, stream);
         check_utf8(entry);
       }
     } else {
       for (const auto& entry : map_field) {
-        target = WireHelper::InternalSerialize(7, entry.first, entry.second, target, stream);
+        target = WireHelper::InternalSerialize(8, entry.first, entry.second, target, stream);
         check_utf8(entry);
       }
     }
@@ -3177,7 +3246,7 @@ size_t CreateRequest::ByteSizeLong() const {
     total_size += data_size;
   }
 
-  // map<string, string> options = 7;
+  // map<string, string> options = 8;
   total_size += 1 *
       ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_options_size());
   for (::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_iterator
@@ -3193,11 +3262,18 @@ size_t CreateRequest::ByteSizeLong() const {
         this->_internal_engine());
   }
 
-  // string region_dir = 6;
-  if (!this->_internal_region_dir().empty()) {
+  // string catalog = 6;
+  if (!this->_internal_catalog().empty()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_region_dir());
+        this->_internal_catalog());
+  }
+
+  // string schema = 7;
+  if (!this->_internal_schema().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_schema());
   }
 
   // uint64 region_id = 1;
@@ -3234,8 +3310,11 @@ void CreateRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
   if (!from._internal_engine().empty()) {
     _this->_internal_set_engine(from._internal_engine());
   }
-  if (!from._internal_region_dir().empty()) {
-    _this->_internal_set_region_dir(from._internal_region_dir());
+  if (!from._internal_catalog().empty()) {
+    _this->_internal_set_catalog(from._internal_catalog());
+  }
+  if (!from._internal_schema().empty()) {
+    _this->_internal_set_schema(from._internal_schema());
   }
   if (from._internal_region_id() != 0) {
     _this->_internal_set_region_id(from._internal_region_id());
@@ -3270,8 +3349,12 @@ void CreateRequest::InternalSwap(CreateRequest* other) {
       &other->_impl_.engine_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.region_dir_, lhs_arena,
-      &other->_impl_.region_dir_, rhs_arena
+      &_impl_.catalog_, lhs_arena,
+      &other->_impl_.catalog_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.schema_, lhs_arena,
+      &other->_impl_.schema_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(CreateRequest, _impl_.create_if_not_exists_)
@@ -3500,7 +3583,8 @@ OpenRequest::OpenRequest(const OpenRequest& from)
   new (&_impl_) Impl_{
       /*decltype(_impl_.options_)*/{}
     , decltype(_impl_.engine_){}
-    , decltype(_impl_.region_dir_){}
+    , decltype(_impl_.catalog_){}
+    , decltype(_impl_.schema_){}
     , decltype(_impl_.region_id_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
@@ -3514,12 +3598,20 @@ OpenRequest::OpenRequest(const OpenRequest& from)
     _this->_impl_.engine_.Set(from._internal_engine(), 
       _this->GetArenaForAllocation());
   }
-  _impl_.region_dir_.InitDefault();
+  _impl_.catalog_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.region_dir_.Set("", GetArenaForAllocation());
+    _impl_.catalog_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_region_dir().empty()) {
-    _this->_impl_.region_dir_.Set(from._internal_region_dir(), 
+  if (!from._internal_catalog().empty()) {
+    _this->_impl_.catalog_.Set(from._internal_catalog(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.schema_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.schema_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_schema().empty()) {
+    _this->_impl_.schema_.Set(from._internal_schema(), 
       _this->GetArenaForAllocation());
   }
   _this->_impl_.region_id_ = from._impl_.region_id_;
@@ -3533,7 +3625,8 @@ inline void OpenRequest::SharedCtor(
   new (&_impl_) Impl_{
       /*decltype(_impl_.options_)*/{::_pbi::ArenaInitialized(), arena}
     , decltype(_impl_.engine_){}
-    , decltype(_impl_.region_dir_){}
+    , decltype(_impl_.catalog_){}
+    , decltype(_impl_.schema_){}
     , decltype(_impl_.region_id_){uint64_t{0u}}
     , /*decltype(_impl_._cached_size_)*/{}
   };
@@ -3541,9 +3634,13 @@ inline void OpenRequest::SharedCtor(
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
     _impl_.engine_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.region_dir_.InitDefault();
+  _impl_.catalog_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.region_dir_.Set("", GetArenaForAllocation());
+    _impl_.catalog_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.schema_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.schema_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
@@ -3562,7 +3659,8 @@ inline void OpenRequest::SharedDtor() {
   _impl_.options_.Destruct();
   _impl_.options_.~MapField();
   _impl_.engine_.Destroy();
-  _impl_.region_dir_.Destroy();
+  _impl_.catalog_.Destroy();
+  _impl_.schema_.Destroy();
 }
 
 void OpenRequest::ArenaDtor(void* object) {
@@ -3581,7 +3679,8 @@ void OpenRequest::Clear() {
 
   _impl_.options_.Clear();
   _impl_.engine_.ClearToEmpty();
-  _impl_.region_dir_.ClearToEmpty();
+  _impl_.catalog_.ClearToEmpty();
+  _impl_.schema_.ClearToEmpty();
   _impl_.region_id_ = uint64_t{0u};
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
@@ -3610,26 +3709,36 @@ const char* OpenRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* c
         } else
           goto handle_unusual;
         continue;
-      // string region_dir = 3;
+      // string catalog = 3;
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
-          auto str = _internal_mutable_region_dir();
+          auto str = _internal_mutable_catalog();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.OpenRequest.region_dir"));
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.OpenRequest.catalog"));
         } else
           goto handle_unusual;
         continue;
-      // map<string, string> options = 4;
+      // string schema = 4;
       case 4:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
+          auto str = _internal_mutable_schema();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.OpenRequest.schema"));
+        } else
+          goto handle_unusual;
+        continue;
+      // map<string, string> options = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 42)) {
           ptr -= 1;
           do {
             ptr += 1;
             ptr = ctx->ParseMessage(&_impl_.options_, ptr);
             CHK_(ptr);
             if (!ctx->DataAvailable(ptr)) break;
-          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<34>(ptr));
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<42>(ptr));
         } else
           goto handle_unusual;
         continue;
@@ -3678,17 +3787,27 @@ uint8_t* OpenRequest::_InternalSerialize(
         2, this->_internal_engine(), target);
   }
 
-  // string region_dir = 3;
-  if (!this->_internal_region_dir().empty()) {
+  // string catalog = 3;
+  if (!this->_internal_catalog().empty()) {
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_region_dir().data(), static_cast<int>(this->_internal_region_dir().length()),
+      this->_internal_catalog().data(), static_cast<int>(this->_internal_catalog().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "greptime.v1.region.OpenRequest.region_dir");
+      "greptime.v1.region.OpenRequest.catalog");
     target = stream->WriteStringMaybeAliased(
-        3, this->_internal_region_dir(), target);
+        3, this->_internal_catalog(), target);
   }
 
-  // map<string, string> options = 4;
+  // string schema = 4;
+  if (!this->_internal_schema().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_schema().data(), static_cast<int>(this->_internal_schema().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.region.OpenRequest.schema");
+    target = stream->WriteStringMaybeAliased(
+        4, this->_internal_schema(), target);
+  }
+
+  // map<string, string> options = 5;
   if (!this->_internal_options().empty()) {
     using MapType = ::_pb::Map<std::string, std::string>;
     using WireHelper = OpenRequest_OptionsEntry_DoNotUse::Funcs;
@@ -3707,12 +3826,12 @@ uint8_t* OpenRequest::_InternalSerialize(
 
     if (stream->IsSerializationDeterministic() && map_field.size() > 1) {
       for (const auto& entry : ::_pbi::MapSorterPtr<MapType>(map_field)) {
-        target = WireHelper::InternalSerialize(4, entry.first, entry.second, target, stream);
+        target = WireHelper::InternalSerialize(5, entry.first, entry.second, target, stream);
         check_utf8(entry);
       }
     } else {
       for (const auto& entry : map_field) {
-        target = WireHelper::InternalSerialize(4, entry.first, entry.second, target, stream);
+        target = WireHelper::InternalSerialize(5, entry.first, entry.second, target, stream);
         check_utf8(entry);
       }
     }
@@ -3734,7 +3853,7 @@ size_t OpenRequest::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // map<string, string> options = 4;
+  // map<string, string> options = 5;
   total_size += 1 *
       ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_options_size());
   for (::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_iterator
@@ -3750,11 +3869,18 @@ size_t OpenRequest::ByteSizeLong() const {
         this->_internal_engine());
   }
 
-  // string region_dir = 3;
-  if (!this->_internal_region_dir().empty()) {
+  // string catalog = 3;
+  if (!this->_internal_catalog().empty()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_region_dir());
+        this->_internal_catalog());
+  }
+
+  // string schema = 4;
+  if (!this->_internal_schema().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_schema());
   }
 
   // uint64 region_id = 1;
@@ -3784,8 +3910,11 @@ void OpenRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PR
   if (!from._internal_engine().empty()) {
     _this->_internal_set_engine(from._internal_engine());
   }
-  if (!from._internal_region_dir().empty()) {
-    _this->_internal_set_region_dir(from._internal_region_dir());
+  if (!from._internal_catalog().empty()) {
+    _this->_internal_set_catalog(from._internal_catalog());
+  }
+  if (!from._internal_schema().empty()) {
+    _this->_internal_set_schema(from._internal_schema());
   }
   if (from._internal_region_id() != 0) {
     _this->_internal_set_region_id(from._internal_region_id());
@@ -3815,8 +3944,12 @@ void OpenRequest::InternalSwap(OpenRequest* other) {
       &other->_impl_.engine_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.region_dir_, lhs_arena,
-      &other->_impl_.region_dir_, rhs_arena
+      &_impl_.catalog_, lhs_arena,
+      &other->_impl_.catalog_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.schema_, lhs_arena,
+      &other->_impl_.schema_, rhs_arena
   );
   swap(_impl_.region_id_, other->_impl_.region_id_);
 }

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -259,7 +259,11 @@ class RegionRequestHeader final :
     kTraceIdFieldNumber = 1,
     kSpanIdFieldNumber = 2,
   };
-  // uint64 trace_id = 1;
+  // optional uint64 trace_id = 1;
+  bool has_trace_id() const;
+  private:
+  bool _internal_has_trace_id() const;
+  public:
   void clear_trace_id();
   uint64_t trace_id() const;
   void set_trace_id(uint64_t value);
@@ -268,7 +272,11 @@ class RegionRequestHeader final :
   void _internal_set_trace_id(uint64_t value);
   public:
 
-  // uint64 span_id = 2;
+  // optional uint64 span_id = 2;
+  bool has_span_id() const;
+  private:
+  bool _internal_has_span_id() const;
+  public:
   void clear_span_id();
   uint64_t span_id() const;
   void set_span_id(uint64_t value);
@@ -285,9 +293,10 @@ class RegionRequestHeader final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     uint64_t trace_id_;
     uint64_t span_id_;
-    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_greptime_2fv1_2fregion_2fserver_2eproto;
@@ -1800,9 +1809,10 @@ class CreateRequest final :
   enum : int {
     kColumnDefsFieldNumber = 3,
     kPrimaryKeyFieldNumber = 4,
-    kOptionsFieldNumber = 7,
+    kOptionsFieldNumber = 8,
     kEngineFieldNumber = 2,
-    kRegionDirFieldNumber = 6,
+    kCatalogFieldNumber = 6,
+    kSchemaFieldNumber = 7,
     kRegionIdFieldNumber = 1,
     kCreateIfNotExistsFieldNumber = 5,
   };
@@ -1846,7 +1856,7 @@ class CreateRequest final :
   ::PROTOBUF_NAMESPACE_ID::RepeatedField< uint32_t >*
       mutable_primary_key();
 
-  // map<string, string> options = 7;
+  // map<string, string> options = 8;
   int options_size() const;
   private:
   int _internal_options_size() const;
@@ -1877,18 +1887,32 @@ class CreateRequest final :
   std::string* _internal_mutable_engine();
   public:
 
-  // string region_dir = 6;
-  void clear_region_dir();
-  const std::string& region_dir() const;
+  // string catalog = 6;
+  void clear_catalog();
+  const std::string& catalog() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_region_dir(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_region_dir();
-  PROTOBUF_NODISCARD std::string* release_region_dir();
-  void set_allocated_region_dir(std::string* region_dir);
+  void set_catalog(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_catalog();
+  PROTOBUF_NODISCARD std::string* release_catalog();
+  void set_allocated_catalog(std::string* catalog);
   private:
-  const std::string& _internal_region_dir() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_region_dir(const std::string& value);
-  std::string* _internal_mutable_region_dir();
+  const std::string& _internal_catalog() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_catalog(const std::string& value);
+  std::string* _internal_mutable_catalog();
+  public:
+
+  // string schema = 7;
+  void clear_schema();
+  const std::string& schema() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_schema(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_schema();
+  PROTOBUF_NODISCARD std::string* release_schema();
+  void set_allocated_schema(std::string* schema);
+  private:
+  const std::string& _internal_schema() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_schema(const std::string& value);
+  std::string* _internal_mutable_schema();
   public:
 
   // uint64 region_id = 1;
@@ -1926,7 +1950,8 @@ class CreateRequest final :
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING> options_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr engine_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr region_dir_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr catalog_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr schema_;
     uint64_t region_id_;
     bool create_if_not_exists_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
@@ -2236,12 +2261,13 @@ class OpenRequest final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kOptionsFieldNumber = 4,
+    kOptionsFieldNumber = 5,
     kEngineFieldNumber = 2,
-    kRegionDirFieldNumber = 3,
+    kCatalogFieldNumber = 3,
+    kSchemaFieldNumber = 4,
     kRegionIdFieldNumber = 1,
   };
-  // map<string, string> options = 4;
+  // map<string, string> options = 5;
   int options_size() const;
   private:
   int _internal_options_size() const;
@@ -2272,18 +2298,32 @@ class OpenRequest final :
   std::string* _internal_mutable_engine();
   public:
 
-  // string region_dir = 3;
-  void clear_region_dir();
-  const std::string& region_dir() const;
+  // string catalog = 3;
+  void clear_catalog();
+  const std::string& catalog() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_region_dir(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_region_dir();
-  PROTOBUF_NODISCARD std::string* release_region_dir();
-  void set_allocated_region_dir(std::string* region_dir);
+  void set_catalog(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_catalog();
+  PROTOBUF_NODISCARD std::string* release_catalog();
+  void set_allocated_catalog(std::string* catalog);
   private:
-  const std::string& _internal_region_dir() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_region_dir(const std::string& value);
-  std::string* _internal_mutable_region_dir();
+  const std::string& _internal_catalog() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_catalog(const std::string& value);
+  std::string* _internal_mutable_catalog();
+  public:
+
+  // string schema = 4;
+  void clear_schema();
+  const std::string& schema() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_schema(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_schema();
+  PROTOBUF_NODISCARD std::string* release_schema();
+  void set_allocated_schema(std::string* schema);
+  private:
+  const std::string& _internal_schema() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_schema(const std::string& value);
+  std::string* _internal_mutable_schema();
   public:
 
   // uint64 region_id = 1;
@@ -2309,7 +2349,8 @@ class OpenRequest final :
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING> options_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr engine_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr region_dir_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr catalog_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr schema_;
     uint64_t region_id_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
@@ -3132,9 +3173,17 @@ class ColumnDef final :
 #endif  // __GNUC__
 // RegionRequestHeader
 
-// uint64 trace_id = 1;
+// optional uint64 trace_id = 1;
+inline bool RegionRequestHeader::_internal_has_trace_id() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool RegionRequestHeader::has_trace_id() const {
+  return _internal_has_trace_id();
+}
 inline void RegionRequestHeader::clear_trace_id() {
   _impl_.trace_id_ = uint64_t{0u};
+  _impl_._has_bits_[0] &= ~0x00000001u;
 }
 inline uint64_t RegionRequestHeader::_internal_trace_id() const {
   return _impl_.trace_id_;
@@ -3144,7 +3193,7 @@ inline uint64_t RegionRequestHeader::trace_id() const {
   return _internal_trace_id();
 }
 inline void RegionRequestHeader::_internal_set_trace_id(uint64_t value) {
-  
+  _impl_._has_bits_[0] |= 0x00000001u;
   _impl_.trace_id_ = value;
 }
 inline void RegionRequestHeader::set_trace_id(uint64_t value) {
@@ -3152,9 +3201,17 @@ inline void RegionRequestHeader::set_trace_id(uint64_t value) {
   // @@protoc_insertion_point(field_set:greptime.v1.region.RegionRequestHeader.trace_id)
 }
 
-// uint64 span_id = 2;
+// optional uint64 span_id = 2;
+inline bool RegionRequestHeader::_internal_has_span_id() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool RegionRequestHeader::has_span_id() const {
+  return _internal_has_span_id();
+}
 inline void RegionRequestHeader::clear_span_id() {
   _impl_.span_id_ = uint64_t{0u};
+  _impl_._has_bits_[0] &= ~0x00000002u;
 }
 inline uint64_t RegionRequestHeader::_internal_span_id() const {
   return _impl_.span_id_;
@@ -3164,7 +3221,7 @@ inline uint64_t RegionRequestHeader::span_id() const {
   return _internal_span_id();
 }
 inline void RegionRequestHeader::_internal_set_span_id(uint64_t value) {
-  
+  _impl_._has_bits_[0] |= 0x00000002u;
   _impl_.span_id_ = value;
 }
 inline void RegionRequestHeader::set_span_id(uint64_t value) {
@@ -4613,57 +4670,107 @@ inline void CreateRequest::set_create_if_not_exists(bool value) {
   // @@protoc_insertion_point(field_set:greptime.v1.region.CreateRequest.create_if_not_exists)
 }
 
-// string region_dir = 6;
-inline void CreateRequest::clear_region_dir() {
-  _impl_.region_dir_.ClearToEmpty();
+// string catalog = 6;
+inline void CreateRequest::clear_catalog() {
+  _impl_.catalog_.ClearToEmpty();
 }
-inline const std::string& CreateRequest::region_dir() const {
-  // @@protoc_insertion_point(field_get:greptime.v1.region.CreateRequest.region_dir)
-  return _internal_region_dir();
+inline const std::string& CreateRequest::catalog() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.CreateRequest.catalog)
+  return _internal_catalog();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void CreateRequest::set_region_dir(ArgT0&& arg0, ArgT... args) {
+void CreateRequest::set_catalog(ArgT0&& arg0, ArgT... args) {
  
- _impl_.region_dir_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:greptime.v1.region.CreateRequest.region_dir)
+ _impl_.catalog_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.CreateRequest.catalog)
 }
-inline std::string* CreateRequest::mutable_region_dir() {
-  std::string* _s = _internal_mutable_region_dir();
-  // @@protoc_insertion_point(field_mutable:greptime.v1.region.CreateRequest.region_dir)
+inline std::string* CreateRequest::mutable_catalog() {
+  std::string* _s = _internal_mutable_catalog();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.CreateRequest.catalog)
   return _s;
 }
-inline const std::string& CreateRequest::_internal_region_dir() const {
-  return _impl_.region_dir_.Get();
+inline const std::string& CreateRequest::_internal_catalog() const {
+  return _impl_.catalog_.Get();
 }
-inline void CreateRequest::_internal_set_region_dir(const std::string& value) {
+inline void CreateRequest::_internal_set_catalog(const std::string& value) {
   
-  _impl_.region_dir_.Set(value, GetArenaForAllocation());
+  _impl_.catalog_.Set(value, GetArenaForAllocation());
 }
-inline std::string* CreateRequest::_internal_mutable_region_dir() {
+inline std::string* CreateRequest::_internal_mutable_catalog() {
   
-  return _impl_.region_dir_.Mutable(GetArenaForAllocation());
+  return _impl_.catalog_.Mutable(GetArenaForAllocation());
 }
-inline std::string* CreateRequest::release_region_dir() {
-  // @@protoc_insertion_point(field_release:greptime.v1.region.CreateRequest.region_dir)
-  return _impl_.region_dir_.Release();
+inline std::string* CreateRequest::release_catalog() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.CreateRequest.catalog)
+  return _impl_.catalog_.Release();
 }
-inline void CreateRequest::set_allocated_region_dir(std::string* region_dir) {
-  if (region_dir != nullptr) {
+inline void CreateRequest::set_allocated_catalog(std::string* catalog) {
+  if (catalog != nullptr) {
     
   } else {
     
   }
-  _impl_.region_dir_.SetAllocated(region_dir, GetArenaForAllocation());
+  _impl_.catalog_.SetAllocated(catalog, GetArenaForAllocation());
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.region_dir_.IsDefault()) {
-    _impl_.region_dir_.Set("", GetArenaForAllocation());
+  if (_impl_.catalog_.IsDefault()) {
+    _impl_.catalog_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.CreateRequest.region_dir)
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.CreateRequest.catalog)
 }
 
-// map<string, string> options = 7;
+// string schema = 7;
+inline void CreateRequest::clear_schema() {
+  _impl_.schema_.ClearToEmpty();
+}
+inline const std::string& CreateRequest::schema() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.CreateRequest.schema)
+  return _internal_schema();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void CreateRequest::set_schema(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.schema_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.CreateRequest.schema)
+}
+inline std::string* CreateRequest::mutable_schema() {
+  std::string* _s = _internal_mutable_schema();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.CreateRequest.schema)
+  return _s;
+}
+inline const std::string& CreateRequest::_internal_schema() const {
+  return _impl_.schema_.Get();
+}
+inline void CreateRequest::_internal_set_schema(const std::string& value) {
+  
+  _impl_.schema_.Set(value, GetArenaForAllocation());
+}
+inline std::string* CreateRequest::_internal_mutable_schema() {
+  
+  return _impl_.schema_.Mutable(GetArenaForAllocation());
+}
+inline std::string* CreateRequest::release_schema() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.CreateRequest.schema)
+  return _impl_.schema_.Release();
+}
+inline void CreateRequest::set_allocated_schema(std::string* schema) {
+  if (schema != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.schema_.SetAllocated(schema, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.schema_.IsDefault()) {
+    _impl_.schema_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.CreateRequest.schema)
+}
+
+// map<string, string> options = 8;
 inline int CreateRequest::_internal_options_size() const {
   return _impl_.options_.size();
 }
@@ -4792,57 +4899,107 @@ inline void OpenRequest::set_allocated_engine(std::string* engine) {
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.OpenRequest.engine)
 }
 
-// string region_dir = 3;
-inline void OpenRequest::clear_region_dir() {
-  _impl_.region_dir_.ClearToEmpty();
+// string catalog = 3;
+inline void OpenRequest::clear_catalog() {
+  _impl_.catalog_.ClearToEmpty();
 }
-inline const std::string& OpenRequest::region_dir() const {
-  // @@protoc_insertion_point(field_get:greptime.v1.region.OpenRequest.region_dir)
-  return _internal_region_dir();
+inline const std::string& OpenRequest::catalog() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.OpenRequest.catalog)
+  return _internal_catalog();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void OpenRequest::set_region_dir(ArgT0&& arg0, ArgT... args) {
+void OpenRequest::set_catalog(ArgT0&& arg0, ArgT... args) {
  
- _impl_.region_dir_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:greptime.v1.region.OpenRequest.region_dir)
+ _impl_.catalog_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.OpenRequest.catalog)
 }
-inline std::string* OpenRequest::mutable_region_dir() {
-  std::string* _s = _internal_mutable_region_dir();
-  // @@protoc_insertion_point(field_mutable:greptime.v1.region.OpenRequest.region_dir)
+inline std::string* OpenRequest::mutable_catalog() {
+  std::string* _s = _internal_mutable_catalog();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.OpenRequest.catalog)
   return _s;
 }
-inline const std::string& OpenRequest::_internal_region_dir() const {
-  return _impl_.region_dir_.Get();
+inline const std::string& OpenRequest::_internal_catalog() const {
+  return _impl_.catalog_.Get();
 }
-inline void OpenRequest::_internal_set_region_dir(const std::string& value) {
+inline void OpenRequest::_internal_set_catalog(const std::string& value) {
   
-  _impl_.region_dir_.Set(value, GetArenaForAllocation());
+  _impl_.catalog_.Set(value, GetArenaForAllocation());
 }
-inline std::string* OpenRequest::_internal_mutable_region_dir() {
+inline std::string* OpenRequest::_internal_mutable_catalog() {
   
-  return _impl_.region_dir_.Mutable(GetArenaForAllocation());
+  return _impl_.catalog_.Mutable(GetArenaForAllocation());
 }
-inline std::string* OpenRequest::release_region_dir() {
-  // @@protoc_insertion_point(field_release:greptime.v1.region.OpenRequest.region_dir)
-  return _impl_.region_dir_.Release();
+inline std::string* OpenRequest::release_catalog() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.OpenRequest.catalog)
+  return _impl_.catalog_.Release();
 }
-inline void OpenRequest::set_allocated_region_dir(std::string* region_dir) {
-  if (region_dir != nullptr) {
+inline void OpenRequest::set_allocated_catalog(std::string* catalog) {
+  if (catalog != nullptr) {
     
   } else {
     
   }
-  _impl_.region_dir_.SetAllocated(region_dir, GetArenaForAllocation());
+  _impl_.catalog_.SetAllocated(catalog, GetArenaForAllocation());
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.region_dir_.IsDefault()) {
-    _impl_.region_dir_.Set("", GetArenaForAllocation());
+  if (_impl_.catalog_.IsDefault()) {
+    _impl_.catalog_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.OpenRequest.region_dir)
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.OpenRequest.catalog)
 }
 
-// map<string, string> options = 4;
+// string schema = 4;
+inline void OpenRequest::clear_schema() {
+  _impl_.schema_.ClearToEmpty();
+}
+inline const std::string& OpenRequest::schema() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.OpenRequest.schema)
+  return _internal_schema();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void OpenRequest::set_schema(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.schema_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.OpenRequest.schema)
+}
+inline std::string* OpenRequest::mutable_schema() {
+  std::string* _s = _internal_mutable_schema();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.OpenRequest.schema)
+  return _s;
+}
+inline const std::string& OpenRequest::_internal_schema() const {
+  return _impl_.schema_.Get();
+}
+inline void OpenRequest::_internal_set_schema(const std::string& value) {
+  
+  _impl_.schema_.Set(value, GetArenaForAllocation());
+}
+inline std::string* OpenRequest::_internal_mutable_schema() {
+  
+  return _impl_.schema_.Mutable(GetArenaForAllocation());
+}
+inline std::string* OpenRequest::release_schema() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.OpenRequest.schema)
+  return _impl_.schema_.Release();
+}
+inline void OpenRequest::set_allocated_schema(std::string* schema) {
+  if (schema != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.schema_.SetAllocated(schema, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.schema_.IsDefault()) {
+    _impl_.schema_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.OpenRequest.schema)
+}
+
+// map<string, string> options = 5;
 inline int OpenRequest::_internal_options_size() const {
   return _impl_.options_.size();
 }

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -23,7 +23,16 @@ public final class Server {
      * TraceID of request
      * </pre>
      *
-     * <code>uint64 trace_id = 1;</code>
+     * <code>optional uint64 trace_id = 1;</code>
+     * @return Whether the traceId field is set.
+     */
+    boolean hasTraceId();
+    /**
+     * <pre>
+     * TraceID of request
+     * </pre>
+     *
+     * <code>optional uint64 trace_id = 1;</code>
      * @return The traceId.
      */
     long getTraceId();
@@ -33,7 +42,16 @@ public final class Server {
      * SpanID of request
      * </pre>
      *
-     * <code>uint64 span_id = 2;</code>
+     * <code>optional uint64 span_id = 2;</code>
+     * @return Whether the spanId field is set.
+     */
+    boolean hasSpanId();
+    /**
+     * <pre>
+     * SpanID of request
+     * </pre>
+     *
+     * <code>optional uint64 span_id = 2;</code>
      * @return The spanId.
      */
     long getSpanId();
@@ -73,6 +91,7 @@ public final class Server {
       if (extensionRegistry == null) {
         throw new java.lang.NullPointerException();
       }
+      int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -84,12 +103,12 @@ public final class Server {
               done = true;
               break;
             case 8: {
-
+              bitField0_ |= 0x00000001;
               traceId_ = input.readUInt64();
               break;
             }
             case 16: {
-
+              bitField0_ |= 0x00000002;
               spanId_ = input.readUInt64();
               break;
             }
@@ -127,6 +146,7 @@ public final class Server {
               io.greptime.v1.region.Server.RegionRequestHeader.class, io.greptime.v1.region.Server.RegionRequestHeader.Builder.class);
     }
 
+    private int bitField0_;
     public static final int TRACE_ID_FIELD_NUMBER = 1;
     private long traceId_;
     /**
@@ -134,7 +154,19 @@ public final class Server {
      * TraceID of request
      * </pre>
      *
-     * <code>uint64 trace_id = 1;</code>
+     * <code>optional uint64 trace_id = 1;</code>
+     * @return Whether the traceId field is set.
+     */
+    @java.lang.Override
+    public boolean hasTraceId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * TraceID of request
+     * </pre>
+     *
+     * <code>optional uint64 trace_id = 1;</code>
      * @return The traceId.
      */
     @java.lang.Override
@@ -149,7 +181,19 @@ public final class Server {
      * SpanID of request
      * </pre>
      *
-     * <code>uint64 span_id = 2;</code>
+     * <code>optional uint64 span_id = 2;</code>
+     * @return Whether the spanId field is set.
+     */
+    @java.lang.Override
+    public boolean hasSpanId() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * SpanID of request
+     * </pre>
+     *
+     * <code>optional uint64 span_id = 2;</code>
      * @return The spanId.
      */
     @java.lang.Override
@@ -171,10 +215,10 @@ public final class Server {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (traceId_ != 0L) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeUInt64(1, traceId_);
       }
-      if (spanId_ != 0L) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, spanId_);
       }
       unknownFields.writeTo(output);
@@ -186,11 +230,11 @@ public final class Server {
       if (size != -1) return size;
 
       size = 0;
-      if (traceId_ != 0L) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(1, traceId_);
       }
-      if (spanId_ != 0L) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, spanId_);
       }
@@ -209,10 +253,16 @@ public final class Server {
       }
       io.greptime.v1.region.Server.RegionRequestHeader other = (io.greptime.v1.region.Server.RegionRequestHeader) obj;
 
-      if (getTraceId()
-          != other.getTraceId()) return false;
-      if (getSpanId()
-          != other.getSpanId()) return false;
+      if (hasTraceId() != other.hasTraceId()) return false;
+      if (hasTraceId()) {
+        if (getTraceId()
+            != other.getTraceId()) return false;
+      }
+      if (hasSpanId() != other.hasSpanId()) return false;
+      if (hasSpanId()) {
+        if (getSpanId()
+            != other.getSpanId()) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -224,12 +274,16 @@ public final class Server {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + TRACE_ID_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getTraceId());
-      hash = (37 * hash) + SPAN_ID_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getSpanId());
+      if (hasTraceId()) {
+        hash = (37 * hash) + TRACE_ID_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getTraceId());
+      }
+      if (hasSpanId()) {
+        hash = (37 * hash) + SPAN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getSpanId());
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -364,9 +418,9 @@ public final class Server {
       public Builder clear() {
         super.clear();
         traceId_ = 0L;
-
+        bitField0_ = (bitField0_ & ~0x00000001);
         spanId_ = 0L;
-
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -393,8 +447,17 @@ public final class Server {
       @java.lang.Override
       public io.greptime.v1.region.Server.RegionRequestHeader buildPartial() {
         io.greptime.v1.region.Server.RegionRequestHeader result = new io.greptime.v1.region.Server.RegionRequestHeader(this);
-        result.traceId_ = traceId_;
-        result.spanId_ = spanId_;
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.traceId_ = traceId_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.spanId_ = spanId_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -443,10 +506,10 @@ public final class Server {
 
       public Builder mergeFrom(io.greptime.v1.region.Server.RegionRequestHeader other) {
         if (other == io.greptime.v1.region.Server.RegionRequestHeader.getDefaultInstance()) return this;
-        if (other.getTraceId() != 0L) {
+        if (other.hasTraceId()) {
           setTraceId(other.getTraceId());
         }
-        if (other.getSpanId() != 0L) {
+        if (other.hasSpanId()) {
           setSpanId(other.getSpanId());
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -477,6 +540,7 @@ public final class Server {
         }
         return this;
       }
+      private int bitField0_;
 
       private long traceId_ ;
       /**
@@ -484,7 +548,19 @@ public final class Server {
        * TraceID of request
        * </pre>
        *
-       * <code>uint64 trace_id = 1;</code>
+       * <code>optional uint64 trace_id = 1;</code>
+       * @return Whether the traceId field is set.
+       */
+      @java.lang.Override
+      public boolean hasTraceId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * TraceID of request
+       * </pre>
+       *
+       * <code>optional uint64 trace_id = 1;</code>
        * @return The traceId.
        */
       @java.lang.Override
@@ -496,12 +572,12 @@ public final class Server {
        * TraceID of request
        * </pre>
        *
-       * <code>uint64 trace_id = 1;</code>
+       * <code>optional uint64 trace_id = 1;</code>
        * @param value The traceId to set.
        * @return This builder for chaining.
        */
       public Builder setTraceId(long value) {
-        
+        bitField0_ |= 0x00000001;
         traceId_ = value;
         onChanged();
         return this;
@@ -511,11 +587,11 @@ public final class Server {
        * TraceID of request
        * </pre>
        *
-       * <code>uint64 trace_id = 1;</code>
+       * <code>optional uint64 trace_id = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearTraceId() {
-        
+        bitField0_ = (bitField0_ & ~0x00000001);
         traceId_ = 0L;
         onChanged();
         return this;
@@ -527,7 +603,19 @@ public final class Server {
        * SpanID of request
        * </pre>
        *
-       * <code>uint64 span_id = 2;</code>
+       * <code>optional uint64 span_id = 2;</code>
+       * @return Whether the spanId field is set.
+       */
+      @java.lang.Override
+      public boolean hasSpanId() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * SpanID of request
+       * </pre>
+       *
+       * <code>optional uint64 span_id = 2;</code>
        * @return The spanId.
        */
       @java.lang.Override
@@ -539,12 +627,12 @@ public final class Server {
        * SpanID of request
        * </pre>
        *
-       * <code>uint64 span_id = 2;</code>
+       * <code>optional uint64 span_id = 2;</code>
        * @param value The spanId to set.
        * @return This builder for chaining.
        */
       public Builder setSpanId(long value) {
-        
+        bitField0_ |= 0x00000002;
         spanId_ = value;
         onChanged();
         return this;
@@ -554,11 +642,11 @@ public final class Server {
        * SpanID of request
        * </pre>
        *
-       * <code>uint64 span_id = 2;</code>
+       * <code>optional uint64 span_id = 2;</code>
        * @return This builder for chaining.
        */
       public Builder clearSpanId() {
-        
+        bitField0_ = (bitField0_ & ~0x00000002);
         spanId_ = 0L;
         onChanged();
         return this;
@@ -7713,7 +7801,7 @@ public final class Server {
 
     /**
      * <pre>
-     * Id of columns in the primary key.
+     * Columns in the primary key.
      * </pre>
      *
      * <code>repeated uint32 primary_key = 4;</code>
@@ -7722,7 +7810,7 @@ public final class Server {
     java.util.List<java.lang.Integer> getPrimaryKeyList();
     /**
      * <pre>
-     * Id of columns in the primary key.
+     * Columns in the primary key.
      * </pre>
      *
      * <code>repeated uint32 primary_key = 4;</code>
@@ -7731,7 +7819,7 @@ public final class Server {
     int getPrimaryKeyCount();
     /**
      * <pre>
-     * Id of columns in the primary key.
+     * Columns in the primary key.
      * </pre>
      *
      * <code>repeated uint32 primary_key = 4;</code>
@@ -7752,32 +7840,52 @@ public final class Server {
 
     /**
      * <pre>
-     * Directory for region's data home. Usually is composed by catalog and table
-     * id
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 6;</code>
-     * @return The regionDir.
+     * <code>string catalog = 6;</code>
+     * @return The catalog.
      */
-    java.lang.String getRegionDir();
+    java.lang.String getCatalog();
     /**
      * <pre>
-     * Directory for region's data home. Usually is composed by catalog and table
-     * id
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 6;</code>
-     * @return The bytes for regionDir.
+     * <code>string catalog = 6;</code>
+     * @return The bytes for catalog.
      */
     com.google.protobuf.ByteString
-        getRegionDirBytes();
+        getCatalogBytes();
+
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 7;</code>
+     * @return The schema.
+     */
+    java.lang.String getSchema();
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 7;</code>
+     * @return The bytes for schema.
+     */
+    com.google.protobuf.ByteString
+        getSchemaBytes();
 
     /**
      * <pre>
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
     int getOptionsCount();
     /**
@@ -7785,7 +7893,7 @@ public final class Server {
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
     boolean containsOptions(
         java.lang.String key);
@@ -7800,7 +7908,7 @@ public final class Server {
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
     java.util.Map<java.lang.String, java.lang.String>
     getOptionsMap();
@@ -7809,7 +7917,7 @@ public final class Server {
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
 
     /* nullable */
@@ -7822,7 +7930,7 @@ java.lang.String defaultValue);
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
 
     java.lang.String getOptionsOrThrow(
@@ -7844,7 +7952,8 @@ java.lang.String defaultValue);
       engine_ = "";
       columnDefs_ = java.util.Collections.emptyList();
       primaryKey_ = emptyIntList();
-      regionDir_ = "";
+      catalog_ = "";
+      schema_ = "";
     }
 
     @java.lang.Override
@@ -7927,10 +8036,16 @@ java.lang.String defaultValue);
             case 50: {
               java.lang.String s = input.readStringRequireUtf8();
 
-              regionDir_ = s;
+              catalog_ = s;
               break;
             }
             case 58: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              schema_ = s;
+              break;
+            }
+            case 66: {
               if (!((mutable_bitField0_ & 0x00000004) != 0)) {
                 options_ = com.google.protobuf.MapField.newMapField(
                     OptionsDefaultEntryHolder.defaultEntry);
@@ -7980,7 +8095,7 @@ java.lang.String defaultValue);
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
-        case 7:
+        case 8:
           return internalGetOptions();
         default:
           throw new RuntimeException(
@@ -8116,7 +8231,7 @@ java.lang.String defaultValue);
     private com.google.protobuf.Internal.IntList primaryKey_;
     /**
      * <pre>
-     * Id of columns in the primary key.
+     * Columns in the primary key.
      * </pre>
      *
      * <code>repeated uint32 primary_key = 4;</code>
@@ -8129,7 +8244,7 @@ java.lang.String defaultValue);
     }
     /**
      * <pre>
-     * Id of columns in the primary key.
+     * Columns in the primary key.
      * </pre>
      *
      * <code>repeated uint32 primary_key = 4;</code>
@@ -8140,7 +8255,7 @@ java.lang.String defaultValue);
     }
     /**
      * <pre>
-     * Id of columns in the primary key.
+     * Columns in the primary key.
      * </pre>
      *
      * <code>repeated uint32 primary_key = 4;</code>
@@ -8167,55 +8282,101 @@ java.lang.String defaultValue);
       return createIfNotExists_;
     }
 
-    public static final int REGION_DIR_FIELD_NUMBER = 6;
-    private volatile java.lang.Object regionDir_;
+    public static final int CATALOG_FIELD_NUMBER = 6;
+    private volatile java.lang.Object catalog_;
     /**
      * <pre>
-     * Directory for region's data home. Usually is composed by catalog and table
-     * id
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 6;</code>
-     * @return The regionDir.
+     * <code>string catalog = 6;</code>
+     * @return The catalog.
      */
     @java.lang.Override
-    public java.lang.String getRegionDir() {
-      java.lang.Object ref = regionDir_;
+    public java.lang.String getCatalog() {
+      java.lang.Object ref = catalog_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
-        regionDir_ = s;
+        catalog_ = s;
         return s;
       }
     }
     /**
      * <pre>
-     * Directory for region's data home. Usually is composed by catalog and table
-     * id
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 6;</code>
-     * @return The bytes for regionDir.
+     * <code>string catalog = 6;</code>
+     * @return The bytes for catalog.
      */
     @java.lang.Override
     public com.google.protobuf.ByteString
-        getRegionDirBytes() {
-      java.lang.Object ref = regionDir_;
+        getCatalogBytes() {
+      java.lang.Object ref = catalog_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        regionDir_ = b;
+        catalog_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
 
-    public static final int OPTIONS_FIELD_NUMBER = 7;
+    public static final int SCHEMA_FIELD_NUMBER = 7;
+    private volatile java.lang.Object schema_;
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 7;</code>
+     * @return The schema.
+     */
+    @java.lang.Override
+    public java.lang.String getSchema() {
+      java.lang.Object ref = schema_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        schema_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 7;</code>
+     * @return The bytes for schema.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getSchemaBytes() {
+      java.lang.Object ref = schema_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        schema_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int OPTIONS_FIELD_NUMBER = 8;
     private static final class OptionsDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<
           java.lang.String, java.lang.String> defaultEntry =
@@ -8246,7 +8407,7 @@ java.lang.String defaultValue);
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
 
     @java.lang.Override
@@ -8268,7 +8429,7 @@ java.lang.String defaultValue);
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
     @java.lang.Override
 
@@ -8280,7 +8441,7 @@ java.lang.String defaultValue);
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
     @java.lang.Override
 
@@ -8297,7 +8458,7 @@ java.lang.String defaultValue);
      * Options of the created region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 7;</code>
+     * <code>map&lt;string, string&gt; options = 8;</code>
      */
     @java.lang.Override
 
@@ -8346,15 +8507,18 @@ java.lang.String defaultValue);
       if (createIfNotExists_ != false) {
         output.writeBool(5, createIfNotExists_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(regionDir_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, regionDir_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, catalog_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(schema_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 7, schema_);
       }
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
           output,
           internalGetOptions(),
           OptionsDefaultEntryHolder.defaultEntry,
-          7);
+          8);
       unknownFields.writeTo(output);
     }
 
@@ -8393,8 +8557,11 @@ java.lang.String defaultValue);
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(5, createIfNotExists_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(regionDir_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, regionDir_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, catalog_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(schema_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, schema_);
       }
       for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
            : internalGetOptions().getMap().entrySet()) {
@@ -8404,7 +8571,7 @@ java.lang.String defaultValue);
             .setValue(entry.getValue())
             .build();
         size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(7, options__);
+            .computeMessageSize(8, options__);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -8431,8 +8598,10 @@ java.lang.String defaultValue);
           .equals(other.getPrimaryKeyList())) return false;
       if (getCreateIfNotExists()
           != other.getCreateIfNotExists()) return false;
-      if (!getRegionDir()
-          .equals(other.getRegionDir())) return false;
+      if (!getCatalog()
+          .equals(other.getCatalog())) return false;
+      if (!getSchema()
+          .equals(other.getSchema())) return false;
       if (!internalGetOptions().equals(
           other.internalGetOptions())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
@@ -8462,8 +8631,10 @@ java.lang.String defaultValue);
       hash = (37 * hash) + CREATE_IF_NOT_EXISTS_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
           getCreateIfNotExists());
-      hash = (37 * hash) + REGION_DIR_FIELD_NUMBER;
-      hash = (53 * hash) + getRegionDir().hashCode();
+      hash = (37 * hash) + CATALOG_FIELD_NUMBER;
+      hash = (53 * hash) + getCatalog().hashCode();
+      hash = (37 * hash) + SCHEMA_FIELD_NUMBER;
+      hash = (53 * hash) + getSchema().hashCode();
       if (!internalGetOptions().getMap().isEmpty()) {
         hash = (37 * hash) + OPTIONS_FIELD_NUMBER;
         hash = (53 * hash) + internalGetOptions().hashCode();
@@ -8579,7 +8750,7 @@ java.lang.String defaultValue);
       protected com.google.protobuf.MapField internalGetMapField(
           int number) {
         switch (number) {
-          case 7:
+          case 8:
             return internalGetOptions();
           default:
             throw new RuntimeException(
@@ -8590,7 +8761,7 @@ java.lang.String defaultValue);
       protected com.google.protobuf.MapField internalGetMutableMapField(
           int number) {
         switch (number) {
-          case 7:
+          case 8:
             return internalGetMutableOptions();
           default:
             throw new RuntimeException(
@@ -8638,7 +8809,9 @@ java.lang.String defaultValue);
         bitField0_ = (bitField0_ & ~0x00000002);
         createIfNotExists_ = false;
 
-        regionDir_ = "";
+        catalog_ = "";
+
+        schema_ = "";
 
         internalGetMutableOptions().clear();
         return this;
@@ -8685,7 +8858,8 @@ java.lang.String defaultValue);
         }
         result.primaryKey_ = primaryKey_;
         result.createIfNotExists_ = createIfNotExists_;
-        result.regionDir_ = regionDir_;
+        result.catalog_ = catalog_;
+        result.schema_ = schema_;
         result.options_ = internalGetOptions();
         result.options_.makeImmutable();
         onBuilt();
@@ -8782,8 +8956,12 @@ java.lang.String defaultValue);
         if (other.getCreateIfNotExists() != false) {
           setCreateIfNotExists(other.getCreateIfNotExists());
         }
-        if (!other.getRegionDir().isEmpty()) {
-          regionDir_ = other.regionDir_;
+        if (!other.getCatalog().isEmpty()) {
+          catalog_ = other.catalog_;
+          onChanged();
+        }
+        if (!other.getSchema().isEmpty()) {
+          schema_ = other.schema_;
           onChanged();
         }
         internalGetMutableOptions().mergeFrom(
@@ -9266,7 +9444,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9279,7 +9457,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9290,7 +9468,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9302,7 +9480,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9319,7 +9497,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9334,7 +9512,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9351,7 +9529,7 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Id of columns in the primary key.
+       * Columns in the primary key.
        * </pre>
        *
        * <code>repeated uint32 primary_key = 4;</code>
@@ -9407,23 +9585,23 @@ java.lang.String defaultValue);
         return this;
       }
 
-      private java.lang.Object regionDir_ = "";
+      private java.lang.Object catalog_ = "";
       /**
        * <pre>
-       * Directory for region's data home. Usually is composed by catalog and table
-       * id
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 6;</code>
-       * @return The regionDir.
+       * <code>string catalog = 6;</code>
+       * @return The catalog.
        */
-      public java.lang.String getRegionDir() {
-        java.lang.Object ref = regionDir_;
+      public java.lang.String getCatalog() {
+        java.lang.Object ref = catalog_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
-          regionDir_ = s;
+          catalog_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9431,21 +9609,21 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Directory for region's data home. Usually is composed by catalog and table
-       * id
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 6;</code>
-       * @return The bytes for regionDir.
+       * <code>string catalog = 6;</code>
+       * @return The bytes for catalog.
        */
       public com.google.protobuf.ByteString
-          getRegionDirBytes() {
-        java.lang.Object ref = regionDir_;
+          getCatalogBytes() {
+        java.lang.Object ref = catalog_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          regionDir_ = b;
+          catalog_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
@@ -9453,57 +9631,153 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Directory for region's data home. Usually is composed by catalog and table
-       * id
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 6;</code>
-       * @param value The regionDir to set.
+       * <code>string catalog = 6;</code>
+       * @param value The catalog to set.
        * @return This builder for chaining.
        */
-      public Builder setRegionDir(
+      public Builder setCatalog(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   
-        regionDir_ = value;
+        catalog_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * Directory for region's data home. Usually is composed by catalog and table
-       * id
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 6;</code>
+       * <code>string catalog = 6;</code>
        * @return This builder for chaining.
        */
-      public Builder clearRegionDir() {
+      public Builder clearCatalog() {
         
-        regionDir_ = getDefaultInstance().getRegionDir();
+        catalog_ = getDefaultInstance().getCatalog();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * Directory for region's data home. Usually is composed by catalog and table
-       * id
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 6;</code>
-       * @param value The bytes for regionDir to set.
+       * <code>string catalog = 6;</code>
+       * @param value The bytes for catalog to set.
        * @return This builder for chaining.
        */
-      public Builder setRegionDirBytes(
+      public Builder setCatalogBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
         
-        regionDir_ = value;
+        catalog_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object schema_ = "";
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 7;</code>
+       * @return The schema.
+       */
+      public java.lang.String getSchema() {
+        java.lang.Object ref = schema_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          schema_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 7;</code>
+       * @return The bytes for schema.
+       */
+      public com.google.protobuf.ByteString
+          getSchemaBytes() {
+        java.lang.Object ref = schema_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          schema_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 7;</code>
+       * @param value The schema to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSchema(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        schema_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 7;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSchema() {
+        
+        schema_ = getDefaultInstance().getSchema();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 7;</code>
+       * @param value The bytes for schema to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSchemaBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        schema_ = value;
         onChanged();
         return this;
       }
@@ -9539,7 +9813,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
 
       @java.lang.Override
@@ -9561,7 +9835,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
       @java.lang.Override
 
@@ -9573,7 +9847,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
       @java.lang.Override
 
@@ -9590,7 +9864,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
       @java.lang.Override
 
@@ -9615,7 +9889,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
 
       public Builder removeOptions(
@@ -9638,7 +9912,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
       public Builder putOptions(
           java.lang.String key,
@@ -9657,7 +9931,7 @@ java.lang.String defaultValue);
        * Options of the created region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 7;</code>
+       * <code>map&lt;string, string&gt; options = 8;</code>
        */
 
       public Builder putAllOptions(
@@ -10242,30 +10516,52 @@ java.lang.String defaultValue);
 
     /**
      * <pre>
-     * Data directory of the region.
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 3;</code>
-     * @return The regionDir.
+     * <code>string catalog = 3;</code>
+     * @return The catalog.
      */
-    java.lang.String getRegionDir();
+    java.lang.String getCatalog();
     /**
      * <pre>
-     * Data directory of the region.
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 3;</code>
-     * @return The bytes for regionDir.
+     * <code>string catalog = 3;</code>
+     * @return The bytes for catalog.
      */
     com.google.protobuf.ByteString
-        getRegionDirBytes();
+        getCatalogBytes();
+
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 4;</code>
+     * @return The schema.
+     */
+    java.lang.String getSchema();
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 4;</code>
+     * @return The bytes for schema.
+     */
+    com.google.protobuf.ByteString
+        getSchemaBytes();
 
     /**
      * <pre>
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
     int getOptionsCount();
     /**
@@ -10273,7 +10569,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
     boolean containsOptions(
         java.lang.String key);
@@ -10288,7 +10584,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
     java.util.Map<java.lang.String, java.lang.String>
     getOptionsMap();
@@ -10297,7 +10593,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
 
     /* nullable */
@@ -10310,7 +10606,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
 
     java.lang.String getOptionsOrThrow(
@@ -10330,7 +10626,8 @@ java.lang.String defaultValue);
     }
     private OpenRequest() {
       engine_ = "";
-      regionDir_ = "";
+      catalog_ = "";
+      schema_ = "";
     }
 
     @java.lang.Override
@@ -10378,10 +10675,16 @@ java.lang.String defaultValue);
             case 26: {
               java.lang.String s = input.readStringRequireUtf8();
 
-              regionDir_ = s;
+              catalog_ = s;
               break;
             }
             case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              schema_ = s;
+              break;
+            }
+            case 42: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 options_ = com.google.protobuf.MapField.newMapField(
                     OptionsDefaultEntryHolder.defaultEntry);
@@ -10425,7 +10728,7 @@ java.lang.String defaultValue);
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
-        case 4:
+        case 5:
           return internalGetOptions();
         default:
           throw new RuntimeException(
@@ -10497,53 +10800,101 @@ java.lang.String defaultValue);
       }
     }
 
-    public static final int REGION_DIR_FIELD_NUMBER = 3;
-    private volatile java.lang.Object regionDir_;
+    public static final int CATALOG_FIELD_NUMBER = 3;
+    private volatile java.lang.Object catalog_;
     /**
      * <pre>
-     * Data directory of the region.
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 3;</code>
-     * @return The regionDir.
+     * <code>string catalog = 3;</code>
+     * @return The catalog.
      */
     @java.lang.Override
-    public java.lang.String getRegionDir() {
-      java.lang.Object ref = regionDir_;
+    public java.lang.String getCatalog() {
+      java.lang.Object ref = catalog_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
-        regionDir_ = s;
+        catalog_ = s;
         return s;
       }
     }
     /**
      * <pre>
-     * Data directory of the region.
+     * catalog name and schema name is to accomplish storage path
+     * catalog name
      * </pre>
      *
-     * <code>string region_dir = 3;</code>
-     * @return The bytes for regionDir.
+     * <code>string catalog = 3;</code>
+     * @return The bytes for catalog.
      */
     @java.lang.Override
     public com.google.protobuf.ByteString
-        getRegionDirBytes() {
-      java.lang.Object ref = regionDir_;
+        getCatalogBytes() {
+      java.lang.Object ref = catalog_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        regionDir_ = b;
+        catalog_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
 
-    public static final int OPTIONS_FIELD_NUMBER = 4;
+    public static final int SCHEMA_FIELD_NUMBER = 4;
+    private volatile java.lang.Object schema_;
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 4;</code>
+     * @return The schema.
+     */
+    @java.lang.Override
+    public java.lang.String getSchema() {
+      java.lang.Object ref = schema_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        schema_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * schema name
+     * </pre>
+     *
+     * <code>string schema = 4;</code>
+     * @return The bytes for schema.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getSchemaBytes() {
+      java.lang.Object ref = schema_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        schema_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int OPTIONS_FIELD_NUMBER = 5;
     private static final class OptionsDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<
           java.lang.String, java.lang.String> defaultEntry =
@@ -10574,7 +10925,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
 
     @java.lang.Override
@@ -10596,7 +10947,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
     @java.lang.Override
 
@@ -10608,7 +10959,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
     @java.lang.Override
 
@@ -10625,7 +10976,7 @@ java.lang.String defaultValue);
      * Options of the opened region.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; options = 4;</code>
+     * <code>map&lt;string, string&gt; options = 5;</code>
      */
     @java.lang.Override
 
@@ -10660,15 +11011,18 @@ java.lang.String defaultValue);
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(engine_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, engine_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(regionDir_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, regionDir_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, catalog_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(schema_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, schema_);
       }
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
           output,
           internalGetOptions(),
           OptionsDefaultEntryHolder.defaultEntry,
-          4);
+          5);
       unknownFields.writeTo(output);
     }
 
@@ -10685,8 +11039,11 @@ java.lang.String defaultValue);
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(engine_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, engine_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(regionDir_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, regionDir_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, catalog_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(schema_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, schema_);
       }
       for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
            : internalGetOptions().getMap().entrySet()) {
@@ -10696,7 +11053,7 @@ java.lang.String defaultValue);
             .setValue(entry.getValue())
             .build();
         size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(4, options__);
+            .computeMessageSize(5, options__);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -10717,8 +11074,10 @@ java.lang.String defaultValue);
           != other.getRegionId()) return false;
       if (!getEngine()
           .equals(other.getEngine())) return false;
-      if (!getRegionDir()
-          .equals(other.getRegionDir())) return false;
+      if (!getCatalog()
+          .equals(other.getCatalog())) return false;
+      if (!getSchema()
+          .equals(other.getSchema())) return false;
       if (!internalGetOptions().equals(
           other.internalGetOptions())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
@@ -10737,8 +11096,10 @@ java.lang.String defaultValue);
           getRegionId());
       hash = (37 * hash) + ENGINE_FIELD_NUMBER;
       hash = (53 * hash) + getEngine().hashCode();
-      hash = (37 * hash) + REGION_DIR_FIELD_NUMBER;
-      hash = (53 * hash) + getRegionDir().hashCode();
+      hash = (37 * hash) + CATALOG_FIELD_NUMBER;
+      hash = (53 * hash) + getCatalog().hashCode();
+      hash = (37 * hash) + SCHEMA_FIELD_NUMBER;
+      hash = (53 * hash) + getSchema().hashCode();
       if (!internalGetOptions().getMap().isEmpty()) {
         hash = (37 * hash) + OPTIONS_FIELD_NUMBER;
         hash = (53 * hash) + internalGetOptions().hashCode();
@@ -10854,7 +11215,7 @@ java.lang.String defaultValue);
       protected com.google.protobuf.MapField internalGetMapField(
           int number) {
         switch (number) {
-          case 4:
+          case 5:
             return internalGetOptions();
           default:
             throw new RuntimeException(
@@ -10865,7 +11226,7 @@ java.lang.String defaultValue);
       protected com.google.protobuf.MapField internalGetMutableMapField(
           int number) {
         switch (number) {
-          case 4:
+          case 5:
             return internalGetMutableOptions();
           default:
             throw new RuntimeException(
@@ -10902,7 +11263,9 @@ java.lang.String defaultValue);
 
         engine_ = "";
 
-        regionDir_ = "";
+        catalog_ = "";
+
+        schema_ = "";
 
         internalGetMutableOptions().clear();
         return this;
@@ -10934,7 +11297,8 @@ java.lang.String defaultValue);
         int from_bitField0_ = bitField0_;
         result.regionId_ = regionId_;
         result.engine_ = engine_;
-        result.regionDir_ = regionDir_;
+        result.catalog_ = catalog_;
+        result.schema_ = schema_;
         result.options_ = internalGetOptions();
         result.options_.makeImmutable();
         onBuilt();
@@ -10992,8 +11356,12 @@ java.lang.String defaultValue);
           engine_ = other.engine_;
           onChanged();
         }
-        if (!other.getRegionDir().isEmpty()) {
-          regionDir_ = other.regionDir_;
+        if (!other.getCatalog().isEmpty()) {
+          catalog_ = other.catalog_;
+          onChanged();
+        }
+        if (!other.getSchema().isEmpty()) {
+          schema_ = other.schema_;
           onChanged();
         }
         internalGetMutableOptions().mergeFrom(
@@ -11155,22 +11523,23 @@ java.lang.String defaultValue);
         return this;
       }
 
-      private java.lang.Object regionDir_ = "";
+      private java.lang.Object catalog_ = "";
       /**
        * <pre>
-       * Data directory of the region.
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 3;</code>
-       * @return The regionDir.
+       * <code>string catalog = 3;</code>
+       * @return The catalog.
        */
-      public java.lang.String getRegionDir() {
-        java.lang.Object ref = regionDir_;
+      public java.lang.String getCatalog() {
+        java.lang.Object ref = catalog_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
-          regionDir_ = s;
+          catalog_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -11178,20 +11547,21 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Data directory of the region.
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 3;</code>
-       * @return The bytes for regionDir.
+       * <code>string catalog = 3;</code>
+       * @return The bytes for catalog.
        */
       public com.google.protobuf.ByteString
-          getRegionDirBytes() {
-        java.lang.Object ref = regionDir_;
+          getCatalogBytes() {
+        java.lang.Object ref = catalog_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          regionDir_ = b;
+          catalog_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
@@ -11199,54 +11569,153 @@ java.lang.String defaultValue);
       }
       /**
        * <pre>
-       * Data directory of the region.
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 3;</code>
-       * @param value The regionDir to set.
+       * <code>string catalog = 3;</code>
+       * @param value The catalog to set.
        * @return This builder for chaining.
        */
-      public Builder setRegionDir(
+      public Builder setCatalog(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   
-        regionDir_ = value;
+        catalog_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * Data directory of the region.
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 3;</code>
+       * <code>string catalog = 3;</code>
        * @return This builder for chaining.
        */
-      public Builder clearRegionDir() {
+      public Builder clearCatalog() {
         
-        regionDir_ = getDefaultInstance().getRegionDir();
+        catalog_ = getDefaultInstance().getCatalog();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * Data directory of the region.
+       * catalog name and schema name is to accomplish storage path
+       * catalog name
        * </pre>
        *
-       * <code>string region_dir = 3;</code>
-       * @param value The bytes for regionDir to set.
+       * <code>string catalog = 3;</code>
+       * @param value The bytes for catalog to set.
        * @return This builder for chaining.
        */
-      public Builder setRegionDirBytes(
+      public Builder setCatalogBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
         
-        regionDir_ = value;
+        catalog_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object schema_ = "";
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 4;</code>
+       * @return The schema.
+       */
+      public java.lang.String getSchema() {
+        java.lang.Object ref = schema_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          schema_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 4;</code>
+       * @return The bytes for schema.
+       */
+      public com.google.protobuf.ByteString
+          getSchemaBytes() {
+        java.lang.Object ref = schema_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          schema_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 4;</code>
+       * @param value The schema to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSchema(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        schema_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSchema() {
+        
+        schema_ = getDefaultInstance().getSchema();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * schema name
+       * </pre>
+       *
+       * <code>string schema = 4;</code>
+       * @param value The bytes for schema to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSchemaBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        schema_ = value;
         onChanged();
         return this;
       }
@@ -11282,7 +11751,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
 
       @java.lang.Override
@@ -11304,7 +11773,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
       @java.lang.Override
 
@@ -11316,7 +11785,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
       @java.lang.Override
 
@@ -11333,7 +11802,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
       @java.lang.Override
 
@@ -11358,7 +11827,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
 
       public Builder removeOptions(
@@ -11381,7 +11850,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
       public Builder putOptions(
           java.lang.String key,
@@ -11400,7 +11869,7 @@ java.lang.String defaultValue);
        * Options of the opened region.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; options = 4;</code>
+       * <code>map&lt;string, string&gt; options = 5;</code>
        */
 
       public Builder putAllOptions(
@@ -14534,59 +15003,60 @@ java.lang.String defaultValue);
     java.lang.String[] descriptorData = {
       "\n\037greptime/v1/region/server.proto\022\022grept" +
       "ime.v1.region\032\030greptime/v1/common.proto\032" +
-      "\025greptime/v1/row.proto\"8\n\023RegionRequestH" +
-      "eader\022\020\n\010trace_id\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004" +
-      "\"\245\004\n\rRegionRequest\0227\n\006header\030\001 \001(\0132\'.gre" +
-      "ptime.v1.region.RegionRequestHeader\0225\n\007i" +
-      "nserts\030\003 \001(\0132\".greptime.v1.region.Insert" +
-      "RequestsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v" +
-      "1.region.DeleteRequestsH\000\0223\n\006create\030\005 \001(" +
-      "\0132!.greptime.v1.region.CreateRequestH\000\022/" +
-      "\n\004drop\030\006 \001(\0132\037.greptime.v1.region.DropRe" +
-      "questH\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.regi" +
-      "on.OpenRequestH\000\0221\n\005close\030\010 \001(\0132 .grepti" +
-      "me.v1.region.CloseRequestH\000\0221\n\005alter\030\t \001" +
-      "(\0132 .greptime.v1.region.AlterRequestH\000\0221" +
-      "\n\005flush\030\n \001(\0132 .greptime.v1.region.Flush" +
-      "RequestH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1" +
-      ".region.CompactRequestH\000B\006\n\004body\"T\n\016Regi" +
-      "onResponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1" +
-      ".ResponseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E" +
-      "\n\016InsertRequests\0223\n\010requests\030\001 \003(\0132!.gre" +
-      "ptime.v1.region.InsertRequest\"E\n\016DeleteR" +
-      "equests\0223\n\010requests\030\001 \003(\0132!.greptime.v1." +
-      "region.DeleteRequest\"C\n\rInsertRequest\022\021\n" +
-      "\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptim" +
-      "e.v1.Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030" +
-      "\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"/" +
-      "\n\014QueryRequest\022\021\n\tregion_id\030\001 \001(\004\022\014\n\004pla" +
-      "n\030\002 \001(\014\"\236\002\n\rCreateRequest\022\021\n\tregion_id\030\001" +
-      " \001(\004\022\016\n\006engine\030\002 \001(\t\0222\n\013column_defs\030\003 \003(" +
-      "\0132\035.greptime.v1.region.ColumnDef\022\023\n\013prim" +
-      "ary_key\030\004 \003(\r\022\034\n\024create_if_not_exists\030\005 " +
-      "\001(\010\022\022\n\nregion_dir\030\006 \001(\t\022?\n\007options\030\007 \003(\013" +
-      "2..greptime.v1.region.CreateRequest.Opti" +
-      "onsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
-      "\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021\n\tregio" +
-      "n_id\030\001 \001(\004\"\263\001\n\013OpenRequest\022\021\n\tregion_id\030" +
-      "\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\022\n\nregion_dir\030\003 \001(" +
-      "\t\022=\n\007options\030\004 \003(\0132,.greptime.v1.region." +
-      "OpenRequest.OptionsEntry\032.\n\014OptionsEntry" +
-      "\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"!\n\014Clos" +
-      "eRequest\022\021\n\tregion_id\030\001 \001(\004\"!\n\014AlterRequ" +
-      "est\022\021\n\tregion_id\030\001 \001(\004\"!\n\014FlushRequest\022\021" +
-      "\n\tregion_id\030\001 \001(\004\"#\n\016CompactRequest\022\021\n\tr" +
-      "egion_id\030\001 \001(\004\"\276\001\n\tColumnDef\022\014\n\004name\030\001 \001" +
-      "(\t\022\021\n\tcolumn_id\030\002 \001(\r\022-\n\010datatype\030\003 \001(\0162" +
-      "\033.greptime.v1.ColumnDataType\022\023\n\013is_nulla" +
-      "ble\030\004 \001(\010\022\032\n\022default_constraint\030\005 \001(\014\0220\n" +
-      "\rsemantic_type\030\006 \001(\0162\031.greptime.v1.Seman" +
-      "ticType2Y\n\006Region\022O\n\006Handle\022!.greptime.v" +
-      "1.region.RegionRequest\032\".greptime.v1.reg" +
-      "ion.RegionResponseB]\n\025io.greptime.v1.reg" +
-      "ionB\006ServerZ<github.com/GreptimeTeam/gre" +
-      "ptime-proto/go/greptime/v1/regionb\006proto" +
-      "3"
+      "\025greptime/v1/row.proto\"[\n\023RegionRequestH" +
+      "eader\022\025\n\010trace_id\030\001 \001(\004H\000\210\001\001\022\024\n\007span_id\030" +
+      "\002 \001(\004H\001\210\001\001B\013\n\t_trace_idB\n\n\010_span_id\"\245\004\n\r" +
+      "RegionRequest\0227\n\006header\030\001 \001(\0132\'.greptime" +
+      ".v1.region.RegionRequestHeader\0225\n\007insert" +
+      "s\030\003 \001(\0132\".greptime.v1.region.InsertReque" +
+      "stsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v1.reg" +
+      "ion.DeleteRequestsH\000\0223\n\006create\030\005 \001(\0132!.g" +
+      "reptime.v1.region.CreateRequestH\000\022/\n\004dro" +
+      "p\030\006 \001(\0132\037.greptime.v1.region.DropRequest" +
+      "H\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.region.Op" +
+      "enRequestH\000\0221\n\005close\030\010 \001(\0132 .greptime.v1" +
+      ".region.CloseRequestH\000\0221\n\005alter\030\t \001(\0132 ." +
+      "greptime.v1.region.AlterRequestH\000\0221\n\005flu" +
+      "sh\030\n \001(\0132 .greptime.v1.region.FlushReque" +
+      "stH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1.regi" +
+      "on.CompactRequestH\000B\006\n\004body\"T\n\016RegionRes" +
+      "ponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1.Resp" +
+      "onseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E\n\016Ins" +
+      "ertRequests\0223\n\010requests\030\001 \003(\0132!.greptime" +
+      ".v1.region.InsertRequest\"E\n\016DeleteReques" +
+      "ts\0223\n\010requests\030\001 \003(\0132!.greptime.v1.regio" +
+      "n.DeleteRequest\"C\n\rInsertRequest\022\021\n\tregi" +
+      "on_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1." +
+      "Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030\001 \001(\004" +
+      "\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"/\n\014Que" +
+      "ryRequest\022\021\n\tregion_id\030\001 \001(\004\022\014\n\004plan\030\002 \001" +
+      "(\014\"\253\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022" +
+      "\016\n\006engine\030\002 \001(\t\0222\n\013column_defs\030\003 \003(\0132\035.g" +
+      "reptime.v1.region.ColumnDef\022\023\n\013primary_k" +
+      "ey\030\004 \003(\r\022\034\n\024create_if_not_exists\030\005 \001(\010\022\017" +
+      "\n\007catalog\030\006 \001(\t\022\016\n\006schema\030\007 \001(\t\022?\n\007optio" +
+      "ns\030\010 \003(\0132..greptime.v1.region.CreateRequ" +
+      "est.OptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030" +
+      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022" +
+      "\021\n\tregion_id\030\001 \001(\004\"\300\001\n\013OpenRequest\022\021\n\tre" +
+      "gion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\017\n\007catalog" +
+      "\030\003 \001(\t\022\016\n\006schema\030\004 \001(\t\022=\n\007options\030\005 \003(\0132" +
+      ",.greptime.v1.region.OpenRequest.Options" +
+      "Entry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va" +
+      "lue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion_" +
+      "id\030\001 \001(\004\"!\n\014AlterRequest\022\021\n\tregion_id\030\001 " +
+      "\001(\004\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\"#" +
+      "\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"\276\001\n\t" +
+      "ColumnDef\022\014\n\004name\030\001 \001(\t\022\021\n\tcolumn_id\030\002 \001" +
+      "(\r\022-\n\010datatype\030\003 \001(\0162\033.greptime.v1.Colum" +
+      "nDataType\022\023\n\013is_nullable\030\004 \001(\010\022\032\n\022defaul" +
+      "t_constraint\030\005 \001(\014\0220\n\rsemantic_type\030\006 \001(" +
+      "\0162\031.greptime.v1.SemanticType2Y\n\006Region\022O" +
+      "\n\006Handle\022!.greptime.v1.region.RegionRequ" +
+      "est\032\".greptime.v1.region.RegionResponseB" +
+      "]\n\025io.greptime.v1.regionB\006ServerZ<github" +
+      ".com/GreptimeTeam/greptime-proto/go/grep" +
+      "time/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -14599,7 +15069,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequestHeader_descriptor,
-        new java.lang.String[] { "TraceId", "SpanId", });
+        new java.lang.String[] { "TraceId", "SpanId", "TraceId", "SpanId", });
     internal_static_greptime_v1_region_RegionRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_greptime_v1_region_RegionRequest_fieldAccessorTable = new
@@ -14647,7 +15117,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_CreateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CreateRequest_descriptor,
-        new java.lang.String[] { "RegionId", "Engine", "ColumnDefs", "PrimaryKey", "CreateIfNotExists", "RegionDir", "Options", });
+        new java.lang.String[] { "RegionId", "Engine", "ColumnDefs", "PrimaryKey", "CreateIfNotExists", "Catalog", "Schema", "Options", });
     internal_static_greptime_v1_region_CreateRequest_OptionsEntry_descriptor =
       internal_static_greptime_v1_region_CreateRequest_descriptor.getNestedTypes().get(0);
     internal_static_greptime_v1_region_CreateRequest_OptionsEntry_fieldAccessorTable = new
@@ -14665,7 +15135,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_OpenRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_OpenRequest_descriptor,
-        new java.lang.String[] { "RegionId", "Engine", "RegionDir", "Options", });
+        new java.lang.String[] { "RegionId", "Engine", "Catalog", "Schema", "Options", });
     internal_static_greptime_v1_region_OpenRequest_OptionsEntry_descriptor =
       internal_static_greptime_v1_region_OpenRequest_descriptor.getNestedTypes().get(0);
     internal_static_greptime_v1_region_OpenRequest_OptionsEntry_fieldAccessorTable = new

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -27,9 +27,9 @@ service Region { rpc Handle(RegionRequest) returns (RegionResponse); }
 
 message RegionRequestHeader {
   // TraceID of request
-  uint64 trace_id = 1;
+  optional uint64 trace_id = 1;
   // SpanID of request
-  uint64 span_id = 2;
+  optional uint64 span_id = 2;
 }
 
 message RegionRequest {
@@ -79,15 +79,17 @@ message CreateRequest {
   string engine = 2;
   // Columns in this region.
   repeated ColumnDef column_defs = 3;
-  // Id of columns in the primary key.
+  // Columns in the primary key.
   repeated uint32 primary_key = 4;
   // Create region if not exists.
   bool create_if_not_exists = 5;
-  // Directory for region's data home. Usually is composed by catalog and table
-  // id
-  string region_dir = 6;
+  // catalog name and schema name is to accomplish storage path
+  // catalog name
+  string catalog = 6;
+  // schema name
+  string schema = 7;
   // Options of the created region.
-  map<string, string> options = 7;
+  map<string, string> options = 8;
   // TODO: add partition def
 }
 
@@ -97,10 +99,13 @@ message OpenRequest {
   uint64 region_id = 1;
   // Region engine name
   string engine = 2;
-  // Data directory of the region.
-  string region_dir = 3;
+  // catalog name and schema name is to accomplish storage path
+  // catalog name
+  string catalog = 3;
+  // schema name
+  string schema = 4;
   // Options of the opened region.
-  map<string, string> options = 4;
+  map<string, string> options = 5;
 }
 
 message CloseRequest { uint64 region_id = 1; }

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -27,9 +27,9 @@ service Region { rpc Handle(RegionRequest) returns (RegionResponse); }
 
 message RegionRequestHeader {
   // TraceID of request
-  optional uint64 trace_id = 1;
+  uint64 trace_id = 1;
   // SpanID of request
-  optional uint64 span_id = 2;
+  uint64 span_id = 2;
 }
 
 message RegionRequest {
@@ -79,7 +79,7 @@ message CreateRequest {
   string engine = 2;
   // Columns in this region.
   repeated ColumnDef column_defs = 3;
-  // Columns in the primary key.
+  // Column Id of primary keys.
   repeated uint32 primary_key = 4;
   // Create region if not exists.
   bool create_if_not_exists = 5;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Open/Create request used to require a dir parameter for storing path. But this path is a relative path, it's then concat-ed to **the root path configured on datanode**. Since the logic of generating a relative path is neither defined in metasrv nor datanode/mito, I prefer to pass all the "raw material" required for a complete storage path, and let datanode handles them all.


The logic of generating storage path is in `src/table/src/engine.rs`:
```rust
pub fn region_dir(catalog_name: &str, schema_name: &str, region_id: RegionId) -> String {
    format!(
        "{}{}",
        table_dir(catalog_name, schema_name, region_id.table_id()),
        region_name(region_id.table_id(), region_id.region_number())
    )
}
```

An alternative way to do this is letting the metasrv to handle all of this, like configuring data root of datanode and assembling `region_dir`. But it looks less viable for now

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
