### PR TITLE
fix: add a missing CMakeLists.txt file

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2023 Greptime Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+cmake_minimum_required(VERSION 3.22)
+
+project(greptime_proto_cpp_lib)
+
+file(GLOB_RECURSE OUTPUT_SOURCES "*.h" "*.cc")
+
+add_library(${PROJECT_NAME} ${OUTPUT_SOURCES})
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add a missing but required `CMakeLists.txt` file in the `c++` directory.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
