### PR TITLE
feat(remote_wal): add wal options to region open/create request

### DIFF
--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -89,6 +89,8 @@ message CreateRequest {
   // Options of the created region.
   map<string, string> options = 6;
   // TODO: add partition def
+  // Wal Options of the created region.
+  map<string, string> wal_options = 7;
 }
 
 message DropRequest { uint64 region_id = 1; }
@@ -101,6 +103,8 @@ message OpenRequest {
   string path = 3;
   // Options of the opened region.
   map<string, string> options = 4;
+  // Wal Options of the opened region.
+  map<string, string> wal_options = 5;
 }
 
 message CloseRequest { uint64 region_id = 1; }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add wal options to region open and region create requests. 

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
