### PR TITLE
refactor: replace `sink_table_id` with `sink_table_name`

### DIFF
--- a/c++/greptime/v1/flow/server.pb.cc
+++ b/c++/greptime/v1/flow/server.pb.cc
@@ -110,7 +110,7 @@ PROTOBUF_CONSTEXPR CreateRequest::CreateRequest(
   , /*decltype(_impl_.comment_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.sql_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.task_id_)*/nullptr
-  , /*decltype(_impl_.sink_table_id_)*/nullptr
+  , /*decltype(_impl_.sink_table_name_)*/nullptr
   , /*decltype(_impl_.create_if_not_exists_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct CreateRequestDefaultTypeInternal {
@@ -218,7 +218,7 @@ const uint32_t TableStruct_greptime_2fv1_2fflow_2fserver_2eproto::offsets[] PROT
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.task_id_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.source_table_ids_),
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.sink_table_id_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.sink_table_name_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.create_if_not_exists_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.expire_when_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::flow::CreateRequest, _impl_.comment_),
@@ -279,25 +279,26 @@ const char descriptor_table_protodef_greptime_2fv1_2fflow_2fserver_2eproto[] PRO
   "on\030\003 \003(\0132-.greptime.v1.flow.FlowResponse"
   ".ExtensionEntry\0220\n\016affected_tasks\030\004 \003(\0132"
   "\030.greptime.v1.flow.TaskId\0320\n\016ExtensionEn"
-  "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"\344\002\n\r"
+  "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"\350\002\n\r"
   "CreateRequest\022)\n\007task_id\030\001 \001(\0132\030.greptim"
   "e.v1.flow.TaskId\022.\n\020source_table_ids\030\002 \003"
-  "(\0132\024.greptime.v1.TableId\022+\n\rsink_table_i"
-  "d\030\003 \001(\0132\024.greptime.v1.TableId\022\034\n\024create_"
-  "if_not_exists\030\004 \001(\010\022\023\n\013expire_when\030\005 \001(\t"
-  "\022\017\n\007comment\030\006 \001(\t\022\013\n\003sql\030\007 \001(\t\022F\n\014task_o"
-  "ptions\030\010 \003(\01320.greptime.v1.flow.CreateRe"
-  "quest.TaskOptionsEntry\0322\n\020TaskOptionsEnt"
-  "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\":\n\rRe"
-  "moveRequest\022)\n\007task_id\030\001 \001(\0132\030.greptime."
-  "v1.flow.TaskId\"\024\n\006TaskId\022\n\n\002id\030\001 \001(\r2\264\001\n"
-  "\004Flow\022S\n\022HandleCreateRemove\022\035.greptime.v"
-  "1.flow.FlowRequest\032\036.greptime.v1.flow.Fl"
-  "owResponse\022W\n\023HandleMirrorRequest\022 .grep"
-  "time.v1.flow.InsertRequests\032\036.greptime.v"
-  "1.flow.FlowResponseBY\n\023io.greptime.v1.fl"
-  "owB\006ServerZ:github.com/GreptimeTeam/grep"
-  "time-proto/go/greptime/v1/flowb\006proto3"
+  "(\0132\024.greptime.v1.TableId\022/\n\017sink_table_n"
+  "ame\030\003 \001(\0132\026.greptime.v1.TableName\022\034\n\024cre"
+  "ate_if_not_exists\030\004 \001(\010\022\023\n\013expire_when\030\005"
+  " \001(\t\022\017\n\007comment\030\006 \001(\t\022\013\n\003sql\030\007 \001(\t\022F\n\014ta"
+  "sk_options\030\010 \003(\01320.greptime.v1.flow.Crea"
+  "teRequest.TaskOptionsEntry\0322\n\020TaskOption"
+  "sEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\":"
+  "\n\rRemoveRequest\022)\n\007task_id\030\001 \001(\0132\030.grept"
+  "ime.v1.flow.TaskId\"\024\n\006TaskId\022\n\n\002id\030\001 \001(\r"
+  "2\264\001\n\004Flow\022S\n\022HandleCreateRemove\022\035.grepti"
+  "me.v1.flow.FlowRequest\032\036.greptime.v1.flo"
+  "w.FlowResponse\022W\n\023HandleMirrorRequest\022 ."
+  "greptime.v1.flow.InsertRequests\032\036.grepti"
+  "me.v1.flow.FlowResponseBY\n\023io.greptime.v"
+  "1.flowB\006ServerZ:github.com/GreptimeTeam/"
+  "greptime-proto/go/greptime/v1/flowb\006prot"
+  "o3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fflow_2fserver_2eproto_deps[3] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -306,7 +307,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fflo
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fflow_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fflow_2fserver_2eproto = {
-    false, false, 1358, descriptor_table_protodef_greptime_2fv1_2fflow_2fserver_2eproto,
+    false, false, 1362, descriptor_table_protodef_greptime_2fv1_2fflow_2fserver_2eproto,
     "greptime/v1/flow/server.proto",
     &descriptor_table_greptime_2fv1_2fflow_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fflow_2fserver_2eproto_deps, 3, 9,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fflow_2fserver_2eproto::offsets,
@@ -1404,25 +1405,25 @@ void CreateRequest_TaskOptionsEntry_DoNotUse::MergeFrom(const CreateRequest_Task
 class CreateRequest::_Internal {
  public:
   static const ::greptime::v1::flow::TaskId& task_id(const CreateRequest* msg);
-  static const ::greptime::v1::TableId& sink_table_id(const CreateRequest* msg);
+  static const ::greptime::v1::TableName& sink_table_name(const CreateRequest* msg);
 };
 
 const ::greptime::v1::flow::TaskId&
 CreateRequest::_Internal::task_id(const CreateRequest* msg) {
   return *msg->_impl_.task_id_;
 }
-const ::greptime::v1::TableId&
-CreateRequest::_Internal::sink_table_id(const CreateRequest* msg) {
-  return *msg->_impl_.sink_table_id_;
+const ::greptime::v1::TableName&
+CreateRequest::_Internal::sink_table_name(const CreateRequest* msg) {
+  return *msg->_impl_.sink_table_name_;
 }
 void CreateRequest::clear_source_table_ids() {
   _impl_.source_table_ids_.Clear();
 }
-void CreateRequest::clear_sink_table_id() {
-  if (GetArenaForAllocation() == nullptr && _impl_.sink_table_id_ != nullptr) {
-    delete _impl_.sink_table_id_;
+void CreateRequest::clear_sink_table_name() {
+  if (GetArenaForAllocation() == nullptr && _impl_.sink_table_name_ != nullptr) {
+    delete _impl_.sink_table_name_;
   }
-  _impl_.sink_table_id_ = nullptr;
+  _impl_.sink_table_name_ = nullptr;
 }
 CreateRequest::CreateRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
@@ -1443,7 +1444,7 @@ CreateRequest::CreateRequest(const CreateRequest& from)
     , decltype(_impl_.comment_){}
     , decltype(_impl_.sql_){}
     , decltype(_impl_.task_id_){nullptr}
-    , decltype(_impl_.sink_table_id_){nullptr}
+    , decltype(_impl_.sink_table_name_){nullptr}
     , decltype(_impl_.create_if_not_exists_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
@@ -1476,8 +1477,8 @@ CreateRequest::CreateRequest(const CreateRequest& from)
   if (from._internal_has_task_id()) {
     _this->_impl_.task_id_ = new ::greptime::v1::flow::TaskId(*from._impl_.task_id_);
   }
-  if (from._internal_has_sink_table_id()) {
-    _this->_impl_.sink_table_id_ = new ::greptime::v1::TableId(*from._impl_.sink_table_id_);
+  if (from._internal_has_sink_table_name()) {
+    _this->_impl_.sink_table_name_ = new ::greptime::v1::TableName(*from._impl_.sink_table_name_);
   }
   _this->_impl_.create_if_not_exists_ = from._impl_.create_if_not_exists_;
   // @@protoc_insertion_point(copy_constructor:greptime.v1.flow.CreateRequest)
@@ -1494,7 +1495,7 @@ inline void CreateRequest::SharedCtor(
     , decltype(_impl_.comment_){}
     , decltype(_impl_.sql_){}
     , decltype(_impl_.task_id_){nullptr}
-    , decltype(_impl_.sink_table_id_){nullptr}
+    , decltype(_impl_.sink_table_name_){nullptr}
     , decltype(_impl_.create_if_not_exists_){false}
     , /*decltype(_impl_._cached_size_)*/{}
   };
@@ -1531,7 +1532,7 @@ inline void CreateRequest::SharedDtor() {
   _impl_.comment_.Destroy();
   _impl_.sql_.Destroy();
   if (this != internal_default_instance()) delete _impl_.task_id_;
-  if (this != internal_default_instance()) delete _impl_.sink_table_id_;
+  if (this != internal_default_instance()) delete _impl_.sink_table_name_;
 }
 
 void CreateRequest::ArenaDtor(void* object) {
@@ -1557,10 +1558,10 @@ void CreateRequest::Clear() {
     delete _impl_.task_id_;
   }
   _impl_.task_id_ = nullptr;
-  if (GetArenaForAllocation() == nullptr && _impl_.sink_table_id_ != nullptr) {
-    delete _impl_.sink_table_id_;
+  if (GetArenaForAllocation() == nullptr && _impl_.sink_table_name_ != nullptr) {
+    delete _impl_.sink_table_name_;
   }
-  _impl_.sink_table_id_ = nullptr;
+  _impl_.sink_table_name_ = nullptr;
   _impl_.create_if_not_exists_ = false;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
@@ -1592,10 +1593,10 @@ const char* CreateRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext*
         } else
           goto handle_unusual;
         continue;
-      // .greptime.v1.TableId sink_table_id = 3;
+      // .greptime.v1.TableName sink_table_name = 3;
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
-          ptr = ctx->ParseMessage(_internal_mutable_sink_table_id(), ptr);
+          ptr = ctx->ParseMessage(_internal_mutable_sink_table_name(), ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -1695,11 +1696,11 @@ uint8_t* CreateRequest::_InternalSerialize(
         InternalWriteMessage(2, repfield, repfield.GetCachedSize(), target, stream);
   }
 
-  // .greptime.v1.TableId sink_table_id = 3;
-  if (this->_internal_has_sink_table_id()) {
+  // .greptime.v1.TableName sink_table_name = 3;
+  if (this->_internal_has_sink_table_name()) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-      InternalWriteMessage(3, _Internal::sink_table_id(this),
-        _Internal::sink_table_id(this).GetCachedSize(), target, stream);
+      InternalWriteMessage(3, _Internal::sink_table_name(this),
+        _Internal::sink_table_name(this).GetCachedSize(), target, stream);
   }
 
   // bool create_if_not_exists = 4;
@@ -1828,11 +1829,11 @@ size_t CreateRequest::ByteSizeLong() const {
         *_impl_.task_id_);
   }
 
-  // .greptime.v1.TableId sink_table_id = 3;
-  if (this->_internal_has_sink_table_id()) {
+  // .greptime.v1.TableName sink_table_name = 3;
+  if (this->_internal_has_sink_table_name()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *_impl_.sink_table_id_);
+        *_impl_.sink_table_name_);
   }
 
   // bool create_if_not_exists = 4;
@@ -1873,9 +1874,9 @@ void CreateRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
     _this->_internal_mutable_task_id()->::greptime::v1::flow::TaskId::MergeFrom(
         from._internal_task_id());
   }
-  if (from._internal_has_sink_table_id()) {
-    _this->_internal_mutable_sink_table_id()->::greptime::v1::TableId::MergeFrom(
-        from._internal_sink_table_id());
+  if (from._internal_has_sink_table_name()) {
+    _this->_internal_mutable_sink_table_name()->::greptime::v1::TableName::MergeFrom(
+        from._internal_sink_table_name());
   }
   if (from._internal_create_if_not_exists() != 0) {
     _this->_internal_set_create_if_not_exists(from._internal_create_if_not_exists());

--- a/c++/greptime/v1/flow/server.pb.h
+++ b/c++/greptime/v1/flow/server.pb.h
@@ -1019,7 +1019,7 @@ class CreateRequest final :
     kCommentFieldNumber = 6,
     kSqlFieldNumber = 7,
     kTaskIdFieldNumber = 1,
-    kSinkTableIdFieldNumber = 3,
+    kSinkTableNameFieldNumber = 3,
     kCreateIfNotExistsFieldNumber = 4,
   };
   // repeated .greptime.v1.TableId source_table_ids = 2;
@@ -1117,23 +1117,23 @@ class CreateRequest final :
       ::greptime::v1::flow::TaskId* task_id);
   ::greptime::v1::flow::TaskId* unsafe_arena_release_task_id();
 
-  // .greptime.v1.TableId sink_table_id = 3;
-  bool has_sink_table_id() const;
+  // .greptime.v1.TableName sink_table_name = 3;
+  bool has_sink_table_name() const;
   private:
-  bool _internal_has_sink_table_id() const;
+  bool _internal_has_sink_table_name() const;
   public:
-  void clear_sink_table_id();
-  const ::greptime::v1::TableId& sink_table_id() const;
-  PROTOBUF_NODISCARD ::greptime::v1::TableId* release_sink_table_id();
-  ::greptime::v1::TableId* mutable_sink_table_id();
-  void set_allocated_sink_table_id(::greptime::v1::TableId* sink_table_id);
+  void clear_sink_table_name();
+  const ::greptime::v1::TableName& sink_table_name() const;
+  PROTOBUF_NODISCARD ::greptime::v1::TableName* release_sink_table_name();
+  ::greptime::v1::TableName* mutable_sink_table_name();
+  void set_allocated_sink_table_name(::greptime::v1::TableName* sink_table_name);
   private:
-  const ::greptime::v1::TableId& _internal_sink_table_id() const;
-  ::greptime::v1::TableId* _internal_mutable_sink_table_id();
+  const ::greptime::v1::TableName& _internal_sink_table_name() const;
+  ::greptime::v1::TableName* _internal_mutable_sink_table_name();
   public:
-  void unsafe_arena_set_allocated_sink_table_id(
-      ::greptime::v1::TableId* sink_table_id);
-  ::greptime::v1::TableId* unsafe_arena_release_sink_table_id();
+  void unsafe_arena_set_allocated_sink_table_name(
+      ::greptime::v1::TableName* sink_table_name);
+  ::greptime::v1::TableName* unsafe_arena_release_sink_table_name();
 
   // bool create_if_not_exists = 4;
   void clear_create_if_not_exists();
@@ -1162,7 +1162,7 @@ class CreateRequest final :
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr comment_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr sql_;
     ::greptime::v1::flow::TaskId* task_id_;
-    ::greptime::v1::TableId* sink_table_id_;
+    ::greptime::v1::TableName* sink_table_name_;
     bool create_if_not_exists_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
@@ -2108,39 +2108,39 @@ CreateRequest::source_table_ids() const {
   return _impl_.source_table_ids_;
 }
 
-// .greptime.v1.TableId sink_table_id = 3;
-inline bool CreateRequest::_internal_has_sink_table_id() const {
-  return this != internal_default_instance() && _impl_.sink_table_id_ != nullptr;
+// .greptime.v1.TableName sink_table_name = 3;
+inline bool CreateRequest::_internal_has_sink_table_name() const {
+  return this != internal_default_instance() && _impl_.sink_table_name_ != nullptr;
 }
-inline bool CreateRequest::has_sink_table_id() const {
-  return _internal_has_sink_table_id();
+inline bool CreateRequest::has_sink_table_name() const {
+  return _internal_has_sink_table_name();
 }
-inline const ::greptime::v1::TableId& CreateRequest::_internal_sink_table_id() const {
-  const ::greptime::v1::TableId* p = _impl_.sink_table_id_;
-  return p != nullptr ? *p : reinterpret_cast<const ::greptime::v1::TableId&>(
-      ::greptime::v1::_TableId_default_instance_);
+inline const ::greptime::v1::TableName& CreateRequest::_internal_sink_table_name() const {
+  const ::greptime::v1::TableName* p = _impl_.sink_table_name_;
+  return p != nullptr ? *p : reinterpret_cast<const ::greptime::v1::TableName&>(
+      ::greptime::v1::_TableName_default_instance_);
 }
-inline const ::greptime::v1::TableId& CreateRequest::sink_table_id() const {
-  // @@protoc_insertion_point(field_get:greptime.v1.flow.CreateRequest.sink_table_id)
-  return _internal_sink_table_id();
+inline const ::greptime::v1::TableName& CreateRequest::sink_table_name() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.flow.CreateRequest.sink_table_name)
+  return _internal_sink_table_name();
 }
-inline void CreateRequest::unsafe_arena_set_allocated_sink_table_id(
-    ::greptime::v1::TableId* sink_table_id) {
+inline void CreateRequest::unsafe_arena_set_allocated_sink_table_name(
+    ::greptime::v1::TableName* sink_table_name) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.sink_table_id_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.sink_table_name_);
   }
-  _impl_.sink_table_id_ = sink_table_id;
-  if (sink_table_id) {
+  _impl_.sink_table_name_ = sink_table_name;
+  if (sink_table_name) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.flow.CreateRequest.sink_table_id)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.flow.CreateRequest.sink_table_name)
 }
-inline ::greptime::v1::TableId* CreateRequest::release_sink_table_id() {
+inline ::greptime::v1::TableName* CreateRequest::release_sink_table_name() {
   
-  ::greptime::v1::TableId* temp = _impl_.sink_table_id_;
-  _impl_.sink_table_id_ = nullptr;
+  ::greptime::v1::TableName* temp = _impl_.sink_table_name_;
+  _impl_.sink_table_name_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -2152,45 +2152,45 @@ inline ::greptime::v1::TableId* CreateRequest::release_sink_table_id() {
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::greptime::v1::TableId* CreateRequest::unsafe_arena_release_sink_table_id() {
-  // @@protoc_insertion_point(field_release:greptime.v1.flow.CreateRequest.sink_table_id)
+inline ::greptime::v1::TableName* CreateRequest::unsafe_arena_release_sink_table_name() {
+  // @@protoc_insertion_point(field_release:greptime.v1.flow.CreateRequest.sink_table_name)
   
-  ::greptime::v1::TableId* temp = _impl_.sink_table_id_;
-  _impl_.sink_table_id_ = nullptr;
+  ::greptime::v1::TableName* temp = _impl_.sink_table_name_;
+  _impl_.sink_table_name_ = nullptr;
   return temp;
 }
-inline ::greptime::v1::TableId* CreateRequest::_internal_mutable_sink_table_id() {
+inline ::greptime::v1::TableName* CreateRequest::_internal_mutable_sink_table_name() {
   
-  if (_impl_.sink_table_id_ == nullptr) {
-    auto* p = CreateMaybeMessage<::greptime::v1::TableId>(GetArenaForAllocation());
-    _impl_.sink_table_id_ = p;
+  if (_impl_.sink_table_name_ == nullptr) {
+    auto* p = CreateMaybeMessage<::greptime::v1::TableName>(GetArenaForAllocation());
+    _impl_.sink_table_name_ = p;
   }
-  return _impl_.sink_table_id_;
+  return _impl_.sink_table_name_;
 }
-inline ::greptime::v1::TableId* CreateRequest::mutable_sink_table_id() {
-  ::greptime::v1::TableId* _msg = _internal_mutable_sink_table_id();
-  // @@protoc_insertion_point(field_mutable:greptime.v1.flow.CreateRequest.sink_table_id)
+inline ::greptime::v1::TableName* CreateRequest::mutable_sink_table_name() {
+  ::greptime::v1::TableName* _msg = _internal_mutable_sink_table_name();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.flow.CreateRequest.sink_table_name)
   return _msg;
 }
-inline void CreateRequest::set_allocated_sink_table_id(::greptime::v1::TableId* sink_table_id) {
+inline void CreateRequest::set_allocated_sink_table_name(::greptime::v1::TableName* sink_table_name) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.sink_table_id_);
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.sink_table_name_);
   }
-  if (sink_table_id) {
+  if (sink_table_name) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
         ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(
-                reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(sink_table_id));
+                reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(sink_table_name));
     if (message_arena != submessage_arena) {
-      sink_table_id = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, sink_table_id, submessage_arena);
+      sink_table_name = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, sink_table_name, submessage_arena);
     }
     
   } else {
     
   }
-  _impl_.sink_table_id_ = sink_table_id;
-  // @@protoc_insertion_point(field_set_allocated:greptime.v1.flow.CreateRequest.sink_table_id)
+  _impl_.sink_table_name_ = sink_table_name;
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.flow.CreateRequest.sink_table_name)
 }
 
 // bool create_if_not_exists = 4;

--- a/java/src/main/java/io/greptime/v1/flow/Server.java
+++ b/java/src/main/java/io/greptime/v1/flow/Server.java
@@ -4001,19 +4001,19 @@ com.google.protobuf.ByteString defaultValue);
         int index);
 
     /**
-     * <code>.greptime.v1.TableId sink_table_id = 3;</code>
-     * @return Whether the sinkTableId field is set.
+     * <code>.greptime.v1.TableName sink_table_name = 3;</code>
+     * @return Whether the sinkTableName field is set.
      */
-    boolean hasSinkTableId();
+    boolean hasSinkTableName();
     /**
-     * <code>.greptime.v1.TableId sink_table_id = 3;</code>
-     * @return The sinkTableId.
+     * <code>.greptime.v1.TableName sink_table_name = 3;</code>
+     * @return The sinkTableName.
      */
-    io.greptime.v1.Ddl.TableId getSinkTableId();
+    io.greptime.v1.Common.TableName getSinkTableName();
     /**
-     * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+     * <code>.greptime.v1.TableName sink_table_name = 3;</code>
      */
-    io.greptime.v1.Ddl.TableIdOrBuilder getSinkTableIdOrBuilder();
+    io.greptime.v1.Common.TableNameOrBuilder getSinkTableNameOrBuilder();
 
     /**
      * <code>bool create_if_not_exists = 4;</code>
@@ -4095,7 +4095,10 @@ java.lang.String defaultValue);
   }
   /**
    * <pre>
-   * very similar to `ddl.CreateTaskExpr` just replace `task_name` with `task_id`
+   * Create a flow task
+   * 
+   * Very similar to `ddl.CreateTaskExpr`, 
+   * replace `source_table_names` with `source_table_ids`
    * </pre>
    *
    * Protobuf type {@code greptime.v1.flow.CreateRequest}
@@ -4170,14 +4173,14 @@ java.lang.String defaultValue);
               break;
             }
             case 26: {
-              io.greptime.v1.Ddl.TableId.Builder subBuilder = null;
-              if (sinkTableId_ != null) {
-                subBuilder = sinkTableId_.toBuilder();
+              io.greptime.v1.Common.TableName.Builder subBuilder = null;
+              if (sinkTableName_ != null) {
+                subBuilder = sinkTableName_.toBuilder();
               }
-              sinkTableId_ = input.readMessage(io.greptime.v1.Ddl.TableId.parser(), extensionRegistry);
+              sinkTableName_ = input.readMessage(io.greptime.v1.Common.TableName.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(sinkTableId_);
-                sinkTableId_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(sinkTableName_);
+                sinkTableName_ = subBuilder.buildPartial();
               }
 
               break;
@@ -4333,30 +4336,30 @@ java.lang.String defaultValue);
       return sourceTableIds_.get(index);
     }
 
-    public static final int SINK_TABLE_ID_FIELD_NUMBER = 3;
-    private io.greptime.v1.Ddl.TableId sinkTableId_;
+    public static final int SINK_TABLE_NAME_FIELD_NUMBER = 3;
+    private io.greptime.v1.Common.TableName sinkTableName_;
     /**
-     * <code>.greptime.v1.TableId sink_table_id = 3;</code>
-     * @return Whether the sinkTableId field is set.
+     * <code>.greptime.v1.TableName sink_table_name = 3;</code>
+     * @return Whether the sinkTableName field is set.
      */
     @java.lang.Override
-    public boolean hasSinkTableId() {
-      return sinkTableId_ != null;
+    public boolean hasSinkTableName() {
+      return sinkTableName_ != null;
     }
     /**
-     * <code>.greptime.v1.TableId sink_table_id = 3;</code>
-     * @return The sinkTableId.
+     * <code>.greptime.v1.TableName sink_table_name = 3;</code>
+     * @return The sinkTableName.
      */
     @java.lang.Override
-    public io.greptime.v1.Ddl.TableId getSinkTableId() {
-      return sinkTableId_ == null ? io.greptime.v1.Ddl.TableId.getDefaultInstance() : sinkTableId_;
+    public io.greptime.v1.Common.TableName getSinkTableName() {
+      return sinkTableName_ == null ? io.greptime.v1.Common.TableName.getDefaultInstance() : sinkTableName_;
     }
     /**
-     * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+     * <code>.greptime.v1.TableName sink_table_name = 3;</code>
      */
     @java.lang.Override
-    public io.greptime.v1.Ddl.TableIdOrBuilder getSinkTableIdOrBuilder() {
-      return getSinkTableId();
+    public io.greptime.v1.Common.TableNameOrBuilder getSinkTableNameOrBuilder() {
+      return getSinkTableName();
     }
 
     public static final int CREATE_IF_NOT_EXISTS_FIELD_NUMBER = 4;
@@ -4585,8 +4588,8 @@ java.lang.String defaultValue);
       for (int i = 0; i < sourceTableIds_.size(); i++) {
         output.writeMessage(2, sourceTableIds_.get(i));
       }
-      if (sinkTableId_ != null) {
-        output.writeMessage(3, getSinkTableId());
+      if (sinkTableName_ != null) {
+        output.writeMessage(3, getSinkTableName());
       }
       if (createIfNotExists_ != false) {
         output.writeBool(4, createIfNotExists_);
@@ -4623,9 +4626,9 @@ java.lang.String defaultValue);
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, sourceTableIds_.get(i));
       }
-      if (sinkTableId_ != null) {
+      if (sinkTableName_ != null) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, getSinkTableId());
+          .computeMessageSize(3, getSinkTableName());
       }
       if (createIfNotExists_ != false) {
         size += com.google.protobuf.CodedOutputStream
@@ -4672,10 +4675,10 @@ java.lang.String defaultValue);
       }
       if (!getSourceTableIdsList()
           .equals(other.getSourceTableIdsList())) return false;
-      if (hasSinkTableId() != other.hasSinkTableId()) return false;
-      if (hasSinkTableId()) {
-        if (!getSinkTableId()
-            .equals(other.getSinkTableId())) return false;
+      if (hasSinkTableName() != other.hasSinkTableName()) return false;
+      if (hasSinkTableName()) {
+        if (!getSinkTableName()
+            .equals(other.getSinkTableName())) return false;
       }
       if (getCreateIfNotExists()
           != other.getCreateIfNotExists()) return false;
@@ -4706,9 +4709,9 @@ java.lang.String defaultValue);
         hash = (37 * hash) + SOURCE_TABLE_IDS_FIELD_NUMBER;
         hash = (53 * hash) + getSourceTableIdsList().hashCode();
       }
-      if (hasSinkTableId()) {
-        hash = (37 * hash) + SINK_TABLE_ID_FIELD_NUMBER;
-        hash = (53 * hash) + getSinkTableId().hashCode();
+      if (hasSinkTableName()) {
+        hash = (37 * hash) + SINK_TABLE_NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getSinkTableName().hashCode();
       }
       hash = (37 * hash) + CREATE_IF_NOT_EXISTS_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
@@ -4820,7 +4823,10 @@ java.lang.String defaultValue);
     }
     /**
      * <pre>
-     * very similar to `ddl.CreateTaskExpr` just replace `task_name` with `task_id`
+     * Create a flow task
+     * 
+     * Very similar to `ddl.CreateTaskExpr`, 
+     * replace `source_table_names` with `source_table_ids`
      * </pre>
      *
      * Protobuf type {@code greptime.v1.flow.CreateRequest}
@@ -4895,11 +4901,11 @@ java.lang.String defaultValue);
         } else {
           sourceTableIdsBuilder_.clear();
         }
-        if (sinkTableIdBuilder_ == null) {
-          sinkTableId_ = null;
+        if (sinkTableNameBuilder_ == null) {
+          sinkTableName_ = null;
         } else {
-          sinkTableId_ = null;
-          sinkTableIdBuilder_ = null;
+          sinkTableName_ = null;
+          sinkTableNameBuilder_ = null;
         }
         createIfNotExists_ = false;
 
@@ -4951,10 +4957,10 @@ java.lang.String defaultValue);
         } else {
           result.sourceTableIds_ = sourceTableIdsBuilder_.build();
         }
-        if (sinkTableIdBuilder_ == null) {
-          result.sinkTableId_ = sinkTableId_;
+        if (sinkTableNameBuilder_ == null) {
+          result.sinkTableName_ = sinkTableName_;
         } else {
-          result.sinkTableId_ = sinkTableIdBuilder_.build();
+          result.sinkTableName_ = sinkTableNameBuilder_.build();
         }
         result.createIfNotExists_ = createIfNotExists_;
         result.expireWhen_ = expireWhen_;
@@ -5039,8 +5045,8 @@ java.lang.String defaultValue);
             }
           }
         }
-        if (other.hasSinkTableId()) {
-          mergeSinkTableId(other.getSinkTableId());
+        if (other.hasSinkTableName()) {
+          mergeSinkTableName(other.getSinkTableName());
         }
         if (other.getCreateIfNotExists() != false) {
           setCreateIfNotExists(other.getCreateIfNotExists());
@@ -5448,123 +5454,123 @@ java.lang.String defaultValue);
         return sourceTableIdsBuilder_;
       }
 
-      private io.greptime.v1.Ddl.TableId sinkTableId_;
+      private io.greptime.v1.Common.TableName sinkTableName_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          io.greptime.v1.Ddl.TableId, io.greptime.v1.Ddl.TableId.Builder, io.greptime.v1.Ddl.TableIdOrBuilder> sinkTableIdBuilder_;
+          io.greptime.v1.Common.TableName, io.greptime.v1.Common.TableName.Builder, io.greptime.v1.Common.TableNameOrBuilder> sinkTableNameBuilder_;
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
-       * @return Whether the sinkTableId field is set.
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
+       * @return Whether the sinkTableName field is set.
        */
-      public boolean hasSinkTableId() {
-        return sinkTableIdBuilder_ != null || sinkTableId_ != null;
+      public boolean hasSinkTableName() {
+        return sinkTableNameBuilder_ != null || sinkTableName_ != null;
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
-       * @return The sinkTableId.
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
+       * @return The sinkTableName.
        */
-      public io.greptime.v1.Ddl.TableId getSinkTableId() {
-        if (sinkTableIdBuilder_ == null) {
-          return sinkTableId_ == null ? io.greptime.v1.Ddl.TableId.getDefaultInstance() : sinkTableId_;
+      public io.greptime.v1.Common.TableName getSinkTableName() {
+        if (sinkTableNameBuilder_ == null) {
+          return sinkTableName_ == null ? io.greptime.v1.Common.TableName.getDefaultInstance() : sinkTableName_;
         } else {
-          return sinkTableIdBuilder_.getMessage();
+          return sinkTableNameBuilder_.getMessage();
         }
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
-      public Builder setSinkTableId(io.greptime.v1.Ddl.TableId value) {
-        if (sinkTableIdBuilder_ == null) {
+      public Builder setSinkTableName(io.greptime.v1.Common.TableName value) {
+        if (sinkTableNameBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          sinkTableId_ = value;
+          sinkTableName_ = value;
           onChanged();
         } else {
-          sinkTableIdBuilder_.setMessage(value);
+          sinkTableNameBuilder_.setMessage(value);
         }
 
         return this;
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
-      public Builder setSinkTableId(
-          io.greptime.v1.Ddl.TableId.Builder builderForValue) {
-        if (sinkTableIdBuilder_ == null) {
-          sinkTableId_ = builderForValue.build();
+      public Builder setSinkTableName(
+          io.greptime.v1.Common.TableName.Builder builderForValue) {
+        if (sinkTableNameBuilder_ == null) {
+          sinkTableName_ = builderForValue.build();
           onChanged();
         } else {
-          sinkTableIdBuilder_.setMessage(builderForValue.build());
+          sinkTableNameBuilder_.setMessage(builderForValue.build());
         }
 
         return this;
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
-      public Builder mergeSinkTableId(io.greptime.v1.Ddl.TableId value) {
-        if (sinkTableIdBuilder_ == null) {
-          if (sinkTableId_ != null) {
-            sinkTableId_ =
-              io.greptime.v1.Ddl.TableId.newBuilder(sinkTableId_).mergeFrom(value).buildPartial();
+      public Builder mergeSinkTableName(io.greptime.v1.Common.TableName value) {
+        if (sinkTableNameBuilder_ == null) {
+          if (sinkTableName_ != null) {
+            sinkTableName_ =
+              io.greptime.v1.Common.TableName.newBuilder(sinkTableName_).mergeFrom(value).buildPartial();
           } else {
-            sinkTableId_ = value;
+            sinkTableName_ = value;
           }
           onChanged();
         } else {
-          sinkTableIdBuilder_.mergeFrom(value);
+          sinkTableNameBuilder_.mergeFrom(value);
         }
 
         return this;
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
-      public Builder clearSinkTableId() {
-        if (sinkTableIdBuilder_ == null) {
-          sinkTableId_ = null;
+      public Builder clearSinkTableName() {
+        if (sinkTableNameBuilder_ == null) {
+          sinkTableName_ = null;
           onChanged();
         } else {
-          sinkTableId_ = null;
-          sinkTableIdBuilder_ = null;
+          sinkTableName_ = null;
+          sinkTableNameBuilder_ = null;
         }
 
         return this;
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
-      public io.greptime.v1.Ddl.TableId.Builder getSinkTableIdBuilder() {
+      public io.greptime.v1.Common.TableName.Builder getSinkTableNameBuilder() {
         
         onChanged();
-        return getSinkTableIdFieldBuilder().getBuilder();
+        return getSinkTableNameFieldBuilder().getBuilder();
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
-      public io.greptime.v1.Ddl.TableIdOrBuilder getSinkTableIdOrBuilder() {
-        if (sinkTableIdBuilder_ != null) {
-          return sinkTableIdBuilder_.getMessageOrBuilder();
+      public io.greptime.v1.Common.TableNameOrBuilder getSinkTableNameOrBuilder() {
+        if (sinkTableNameBuilder_ != null) {
+          return sinkTableNameBuilder_.getMessageOrBuilder();
         } else {
-          return sinkTableId_ == null ?
-              io.greptime.v1.Ddl.TableId.getDefaultInstance() : sinkTableId_;
+          return sinkTableName_ == null ?
+              io.greptime.v1.Common.TableName.getDefaultInstance() : sinkTableName_;
         }
       }
       /**
-       * <code>.greptime.v1.TableId sink_table_id = 3;</code>
+       * <code>.greptime.v1.TableName sink_table_name = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          io.greptime.v1.Ddl.TableId, io.greptime.v1.Ddl.TableId.Builder, io.greptime.v1.Ddl.TableIdOrBuilder> 
-          getSinkTableIdFieldBuilder() {
-        if (sinkTableIdBuilder_ == null) {
-          sinkTableIdBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              io.greptime.v1.Ddl.TableId, io.greptime.v1.Ddl.TableId.Builder, io.greptime.v1.Ddl.TableIdOrBuilder>(
-                  getSinkTableId(),
+          io.greptime.v1.Common.TableName, io.greptime.v1.Common.TableName.Builder, io.greptime.v1.Common.TableNameOrBuilder> 
+          getSinkTableNameFieldBuilder() {
+        if (sinkTableNameBuilder_ == null) {
+          sinkTableNameBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              io.greptime.v1.Common.TableName, io.greptime.v1.Common.TableName.Builder, io.greptime.v1.Common.TableNameOrBuilder>(
+                  getSinkTableName(),
                   getParentForChildren(),
                   isClean());
-          sinkTableId_ = null;
+          sinkTableName_ = null;
         }
-        return sinkTableIdBuilder_;
+        return sinkTableNameBuilder_;
       }
 
       private boolean createIfNotExists_ ;
@@ -7191,25 +7197,26 @@ java.lang.String defaultValue);
       "on\030\003 \003(\0132-.greptime.v1.flow.FlowResponse" +
       ".ExtensionEntry\0220\n\016affected_tasks\030\004 \003(\0132" +
       "\030.greptime.v1.flow.TaskId\0320\n\016ExtensionEn" +
-      "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"\344\002\n\r" +
+      "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"\350\002\n\r" +
       "CreateRequest\022)\n\007task_id\030\001 \001(\0132\030.greptim" +
       "e.v1.flow.TaskId\022.\n\020source_table_ids\030\002 \003" +
-      "(\0132\024.greptime.v1.TableId\022+\n\rsink_table_i" +
-      "d\030\003 \001(\0132\024.greptime.v1.TableId\022\034\n\024create_" +
-      "if_not_exists\030\004 \001(\010\022\023\n\013expire_when\030\005 \001(\t" +
-      "\022\017\n\007comment\030\006 \001(\t\022\013\n\003sql\030\007 \001(\t\022F\n\014task_o" +
-      "ptions\030\010 \003(\01320.greptime.v1.flow.CreateRe" +
-      "quest.TaskOptionsEntry\0322\n\020TaskOptionsEnt" +
-      "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\":\n\rRe" +
-      "moveRequest\022)\n\007task_id\030\001 \001(\0132\030.greptime." +
-      "v1.flow.TaskId\"\024\n\006TaskId\022\n\n\002id\030\001 \001(\r2\264\001\n" +
-      "\004Flow\022S\n\022HandleCreateRemove\022\035.greptime.v" +
-      "1.flow.FlowRequest\032\036.greptime.v1.flow.Fl" +
-      "owResponse\022W\n\023HandleMirrorRequest\022 .grep" +
-      "time.v1.flow.InsertRequests\032\036.greptime.v" +
-      "1.flow.FlowResponseBY\n\023io.greptime.v1.fl" +
-      "owB\006ServerZ:github.com/GreptimeTeam/grep" +
-      "time-proto/go/greptime/v1/flowb\006proto3"
+      "(\0132\024.greptime.v1.TableId\022/\n\017sink_table_n" +
+      "ame\030\003 \001(\0132\026.greptime.v1.TableName\022\034\n\024cre" +
+      "ate_if_not_exists\030\004 \001(\010\022\023\n\013expire_when\030\005" +
+      " \001(\t\022\017\n\007comment\030\006 \001(\t\022\013\n\003sql\030\007 \001(\t\022F\n\014ta" +
+      "sk_options\030\010 \003(\01320.greptime.v1.flow.Crea" +
+      "teRequest.TaskOptionsEntry\0322\n\020TaskOption" +
+      "sEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\":" +
+      "\n\rRemoveRequest\022)\n\007task_id\030\001 \001(\0132\030.grept" +
+      "ime.v1.flow.TaskId\"\024\n\006TaskId\022\n\n\002id\030\001 \001(\r" +
+      "2\264\001\n\004Flow\022S\n\022HandleCreateRemove\022\035.grepti" +
+      "me.v1.flow.FlowRequest\032\036.greptime.v1.flo" +
+      "w.FlowResponse\022W\n\023HandleMirrorRequest\022 ." +
+      "greptime.v1.flow.InsertRequests\032\036.grepti" +
+      "me.v1.flow.FlowResponseBY\n\023io.greptime.v" +
+      "1.flowB\006ServerZ:github.com/GreptimeTeam/" +
+      "greptime-proto/go/greptime/v1/flowb\006prot" +
+      "o3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -7253,7 +7260,7 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_flow_CreateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_flow_CreateRequest_descriptor,
-        new java.lang.String[] { "TaskId", "SourceTableIds", "SinkTableId", "CreateIfNotExists", "ExpireWhen", "Comment", "Sql", "TaskOptions", });
+        new java.lang.String[] { "TaskId", "SourceTableIds", "SinkTableName", "CreateIfNotExists", "ExpireWhen", "Comment", "Sql", "TaskOptions", });
     internal_static_greptime_v1_flow_CreateRequest_TaskOptionsEntry_descriptor =
       internal_static_greptime_v1_flow_CreateRequest_descriptor.getNestedTypes().get(0);
     internal_static_greptime_v1_flow_CreateRequest_TaskOptionsEntry_fieldAccessorTable = new

--- a/proto/greptime/v1/flow/server.proto
+++ b/proto/greptime/v1/flow/server.proto
@@ -55,11 +55,14 @@ message FlowResponse {
   repeated TaskId affected_tasks = 4;
 }
 
-// very similar to `ddl.CreateTaskExpr` just replace `task_name` with `task_id`
+// Create a flow task
+// 
+// Very similar to `ddl.CreateTaskExpr`, 
+// replace `source_table_names` with `source_table_ids`
 message CreateRequest {
   TaskId task_id = 1; 
   repeated TableId source_table_ids = 2;
-  TableId sink_table_id = 3;
+  TableName sink_table_name = 3;
   bool create_if_not_exists = 4;
   string expire_when = 5;
   string comment = 6;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

refactor: replace `sink_table_id` with `sink_table_name`

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
