### PR TITLE
chore: add `dbname` in region request header for tracking purpose

### DIFF
--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -25,7 +25,8 @@ namespace v1 {
 namespace region {
 PROTOBUF_CONSTEXPR RegionRequestHeader::RegionRequestHeader(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.trace_id_)*/uint64_t{0u}
+    /*decltype(_impl_.dbname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.trace_id_)*/uint64_t{0u}
   , /*decltype(_impl_.span_id_)*/uint64_t{0u}
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct RegionRequestHeaderDefaultTypeInternal {
@@ -356,6 +357,7 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.trace_id_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.span_id_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.dbname_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -549,28 +551,28 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, -1, sizeof(::greptime::v1::region::RegionRequestHeader)},
-  { 8, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
-  { 26, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
-  { 34, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
-  { 41, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
-  { 48, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
-  { 56, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
-  { 64, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
-  { 73, 81, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
-  { 83, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
-  { 95, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
-  { 102, 110, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
-  { 112, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
-  { 122, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
-  { 129, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
-  { 140, -1, -1, sizeof(::greptime::v1::region::AddColumns)},
-  { 147, -1, -1, sizeof(::greptime::v1::region::DropColumns)},
-  { 154, -1, -1, sizeof(::greptime::v1::region::AddColumn)},
-  { 162, -1, -1, sizeof(::greptime::v1::region::DropColumn)},
-  { 169, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
-  { 176, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
-  { 183, -1, -1, sizeof(::greptime::v1::region::TruncateRequest)},
-  { 190, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
+  { 9, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
+  { 27, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
+  { 35, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
+  { 42, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
+  { 49, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
+  { 57, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
+  { 65, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
+  { 74, 82, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
+  { 84, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
+  { 96, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
+  { 103, 111, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
+  { 113, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
+  { 123, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
+  { 130, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
+  { 141, -1, -1, sizeof(::greptime::v1::region::AddColumns)},
+  { 148, -1, -1, sizeof(::greptime::v1::region::DropColumns)},
+  { 155, -1, -1, sizeof(::greptime::v1::region::AddColumn)},
+  { 163, -1, -1, sizeof(::greptime::v1::region::DropColumn)},
+  { 170, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
+  { 177, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
+  { 184, -1, -1, sizeof(::greptime::v1::region::TruncateRequest)},
+  { 191, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -603,69 +605,69 @@ const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] P
   "\n\037greptime/v1/region/server.proto\022\022grept"
   "ime.v1.region\032\030greptime/v1/common.proto\032"
   "\025greptime/v1/row.proto\032\025greptime/v1/ddl."
-  "proto\"8\n\023RegionRequestHeader\022\020\n\010trace_id"
-  "\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004\"\336\004\n\rRegionReques"
-  "t\0227\n\006header\030\001 \001(\0132\'.greptime.v1.region.R"
-  "egionRequestHeader\0225\n\007inserts\030\003 \001(\0132\".gr"
-  "eptime.v1.region.InsertRequestsH\000\0225\n\007del"
-  "etes\030\004 \001(\0132\".greptime.v1.region.DeleteRe"
-  "questsH\000\0223\n\006create\030\005 \001(\0132!.greptime.v1.r"
-  "egion.CreateRequestH\000\022/\n\004drop\030\006 \001(\0132\037.gr"
-  "eptime.v1.region.DropRequestH\000\022/\n\004open\030\007"
-  " \001(\0132\037.greptime.v1.region.OpenRequestH\000\022"
-  "1\n\005close\030\010 \001(\0132 .greptime.v1.region.Clos"
-  "eRequestH\000\0221\n\005alter\030\t \001(\0132 .greptime.v1."
-  "region.AlterRequestH\000\0221\n\005flush\030\n \001(\0132 .g"
-  "reptime.v1.region.FlushRequestH\000\0225\n\007comp"
-  "act\030\013 \001(\0132\".greptime.v1.region.CompactRe"
-  "questH\000\0227\n\010truncate\030\014 \001(\0132#.greptime.v1."
-  "region.TruncateRequestH\000B\006\n\004body\"T\n\016Regi"
-  "onResponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1"
-  ".ResponseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E"
-  "\n\016InsertRequests\0223\n\010requests\030\001 \003(\0132!.gre"
-  "ptime.v1.region.InsertRequest\"E\n\016DeleteR"
-  "equests\0223\n\010requests\030\001 \003(\0132!.greptime.v1."
-  "region.DeleteRequest\"C\n\rInsertRequest\022\021\n"
-  "\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptim"
-  "e.v1.Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030"
-  "\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"h"
-  "\n\014QueryRequest\0227\n\006header\030\001 \001(\0132\'.greptim"
-  "e.v1.region.RegionRequestHeader\022\021\n\tregio"
-  "n_id\030\002 \001(\004\022\014\n\004plan\030\003 \001(\014\"\200\002\n\rCreateReque"
-  "st\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0228\n"
-  "\013column_defs\030\003 \003(\0132#.greptime.v1.region."
-  "RegionColumnDef\022\023\n\013primary_key\030\004 \003(\r\022\014\n\004"
-  "path\030\005 \001(\t\022\?\n\007options\030\006 \003(\0132..greptime.v"
-  "1.region.CreateRequest.OptionsEntry\032.\n\014O"
-  "ptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:"
-  "\0028\001\" \n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\255\001"
-  "\n\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engi"
-  "ne\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=\n\007options\030\004 \003(\0132"
-  ",.greptime.v1.region.OpenRequest.Options"
-  "Entry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va"
-  "lue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion_"
-  "id\030\001 \001(\004\"\261\001\n\014AlterRequest\022\021\n\tregion_id\030\001"
-  " \001(\004\0225\n\013add_columns\030\002 \001(\0132\036.greptime.v1."
-  "region.AddColumnsH\000\0227\n\014drop_columns\030\003 \001("
-  "\0132\037.greptime.v1.region.DropColumnsH\000\022\026\n\016"
-  "schema_version\030\004 \001(\004B\006\n\004kind\"@\n\nAddColum"
-  "ns\0222\n\013add_columns\030\001 \003(\0132\035.greptime.v1.re"
-  "gion.AddColumn\"C\n\013DropColumns\0224\n\014drop_co"
-  "lumns\030\001 \003(\0132\036.greptime.v1.region.DropCol"
-  "umn\"v\n\tAddColumn\0227\n\ncolumn_def\030\001 \001(\0132#.g"
-  "reptime.v1.region.RegionColumnDef\0220\n\010loc"
-  "ation\030\003 \001(\0132\036.greptime.v1.AddColumnLocat"
-  "ion\"\032\n\nDropColumn\022\014\n\004name\030\001 \001(\t\"!\n\014Flush"
-  "Request\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactReq"
-  "uest\022\021\n\tregion_id\030\001 \001(\004\"$\n\017TruncateReque"
-  "st\022\021\n\tregion_id\030\001 \001(\004\"P\n\017RegionColumnDef"
-  "\022*\n\ncolumn_def\030\001 \001(\0132\026.greptime.v1.Colum"
-  "nDef\022\021\n\tcolumn_id\030\002 \001(\r2Y\n\006Region\022O\n\006Han"
-  "dle\022!.greptime.v1.region.RegionRequest\032\""
-  ".greptime.v1.region.RegionResponseB]\n\025io"
-  ".greptime.v1.regionB\006ServerZ<github.com/"
-  "GreptimeTeam/greptime-proto/go/greptime/"
-  "v1/regionb\006proto3"
+  "proto\"H\n\023RegionRequestHeader\022\020\n\010trace_id"
+  "\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004\022\016\n\006dbname\030\003 \001(\t\""
+  "\336\004\n\rRegionRequest\0227\n\006header\030\001 \001(\0132\'.grep"
+  "time.v1.region.RegionRequestHeader\0225\n\007in"
+  "serts\030\003 \001(\0132\".greptime.v1.region.InsertR"
+  "equestsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v1"
+  ".region.DeleteRequestsH\000\0223\n\006create\030\005 \001(\013"
+  "2!.greptime.v1.region.CreateRequestH\000\022/\n"
+  "\004drop\030\006 \001(\0132\037.greptime.v1.region.DropReq"
+  "uestH\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.regio"
+  "n.OpenRequestH\000\0221\n\005close\030\010 \001(\0132 .greptim"
+  "e.v1.region.CloseRequestH\000\0221\n\005alter\030\t \001("
+  "\0132 .greptime.v1.region.AlterRequestH\000\0221\n"
+  "\005flush\030\n \001(\0132 .greptime.v1.region.FlushR"
+  "equestH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1."
+  "region.CompactRequestH\000\0227\n\010truncate\030\014 \001("
+  "\0132#.greptime.v1.region.TruncateRequestH\000"
+  "B\006\n\004body\"T\n\016RegionResponse\022+\n\006header\030\001 \001"
+  "(\0132\033.greptime.v1.ResponseHeader\022\025\n\raffec"
+  "ted_rows\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requ"
+  "ests\030\001 \003(\0132!.greptime.v1.region.InsertRe"
+  "quest\"E\n\016DeleteRequests\0223\n\010requests\030\001 \003("
+  "\0132!.greptime.v1.region.DeleteRequest\"C\n\r"
+  "InsertRequest\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows"
+  "\030\002 \001(\0132\021.greptime.v1.Rows\"C\n\rDeleteReque"
+  "st\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.gr"
+  "eptime.v1.Rows\"h\n\014QueryRequest\0227\n\006header"
+  "\030\001 \001(\0132\'.greptime.v1.region.RegionReques"
+  "tHeader\022\021\n\tregion_id\030\002 \001(\004\022\014\n\004plan\030\003 \001(\014"
+  "\"\200\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n"
+  "\006engine\030\002 \001(\t\0228\n\013column_defs\030\003 \003(\0132#.gre"
+  "ptime.v1.region.RegionColumnDef\022\023\n\013prima"
+  "ry_key\030\004 \003(\r\022\014\n\004path\030\005 \001(\t\022\?\n\007options\030\006 "
+  "\003(\0132..greptime.v1.region.CreateRequest.O"
+  "ptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t"
+  "\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021\n\tre"
+  "gion_id\030\001 \001(\004\"\255\001\n\013OpenRequest\022\021\n\tregion_"
+  "id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022="
+  "\n\007options\030\004 \003(\0132,.greptime.v1.region.Ope"
+  "nRequest.OptionsEntry\032.\n\014OptionsEntry\022\013\n"
+  "\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"!\n\014CloseRe"
+  "quest\022\021\n\tregion_id\030\001 \001(\004\"\261\001\n\014AlterReques"
+  "t\022\021\n\tregion_id\030\001 \001(\004\0225\n\013add_columns\030\002 \001("
+  "\0132\036.greptime.v1.region.AddColumnsH\000\0227\n\014d"
+  "rop_columns\030\003 \001(\0132\037.greptime.v1.region.D"
+  "ropColumnsH\000\022\026\n\016schema_version\030\004 \001(\004B\006\n\004"
+  "kind\"@\n\nAddColumns\0222\n\013add_columns\030\001 \003(\0132"
+  "\035.greptime.v1.region.AddColumn\"C\n\013DropCo"
+  "lumns\0224\n\014drop_columns\030\001 \003(\0132\036.greptime.v"
+  "1.region.DropColumn\"v\n\tAddColumn\0227\n\ncolu"
+  "mn_def\030\001 \001(\0132#.greptime.v1.region.Region"
+  "ColumnDef\0220\n\010location\030\003 \001(\0132\036.greptime.v"
+  "1.AddColumnLocation\"\032\n\nDropColumn\022\014\n\004nam"
+  "e\030\001 \001(\t\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001"
+  "(\004\"#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\""
+  "$\n\017TruncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n"
+  "\017RegionColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.g"
+  "reptime.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2"
+  "Y\n\006Region\022O\n\006Handle\022!.greptime.v1.region"
+  ".RegionRequest\032\".greptime.v1.region.Regi"
+  "onResponseB]\n\025io.greptime.v1.regionB\006Ser"
+  "verZ<github.com/GreptimeTeam/greptime-pr"
+  "oto/go/greptime/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[3] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -674,7 +676,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 2617, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 2633, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
     &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 23,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
@@ -707,11 +709,20 @@ RegionRequestHeader::RegionRequestHeader(const RegionRequestHeader& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   RegionRequestHeader* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.trace_id_){}
+      decltype(_impl_.dbname_){}
+    , decltype(_impl_.trace_id_){}
     , decltype(_impl_.span_id_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.dbname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.dbname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_dbname().empty()) {
+    _this->_impl_.dbname_.Set(from._internal_dbname(), 
+      _this->GetArenaForAllocation());
+  }
   ::memcpy(&_impl_.trace_id_, &from._impl_.trace_id_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.span_id_) -
     reinterpret_cast<char*>(&_impl_.trace_id_)) + sizeof(_impl_.span_id_));
@@ -723,10 +734,15 @@ inline void RegionRequestHeader::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.trace_id_){uint64_t{0u}}
+      decltype(_impl_.dbname_){}
+    , decltype(_impl_.trace_id_){uint64_t{0u}}
     , decltype(_impl_.span_id_){uint64_t{0u}}
     , /*decltype(_impl_._cached_size_)*/{}
   };
+  _impl_.dbname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.dbname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
 RegionRequestHeader::~RegionRequestHeader() {
@@ -740,6 +756,7 @@ RegionRequestHeader::~RegionRequestHeader() {
 
 inline void RegionRequestHeader::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.dbname_.Destroy();
 }
 
 void RegionRequestHeader::SetCachedSize(int size) const {
@@ -752,6 +769,7 @@ void RegionRequestHeader::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  _impl_.dbname_.ClearToEmpty();
   ::memset(&_impl_.trace_id_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&_impl_.span_id_) -
       reinterpret_cast<char*>(&_impl_.trace_id_)) + sizeof(_impl_.span_id_));
@@ -777,6 +795,16 @@ const char* RegionRequestHeader::_InternalParse(const char* ptr, ::_pbi::ParseCo
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
           _impl_.span_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // string dbname = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_dbname();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.RegionRequestHeader.dbname"));
         } else
           goto handle_unusual;
         continue;
@@ -821,6 +849,16 @@ uint8_t* RegionRequestHeader::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteUInt64ToArray(2, this->_internal_span_id(), target);
   }
 
+  // string dbname = 3;
+  if (!this->_internal_dbname().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_dbname().data(), static_cast<int>(this->_internal_dbname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.region.RegionRequestHeader.dbname");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_dbname(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -836,6 +874,13 @@ size_t RegionRequestHeader::ByteSizeLong() const {
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
+
+  // string dbname = 3;
+  if (!this->_internal_dbname().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_dbname());
+  }
 
   // uint64 trace_id = 1;
   if (this->_internal_trace_id() != 0) {
@@ -865,6 +910,9 @@ void RegionRequestHeader::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, co
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (!from._internal_dbname().empty()) {
+    _this->_internal_set_dbname(from._internal_dbname());
+  }
   if (from._internal_trace_id() != 0) {
     _this->_internal_set_trace_id(from._internal_trace_id());
   }
@@ -887,7 +935,13 @@ bool RegionRequestHeader::IsInitialized() const {
 
 void RegionRequestHeader::InternalSwap(RegionRequestHeader* other) {
   using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.dbname_, lhs_arena,
+      &other->_impl_.dbname_, rhs_arena
+  );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(RegionRequestHeader, _impl_.span_id_)
       + sizeof(RegionRequestHeader::_impl_.span_id_)

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -277,9 +277,24 @@ class RegionRequestHeader final :
   // accessors -------------------------------------------------------
 
   enum : int {
+    kDbnameFieldNumber = 3,
     kTraceIdFieldNumber = 1,
     kSpanIdFieldNumber = 2,
   };
+  // string dbname = 3;
+  void clear_dbname();
+  const std::string& dbname() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_dbname(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_dbname();
+  PROTOBUF_NODISCARD std::string* release_dbname();
+  void set_allocated_dbname(std::string* dbname);
+  private:
+  const std::string& _internal_dbname() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_dbname(const std::string& value);
+  std::string* _internal_mutable_dbname();
+  public:
+
   // uint64 trace_id = 1;
   void clear_trace_id();
   uint64_t trace_id() const;
@@ -306,6 +321,7 @@ class RegionRequestHeader final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr dbname_;
     uint64_t trace_id_;
     uint64_t span_id_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
@@ -4039,6 +4055,56 @@ inline void RegionRequestHeader::_internal_set_span_id(uint64_t value) {
 inline void RegionRequestHeader::set_span_id(uint64_t value) {
   _internal_set_span_id(value);
   // @@protoc_insertion_point(field_set:greptime.v1.region.RegionRequestHeader.span_id)
+}
+
+// string dbname = 3;
+inline void RegionRequestHeader::clear_dbname() {
+  _impl_.dbname_.ClearToEmpty();
+}
+inline const std::string& RegionRequestHeader::dbname() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionRequestHeader.dbname)
+  return _internal_dbname();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void RegionRequestHeader::set_dbname(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.dbname_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.RegionRequestHeader.dbname)
+}
+inline std::string* RegionRequestHeader::mutable_dbname() {
+  std::string* _s = _internal_mutable_dbname();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.RegionRequestHeader.dbname)
+  return _s;
+}
+inline const std::string& RegionRequestHeader::_internal_dbname() const {
+  return _impl_.dbname_.Get();
+}
+inline void RegionRequestHeader::_internal_set_dbname(const std::string& value) {
+  
+  _impl_.dbname_.Set(value, GetArenaForAllocation());
+}
+inline std::string* RegionRequestHeader::_internal_mutable_dbname() {
+  
+  return _impl_.dbname_.Mutable(GetArenaForAllocation());
+}
+inline std::string* RegionRequestHeader::release_dbname() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequestHeader.dbname)
+  return _impl_.dbname_.Release();
+}
+inline void RegionRequestHeader::set_allocated_dbname(std::string* dbname) {
+  if (dbname != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.dbname_.SetAllocated(dbname, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.dbname_.IsDefault()) {
+    _impl_.dbname_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequestHeader.dbname)
 }
 
 // -------------------------------------------------------------------

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -37,6 +37,26 @@ public final class Server {
      * @return The spanId.
      */
     long getSpanId();
+
+    /**
+     * <pre>
+     * DB Name of request, tracking only
+     * </pre>
+     *
+     * <code>string dbname = 3;</code>
+     * @return The dbname.
+     */
+    java.lang.String getDbname();
+    /**
+     * <pre>
+     * DB Name of request, tracking only
+     * </pre>
+     *
+     * <code>string dbname = 3;</code>
+     * @return The bytes for dbname.
+     */
+    com.google.protobuf.ByteString
+        getDbnameBytes();
   }
   /**
    * Protobuf type {@code greptime.v1.region.RegionRequestHeader}
@@ -51,6 +71,7 @@ public final class Server {
       super(builder);
     }
     private RegionRequestHeader() {
+      dbname_ = "";
     }
 
     @java.lang.Override
@@ -91,6 +112,12 @@ public final class Server {
             case 16: {
 
               spanId_ = input.readUInt64();
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              dbname_ = s;
               break;
             }
             default: {
@@ -157,6 +184,52 @@ public final class Server {
       return spanId_;
     }
 
+    public static final int DBNAME_FIELD_NUMBER = 3;
+    private volatile java.lang.Object dbname_;
+    /**
+     * <pre>
+     * DB Name of request, tracking only
+     * </pre>
+     *
+     * <code>string dbname = 3;</code>
+     * @return The dbname.
+     */
+    @java.lang.Override
+    public java.lang.String getDbname() {
+      java.lang.Object ref = dbname_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        dbname_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * DB Name of request, tracking only
+     * </pre>
+     *
+     * <code>string dbname = 3;</code>
+     * @return The bytes for dbname.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getDbnameBytes() {
+      java.lang.Object ref = dbname_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        dbname_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -177,6 +250,9 @@ public final class Server {
       if (spanId_ != 0L) {
         output.writeUInt64(2, spanId_);
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(dbname_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, dbname_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -193,6 +269,9 @@ public final class Server {
       if (spanId_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, spanId_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(dbname_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, dbname_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -213,6 +292,8 @@ public final class Server {
           != other.getTraceId()) return false;
       if (getSpanId()
           != other.getSpanId()) return false;
+      if (!getDbname()
+          .equals(other.getDbname())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -230,6 +311,8 @@ public final class Server {
       hash = (37 * hash) + SPAN_ID_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getSpanId());
+      hash = (37 * hash) + DBNAME_FIELD_NUMBER;
+      hash = (53 * hash) + getDbname().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -367,6 +450,8 @@ public final class Server {
 
         spanId_ = 0L;
 
+        dbname_ = "";
+
         return this;
       }
 
@@ -395,6 +480,7 @@ public final class Server {
         io.greptime.v1.region.Server.RegionRequestHeader result = new io.greptime.v1.region.Server.RegionRequestHeader(this);
         result.traceId_ = traceId_;
         result.spanId_ = spanId_;
+        result.dbname_ = dbname_;
         onBuilt();
         return result;
       }
@@ -448,6 +534,10 @@ public final class Server {
         }
         if (other.getSpanId() != 0L) {
           setSpanId(other.getSpanId());
+        }
+        if (!other.getDbname().isEmpty()) {
+          dbname_ = other.dbname_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -560,6 +650,102 @@ public final class Server {
       public Builder clearSpanId() {
         
         spanId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object dbname_ = "";
+      /**
+       * <pre>
+       * DB Name of request, tracking only
+       * </pre>
+       *
+       * <code>string dbname = 3;</code>
+       * @return The dbname.
+       */
+      public java.lang.String getDbname() {
+        java.lang.Object ref = dbname_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          dbname_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * DB Name of request, tracking only
+       * </pre>
+       *
+       * <code>string dbname = 3;</code>
+       * @return The bytes for dbname.
+       */
+      public com.google.protobuf.ByteString
+          getDbnameBytes() {
+        java.lang.Object ref = dbname_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          dbname_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * DB Name of request, tracking only
+       * </pre>
+       *
+       * <code>string dbname = 3;</code>
+       * @param value The dbname to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDbname(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        dbname_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * DB Name of request, tracking only
+       * </pre>
+       *
+       * <code>string dbname = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearDbname() {
+        
+        dbname_ = getDefaultInstance().getDbname();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * DB Name of request, tracking only
+       * </pre>
+       *
+       * <code>string dbname = 3;</code>
+       * @param value The bytes for dbname to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDbnameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        dbname_ = value;
         onChanged();
         return this;
       }
@@ -18692,69 +18878,69 @@ java.lang.String defaultValue);
       "\n\037greptime/v1/region/server.proto\022\022grept" +
       "ime.v1.region\032\030greptime/v1/common.proto\032" +
       "\025greptime/v1/row.proto\032\025greptime/v1/ddl." +
-      "proto\"8\n\023RegionRequestHeader\022\020\n\010trace_id" +
-      "\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004\"\336\004\n\rRegionReques" +
-      "t\0227\n\006header\030\001 \001(\0132\'.greptime.v1.region.R" +
-      "egionRequestHeader\0225\n\007inserts\030\003 \001(\0132\".gr" +
-      "eptime.v1.region.InsertRequestsH\000\0225\n\007del" +
-      "etes\030\004 \001(\0132\".greptime.v1.region.DeleteRe" +
-      "questsH\000\0223\n\006create\030\005 \001(\0132!.greptime.v1.r" +
-      "egion.CreateRequestH\000\022/\n\004drop\030\006 \001(\0132\037.gr" +
-      "eptime.v1.region.DropRequestH\000\022/\n\004open\030\007" +
-      " \001(\0132\037.greptime.v1.region.OpenRequestH\000\022" +
-      "1\n\005close\030\010 \001(\0132 .greptime.v1.region.Clos" +
-      "eRequestH\000\0221\n\005alter\030\t \001(\0132 .greptime.v1." +
-      "region.AlterRequestH\000\0221\n\005flush\030\n \001(\0132 .g" +
-      "reptime.v1.region.FlushRequestH\000\0225\n\007comp" +
-      "act\030\013 \001(\0132\".greptime.v1.region.CompactRe" +
-      "questH\000\0227\n\010truncate\030\014 \001(\0132#.greptime.v1." +
-      "region.TruncateRequestH\000B\006\n\004body\"T\n\016Regi" +
-      "onResponse\022+\n\006header\030\001 \001(\0132\033.greptime.v1" +
-      ".ResponseHeader\022\025\n\raffected_rows\030\002 \001(\004\"E" +
-      "\n\016InsertRequests\0223\n\010requests\030\001 \003(\0132!.gre" +
-      "ptime.v1.region.InsertRequest\"E\n\016DeleteR" +
-      "equests\0223\n\010requests\030\001 \003(\0132!.greptime.v1." +
-      "region.DeleteRequest\"C\n\rInsertRequest\022\021\n" +
-      "\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptim" +
-      "e.v1.Rows\"C\n\rDeleteRequest\022\021\n\tregion_id\030" +
-      "\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"h" +
-      "\n\014QueryRequest\0227\n\006header\030\001 \001(\0132\'.greptim" +
-      "e.v1.region.RegionRequestHeader\022\021\n\tregio" +
-      "n_id\030\002 \001(\004\022\014\n\004plan\030\003 \001(\014\"\200\002\n\rCreateReque" +
-      "st\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\0228\n" +
-      "\013column_defs\030\003 \003(\0132#.greptime.v1.region." +
-      "RegionColumnDef\022\023\n\013primary_key\030\004 \003(\r\022\014\n\004" +
-      "path\030\005 \001(\t\022?\n\007options\030\006 \003(\0132..greptime.v" +
-      "1.region.CreateRequest.OptionsEntry\032.\n\014O" +
-      "ptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:" +
-      "\0028\001\" \n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\255\001" +
-      "\n\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engi" +
-      "ne\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=\n\007options\030\004 \003(\0132" +
-      ",.greptime.v1.region.OpenRequest.Options" +
-      "Entry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005va" +
-      "lue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion_" +
-      "id\030\001 \001(\004\"\261\001\n\014AlterRequest\022\021\n\tregion_id\030\001" +
-      " \001(\004\0225\n\013add_columns\030\002 \001(\0132\036.greptime.v1." +
-      "region.AddColumnsH\000\0227\n\014drop_columns\030\003 \001(" +
-      "\0132\037.greptime.v1.region.DropColumnsH\000\022\026\n\016" +
-      "schema_version\030\004 \001(\004B\006\n\004kind\"@\n\nAddColum" +
-      "ns\0222\n\013add_columns\030\001 \003(\0132\035.greptime.v1.re" +
-      "gion.AddColumn\"C\n\013DropColumns\0224\n\014drop_co" +
-      "lumns\030\001 \003(\0132\036.greptime.v1.region.DropCol" +
-      "umn\"v\n\tAddColumn\0227\n\ncolumn_def\030\001 \001(\0132#.g" +
-      "reptime.v1.region.RegionColumnDef\0220\n\010loc" +
-      "ation\030\003 \001(\0132\036.greptime.v1.AddColumnLocat" +
-      "ion\"\032\n\nDropColumn\022\014\n\004name\030\001 \001(\t\"!\n\014Flush" +
-      "Request\022\021\n\tregion_id\030\001 \001(\004\"#\n\016CompactReq" +
-      "uest\022\021\n\tregion_id\030\001 \001(\004\"$\n\017TruncateReque" +
-      "st\022\021\n\tregion_id\030\001 \001(\004\"P\n\017RegionColumnDef" +
-      "\022*\n\ncolumn_def\030\001 \001(\0132\026.greptime.v1.Colum" +
-      "nDef\022\021\n\tcolumn_id\030\002 \001(\r2Y\n\006Region\022O\n\006Han" +
-      "dle\022!.greptime.v1.region.RegionRequest\032\"" +
-      ".greptime.v1.region.RegionResponseB]\n\025io" +
-      ".greptime.v1.regionB\006ServerZ<github.com/" +
-      "GreptimeTeam/greptime-proto/go/greptime/" +
-      "v1/regionb\006proto3"
+      "proto\"H\n\023RegionRequestHeader\022\020\n\010trace_id" +
+      "\030\001 \001(\004\022\017\n\007span_id\030\002 \001(\004\022\016\n\006dbname\030\003 \001(\t\"" +
+      "\336\004\n\rRegionRequest\0227\n\006header\030\001 \001(\0132\'.grep" +
+      "time.v1.region.RegionRequestHeader\0225\n\007in" +
+      "serts\030\003 \001(\0132\".greptime.v1.region.InsertR" +
+      "equestsH\000\0225\n\007deletes\030\004 \001(\0132\".greptime.v1" +
+      ".region.DeleteRequestsH\000\0223\n\006create\030\005 \001(\013" +
+      "2!.greptime.v1.region.CreateRequestH\000\022/\n" +
+      "\004drop\030\006 \001(\0132\037.greptime.v1.region.DropReq" +
+      "uestH\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1.regio" +
+      "n.OpenRequestH\000\0221\n\005close\030\010 \001(\0132 .greptim" +
+      "e.v1.region.CloseRequestH\000\0221\n\005alter\030\t \001(" +
+      "\0132 .greptime.v1.region.AlterRequestH\000\0221\n" +
+      "\005flush\030\n \001(\0132 .greptime.v1.region.FlushR" +
+      "equestH\000\0225\n\007compact\030\013 \001(\0132\".greptime.v1." +
+      "region.CompactRequestH\000\0227\n\010truncate\030\014 \001(" +
+      "\0132#.greptime.v1.region.TruncateRequestH\000" +
+      "B\006\n\004body\"T\n\016RegionResponse\022+\n\006header\030\001 \001" +
+      "(\0132\033.greptime.v1.ResponseHeader\022\025\n\raffec" +
+      "ted_rows\030\002 \001(\004\"E\n\016InsertRequests\0223\n\010requ" +
+      "ests\030\001 \003(\0132!.greptime.v1.region.InsertRe" +
+      "quest\"E\n\016DeleteRequests\0223\n\010requests\030\001 \003(" +
+      "\0132!.greptime.v1.region.DeleteRequest\"C\n\r" +
+      "InsertRequest\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows" +
+      "\030\002 \001(\0132\021.greptime.v1.Rows\"C\n\rDeleteReque" +
+      "st\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\0132\021.gr" +
+      "eptime.v1.Rows\"h\n\014QueryRequest\0227\n\006header" +
+      "\030\001 \001(\0132\'.greptime.v1.region.RegionReques" +
+      "tHeader\022\021\n\tregion_id\030\002 \001(\004\022\014\n\004plan\030\003 \001(\014" +
+      "\"\200\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n" +
+      "\006engine\030\002 \001(\t\0228\n\013column_defs\030\003 \003(\0132#.gre" +
+      "ptime.v1.region.RegionColumnDef\022\023\n\013prima" +
+      "ry_key\030\004 \003(\r\022\014\n\004path\030\005 \001(\t\022?\n\007options\030\006 " +
+      "\003(\0132..greptime.v1.region.CreateRequest.O" +
+      "ptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t" +
+      "\022\r\n\005value\030\002 \001(\t:\0028\001\" \n\013DropRequest\022\021\n\tre" +
+      "gion_id\030\001 \001(\004\"\255\001\n\013OpenRequest\022\021\n\tregion_" +
+      "id\030\001 \001(\004\022\016\n\006engine\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=" +
+      "\n\007options\030\004 \003(\0132,.greptime.v1.region.Ope" +
+      "nRequest.OptionsEntry\032.\n\014OptionsEntry\022\013\n" +
+      "\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"!\n\014CloseRe" +
+      "quest\022\021\n\tregion_id\030\001 \001(\004\"\261\001\n\014AlterReques" +
+      "t\022\021\n\tregion_id\030\001 \001(\004\0225\n\013add_columns\030\002 \001(" +
+      "\0132\036.greptime.v1.region.AddColumnsH\000\0227\n\014d" +
+      "rop_columns\030\003 \001(\0132\037.greptime.v1.region.D" +
+      "ropColumnsH\000\022\026\n\016schema_version\030\004 \001(\004B\006\n\004" +
+      "kind\"@\n\nAddColumns\0222\n\013add_columns\030\001 \003(\0132" +
+      "\035.greptime.v1.region.AddColumn\"C\n\013DropCo" +
+      "lumns\0224\n\014drop_columns\030\001 \003(\0132\036.greptime.v" +
+      "1.region.DropColumn\"v\n\tAddColumn\0227\n\ncolu" +
+      "mn_def\030\001 \001(\0132#.greptime.v1.region.Region" +
+      "ColumnDef\0220\n\010location\030\003 \001(\0132\036.greptime.v" +
+      "1.AddColumnLocation\"\032\n\nDropColumn\022\014\n\004nam" +
+      "e\030\001 \001(\t\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001" +
+      "(\004\"#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"" +
+      "$\n\017TruncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n" +
+      "\017RegionColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.g" +
+      "reptime.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2" +
+      "Y\n\006Region\022O\n\006Handle\022!.greptime.v1.region" +
+      ".RegionRequest\032\".greptime.v1.region.Regi" +
+      "onResponseB]\n\025io.greptime.v1.regionB\006Ser" +
+      "verZ<github.com/GreptimeTeam/greptime-pr" +
+      "oto/go/greptime/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -18768,7 +18954,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequestHeader_descriptor,
-        new java.lang.String[] { "TraceId", "SpanId", });
+        new java.lang.String[] { "TraceId", "SpanId", "Dbname", });
     internal_static_greptime_v1_region_RegionRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_greptime_v1_region_RegionRequest_fieldAccessorTable = new

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -31,6 +31,8 @@ message RegionRequestHeader {
   uint64 trace_id = 1;
   // SpanID of request
   uint64 span_id = 2;
+  // DB Name of request, tracking only
+  string dbname = 3;
 }
 
 message RegionRequest {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly adds `dbname` to region request header for tracing from frontend to datanode.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
