### PR TITLE
feat: update tonic to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
-tonic = "0.10"
+tonic = "0.11"
 
 [build-dependencies]
-tonic-build = "0.10"
+tonic-build = "0.11"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Use tonic 0.11

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
