### PR TITLE
chore: upgrade maven gpg plugin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -63,7 +63,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Failed to execute old maven gpg plugin, see https://github.com/GreptimeTeam/greptime-proto/actions/runs/6732265535/job/18298632332

The latest gpg plugin runs fine: https://github.com/GreptimeTeam/greptime-proto/actions/runs/6732444618

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
