### PR TITLE
chore(deps): bump tonic, tonic-build and prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-prost = "0.11"
+prost = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
-tonic = "0.9"
+tonic = "0.10"
 
 [build-dependencies]
-tonic-build = "0.9"
+tonic-build = "0.10"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


bump
- tonic: `0.10`
- tonic-build: `0.10`
- prost: `0.12`

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
