### PR TITLE
feat: add QueryContext to RegionRequestHeader

### DIFF
--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -23,6 +23,33 @@ namespace _pbi = _pb::internal;
 namespace greptime {
 namespace v1 {
 namespace region {
+PROTOBUF_CONSTEXPR QueryContext_ExtensionsEntry_DoNotUse::QueryContext_ExtensionsEntry_DoNotUse(
+    ::_pbi::ConstantInitialized) {}
+struct QueryContext_ExtensionsEntry_DoNotUseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR QueryContext_ExtensionsEntry_DoNotUseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~QueryContext_ExtensionsEntry_DoNotUseDefaultTypeInternal() {}
+  union {
+    QueryContext_ExtensionsEntry_DoNotUse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 QueryContext_ExtensionsEntry_DoNotUseDefaultTypeInternal _QueryContext_ExtensionsEntry_DoNotUse_default_instance_;
+PROTOBUF_CONSTEXPR QueryContext::QueryContext(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.extensions_)*/{::_pbi::ConstantInitialized()}
+  , /*decltype(_impl_.current_catalog_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.current_schema_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.timezone_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct QueryContextDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR QueryContextDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~QueryContextDefaultTypeInternal() {}
+  union {
+    QueryContext _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 QueryContextDefaultTypeInternal _QueryContext_default_instance_;
 PROTOBUF_CONSTEXPR RegionRequestHeader_TracingContextEntry_DoNotUse::RegionRequestHeader_TracingContextEntry_DoNotUse(
     ::_pbi::ConstantInitialized) {}
 struct RegionRequestHeader_TracingContextEntry_DoNotUseDefaultTypeInternal {
@@ -38,7 +65,7 @@ PROTOBUF_CONSTEXPR RegionRequestHeader::RegionRequestHeader(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.tracing_context_)*/{::_pbi::ConstantInitialized()}
   , /*decltype(_impl_.dbname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.timezone_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.query_context_)*/nullptr
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct RegionRequestHeaderDefaultTypeInternal {
   PROTOBUF_CONSTEXPR RegionRequestHeaderDefaultTypeInternal()
@@ -406,11 +433,31 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace region
 }  // namespace v1
 }  // namespace greptime
-static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[28];
+static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[30];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 
 const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse, _has_bits_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse, key_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext, _impl_.current_catalog_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext, _impl_.current_schema_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext, _impl_.timezone_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::QueryContext, _impl_.extensions_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse, _has_bits_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -429,7 +476,7 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.tracing_context_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.dbname_),
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.timezone_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequestHeader, _impl_.query_context_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -658,37 +705,41 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionColumnDef, _impl_.column_id_),
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, 8, -1, sizeof(::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse)},
-  { 10, -1, -1, sizeof(::greptime::v1::region::RegionRequestHeader)},
-  { 19, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
-  { 40, 48, -1, sizeof(::greptime::v1::region::RegionResponse_ExtensionEntry_DoNotUse)},
-  { 50, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
-  { 59, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
-  { 66, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
-  { 73, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
-  { 81, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
-  { 89, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
-  { 98, -1, -1, sizeof(::greptime::v1::region::CreateRequests)},
-  { 105, 113, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
-  { 115, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
-  { 127, -1, -1, sizeof(::greptime::v1::region::DropRequests)},
-  { 134, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
-  { 141, 149, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
-  { 151, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
-  { 161, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
-  { 168, -1, -1, sizeof(::greptime::v1::region::AlterRequests)},
-  { 175, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
-  { 187, -1, -1, sizeof(::greptime::v1::region::AddColumns)},
-  { 194, -1, -1, sizeof(::greptime::v1::region::DropColumns)},
-  { 201, -1, -1, sizeof(::greptime::v1::region::AddColumn)},
-  { 209, -1, -1, sizeof(::greptime::v1::region::DropColumn)},
-  { 216, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
-  { 223, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
-  { 230, -1, -1, sizeof(::greptime::v1::region::TruncateRequest)},
-  { 237, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
+  { 0, 8, -1, sizeof(::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse)},
+  { 10, -1, -1, sizeof(::greptime::v1::region::QueryContext)},
+  { 20, 28, -1, sizeof(::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse)},
+  { 30, -1, -1, sizeof(::greptime::v1::region::RegionRequestHeader)},
+  { 39, -1, -1, sizeof(::greptime::v1::region::RegionRequest)},
+  { 60, 68, -1, sizeof(::greptime::v1::region::RegionResponse_ExtensionEntry_DoNotUse)},
+  { 70, -1, -1, sizeof(::greptime::v1::region::RegionResponse)},
+  { 79, -1, -1, sizeof(::greptime::v1::region::InsertRequests)},
+  { 86, -1, -1, sizeof(::greptime::v1::region::DeleteRequests)},
+  { 93, -1, -1, sizeof(::greptime::v1::region::InsertRequest)},
+  { 101, -1, -1, sizeof(::greptime::v1::region::DeleteRequest)},
+  { 109, -1, -1, sizeof(::greptime::v1::region::QueryRequest)},
+  { 118, -1, -1, sizeof(::greptime::v1::region::CreateRequests)},
+  { 125, 133, -1, sizeof(::greptime::v1::region::CreateRequest_OptionsEntry_DoNotUse)},
+  { 135, -1, -1, sizeof(::greptime::v1::region::CreateRequest)},
+  { 147, -1, -1, sizeof(::greptime::v1::region::DropRequests)},
+  { 154, -1, -1, sizeof(::greptime::v1::region::DropRequest)},
+  { 161, 169, -1, sizeof(::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse)},
+  { 171, -1, -1, sizeof(::greptime::v1::region::OpenRequest)},
+  { 181, -1, -1, sizeof(::greptime::v1::region::CloseRequest)},
+  { 188, -1, -1, sizeof(::greptime::v1::region::AlterRequests)},
+  { 195, -1, -1, sizeof(::greptime::v1::region::AlterRequest)},
+  { 207, -1, -1, sizeof(::greptime::v1::region::AddColumns)},
+  { 214, -1, -1, sizeof(::greptime::v1::region::DropColumns)},
+  { 221, -1, -1, sizeof(::greptime::v1::region::AddColumn)},
+  { 229, -1, -1, sizeof(::greptime::v1::region::DropColumn)},
+  { 236, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
+  { 243, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
+  { 250, -1, -1, sizeof(::greptime::v1::region::TruncateRequest)},
+  { 257, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
+  &::greptime::v1::region::_QueryContext_ExtensionsEntry_DoNotUse_default_instance_._instance,
+  &::greptime::v1::region::_QueryContext_default_instance_._instance,
   &::greptime::v1::region::_RegionRequestHeader_TracingContextEntry_DoNotUse_default_instance_._instance,
   &::greptime::v1::region::_RegionRequestHeader_default_instance_._instance,
   &::greptime::v1::region::_RegionRequest_default_instance_._instance,
@@ -723,86 +774,92 @@ const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] P
   "\n\037greptime/v1/region/server.proto\022\022grept"
   "ime.v1.region\032\030greptime/v1/common.proto\032"
   "\025greptime/v1/row.proto\032\025greptime/v1/ddl."
-  "proto\"\304\001\n\023RegionRequestHeader\022T\n\017tracing"
-  "_context\030\005 \003(\0132;.greptime.v1.region.Regi"
-  "onRequestHeader.TracingContextEntry\022\016\n\006d"
-  "bname\030\003 \001(\t\022\020\n\010timezone\030\004 \001(\t\0325\n\023Tracing"
-  "ContextEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t"
-  ":\0028\001\"\375\005\n\rRegionRequest\0227\n\006header\030\001 \001(\0132\'"
-  ".greptime.v1.region.RegionRequestHeader\022"
-  "5\n\007inserts\030\003 \001(\0132\".greptime.v1.region.In"
-  "sertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".grepti"
-  "me.v1.region.DeleteRequestsH\000\0223\n\006create\030"
-  "\005 \001(\0132!.greptime.v1.region.CreateRequest"
-  "H\000\022/\n\004drop\030\006 \001(\0132\037.greptime.v1.region.Dr"
-  "opRequestH\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1."
-  "region.OpenRequestH\000\0221\n\005close\030\010 \001(\0132 .gr"
-  "eptime.v1.region.CloseRequestH\000\0221\n\005alter"
-  "\030\t \001(\0132 .greptime.v1.region.AlterRequest"
-  "H\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.region.F"
-  "lushRequestH\000\0225\n\007compact\030\013 \001(\0132\".greptim"
-  "e.v1.region.CompactRequestH\000\0227\n\010truncate"
-  "\030\014 \001(\0132#.greptime.v1.region.TruncateRequ"
-  "estH\000\0225\n\007creates\030\r \001(\0132\".greptime.v1.reg"
-  "ion.CreateRequestsH\000\0221\n\005drops\030\016 \001(\0132 .gr"
-  "eptime.v1.region.DropRequestsH\000\0223\n\006alter"
-  "s\030\017 \001(\0132!.greptime.v1.region.AlterReques"
-  "tsH\000B\006\n\004body\"\314\001\n\016RegionResponse\022+\n\006heade"
-  "r\030\001 \001(\0132\033.greptime.v1.ResponseHeader\022\025\n\r"
-  "affected_rows\030\002 \001(\004\022D\n\textension\030\003 \003(\01321"
-  ".greptime.v1.region.RegionResponse.Exten"
-  "sionEntry\0320\n\016ExtensionEntry\022\013\n\003key\030\001 \001(\t"
-  "\022\r\n\005value\030\002 \001(\014:\0028\001\"E\n\016InsertRequests\0223\n"
-  "\010requests\030\001 \003(\0132!.greptime.v1.region.Ins"
-  "ertRequest\"E\n\016DeleteRequests\0223\n\010requests"
-  "\030\001 \003(\0132!.greptime.v1.region.DeleteReques"
-  "t\"C\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(\004\022\037\n"
-  "\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"C\n\rDelete"
-  "Request\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\013"
-  "2\021.greptime.v1.Rows\"h\n\014QueryRequest\0227\n\006h"
-  "eader\030\001 \001(\0132\'.greptime.v1.region.RegionR"
-  "equestHeader\022\021\n\tregion_id\030\002 \001(\004\022\014\n\004plan\030"
-  "\003 \001(\014\"E\n\016CreateRequests\0223\n\010requests\030\001 \003("
-  "\0132!.greptime.v1.region.CreateRequest\"\200\002\n"
-  "\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006eng"
-  "ine\030\002 \001(\t\0228\n\013column_defs\030\003 \003(\0132#.greptim"
-  "e.v1.region.RegionColumnDef\022\023\n\013primary_k"
-  "ey\030\004 \003(\r\022\014\n\004path\030\005 \001(\t\022\?\n\007options\030\006 \003(\0132"
-  "..greptime.v1.region.CreateRequest.Optio"
-  "nsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005"
-  "value\030\002 \001(\t:\0028\001\"A\n\014DropRequests\0221\n\010reque"
-  "sts\030\001 \003(\0132\037.greptime.v1.region.DropReque"
-  "st\" \n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\255\001\n"
-  "\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engin"
-  "e\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=\n\007options\030\004 \003(\0132,"
-  ".greptime.v1.region.OpenRequest.OptionsE"
-  "ntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005val"
-  "ue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion_i"
-  "d\030\001 \001(\004\"C\n\rAlterRequests\0222\n\010requests\030\001 \003"
-  "(\0132 .greptime.v1.region.AlterRequest\"\360\001\n"
-  "\014AlterRequest\022\021\n\tregion_id\030\001 \001(\004\0225\n\013add_"
-  "columns\030\002 \001(\0132\036.greptime.v1.region.AddCo"
-  "lumnsH\000\0227\n\014drop_columns\030\003 \001(\0132\037.greptime"
-  ".v1.region.DropColumnsH\000\022=\n\023change_colum"
-  "n_types\030\005 \001(\0132\036.greptime.v1.ChangeColumn"
-  "TypesH\000\022\026\n\016schema_version\030\004 \001(\004B\006\n\004kind\""
-  "@\n\nAddColumns\0222\n\013add_columns\030\001 \003(\0132\035.gre"
-  "ptime.v1.region.AddColumn\"C\n\013DropColumns"
-  "\0224\n\014drop_columns\030\001 \003(\0132\036.greptime.v1.reg"
-  "ion.DropColumn\"v\n\tAddColumn\0227\n\ncolumn_de"
-  "f\030\001 \001(\0132#.greptime.v1.region.RegionColum"
-  "nDef\0220\n\010location\030\003 \001(\0132\036.greptime.v1.Add"
-  "ColumnLocation\"\032\n\nDropColumn\022\014\n\004name\030\001 \001"
-  "(\t\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\"#\n"
-  "\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"$\n\017Tr"
-  "uncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n\017Regi"
-  "onColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.grepti"
-  "me.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2Y\n\006Re"
-  "gion\022O\n\006Handle\022!.greptime.v1.region.Regi"
-  "onRequest\032\".greptime.v1.region.RegionRes"
-  "ponseB]\n\025io.greptime.v1.regionB\006ServerZ<"
-  "github.com/GreptimeTeam/greptime-proto/g"
-  "o/greptime/v1/regionb\006proto3"
+  "proto\"\312\001\n\014QueryContext\022\027\n\017current_catalo"
+  "g\030\001 \001(\t\022\026\n\016current_schema\030\002 \001(\t\022\020\n\010timez"
+  "one\030\004 \001(\t\022D\n\nextensions\030\005 \003(\01320.greptime"
+  ".v1.region.QueryContext.ExtensionsEntry\032"
+  "1\n\017ExtensionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
+  "\030\002 \001(\t:\0028\001\"\353\001\n\023RegionRequestHeader\022T\n\017tr"
+  "acing_context\030\005 \003(\0132;.greptime.v1.region"
+  ".RegionRequestHeader.TracingContextEntry"
+  "\022\016\n\006dbname\030\003 \001(\t\0227\n\rquery_context\030\006 \001(\0132"
+  " .greptime.v1.region.QueryContext\0325\n\023Tra"
+  "cingContextEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002"
+  " \001(\t:\0028\001\"\375\005\n\rRegionRequest\0227\n\006header\030\001 \001"
+  "(\0132\'.greptime.v1.region.RegionRequestHea"
+  "der\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regio"
+  "n.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".gr"
+  "eptime.v1.region.DeleteRequestsH\000\0223\n\006cre"
+  "ate\030\005 \001(\0132!.greptime.v1.region.CreateReq"
+  "uestH\000\022/\n\004drop\030\006 \001(\0132\037.greptime.v1.regio"
+  "n.DropRequestH\000\022/\n\004open\030\007 \001(\0132\037.greptime"
+  ".v1.region.OpenRequestH\000\0221\n\005close\030\010 \001(\0132"
+  " .greptime.v1.region.CloseRequestH\000\0221\n\005a"
+  "lter\030\t \001(\0132 .greptime.v1.region.AlterReq"
+  "uestH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.regi"
+  "on.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gre"
+  "ptime.v1.region.CompactRequestH\000\0227\n\010trun"
+  "cate\030\014 \001(\0132#.greptime.v1.region.Truncate"
+  "RequestH\000\0225\n\007creates\030\r \001(\0132\".greptime.v1"
+  ".region.CreateRequestsH\000\0221\n\005drops\030\016 \001(\0132"
+  " .greptime.v1.region.DropRequestsH\000\0223\n\006a"
+  "lters\030\017 \001(\0132!.greptime.v1.region.AlterRe"
+  "questsH\000B\006\n\004body\"\314\001\n\016RegionResponse\022+\n\006h"
+  "eader\030\001 \001(\0132\033.greptime.v1.ResponseHeader"
+  "\022\025\n\raffected_rows\030\002 \001(\004\022D\n\textension\030\003 \003"
+  "(\01321.greptime.v1.region.RegionResponse.E"
+  "xtensionEntry\0320\n\016ExtensionEntry\022\013\n\003key\030\001"
+  " \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"E\n\016InsertRequest"
+  "s\0223\n\010requests\030\001 \003(\0132!.greptime.v1.region"
+  ".InsertRequest\"E\n\016DeleteRequests\0223\n\010requ"
+  "ests\030\001 \003(\0132!.greptime.v1.region.DeleteRe"
+  "quest\"C\n\rInsertRequest\022\021\n\tregion_id\030\001 \001("
+  "\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"C\n\rDe"
+  "leteRequest\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002"
+  " \001(\0132\021.greptime.v1.Rows\"h\n\014QueryRequest\022"
+  "7\n\006header\030\001 \001(\0132\'.greptime.v1.region.Reg"
+  "ionRequestHeader\022\021\n\tregion_id\030\002 \001(\004\022\014\n\004p"
+  "lan\030\003 \001(\014\"E\n\016CreateRequests\0223\n\010requests\030"
+  "\001 \003(\0132!.greptime.v1.region.CreateRequest"
+  "\"\200\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n"
+  "\006engine\030\002 \001(\t\0228\n\013column_defs\030\003 \003(\0132#.gre"
+  "ptime.v1.region.RegionColumnDef\022\023\n\013prima"
+  "ry_key\030\004 \003(\r\022\014\n\004path\030\005 \001(\t\022\?\n\007options\030\006 "
+  "\003(\0132..greptime.v1.region.CreateRequest.O"
+  "ptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t"
+  "\022\r\n\005value\030\002 \001(\t:\0028\001\"A\n\014DropRequests\0221\n\010r"
+  "equests\030\001 \003(\0132\037.greptime.v1.region.DropR"
+  "equest\" \n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004"
+  "\"\255\001\n\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006e"
+  "ngine\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=\n\007options\030\004 \003"
+  "(\0132,.greptime.v1.region.OpenRequest.Opti"
+  "onsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n"
+  "\005value\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregi"
+  "on_id\030\001 \001(\004\"C\n\rAlterRequests\0222\n\010requests"
+  "\030\001 \003(\0132 .greptime.v1.region.AlterRequest"
+  "\"\360\001\n\014AlterRequest\022\021\n\tregion_id\030\001 \001(\004\0225\n\013"
+  "add_columns\030\002 \001(\0132\036.greptime.v1.region.A"
+  "ddColumnsH\000\0227\n\014drop_columns\030\003 \001(\0132\037.grep"
+  "time.v1.region.DropColumnsH\000\022=\n\023change_c"
+  "olumn_types\030\005 \001(\0132\036.greptime.v1.ChangeCo"
+  "lumnTypesH\000\022\026\n\016schema_version\030\004 \001(\004B\006\n\004k"
+  "ind\"@\n\nAddColumns\0222\n\013add_columns\030\001 \003(\0132\035"
+  ".greptime.v1.region.AddColumn\"C\n\013DropCol"
+  "umns\0224\n\014drop_columns\030\001 \003(\0132\036.greptime.v1"
+  ".region.DropColumn\"v\n\tAddColumn\0227\n\ncolum"
+  "n_def\030\001 \001(\0132#.greptime.v1.region.RegionC"
+  "olumnDef\0220\n\010location\030\003 \001(\0132\036.greptime.v1"
+  ".AddColumnLocation\"\032\n\nDropColumn\022\014\n\004name"
+  "\030\001 \001(\t\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001("
+  "\004\"#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"$"
+  "\n\017TruncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n\017"
+  "RegionColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.gr"
+  "eptime.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2Y"
+  "\n\006Region\022O\n\006Handle\022!.greptime.v1.region."
+  "RegionRequest\032\".greptime.v1.region.Regio"
+  "nResponseB]\n\025io.greptime.v1.regionB\006Serv"
+  "erZ<github.com/GreptimeTeam/greptime-pro"
+  "to/go/greptime/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[3] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -811,9 +868,9 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 3308, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 3552, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
-    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 28,
+    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 30,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
     file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto, file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
     file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
@@ -830,6 +887,391 @@ namespace region {
 
 // ===================================================================
 
+QueryContext_ExtensionsEntry_DoNotUse::QueryContext_ExtensionsEntry_DoNotUse() {}
+QueryContext_ExtensionsEntry_DoNotUse::QueryContext_ExtensionsEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+    : SuperType(arena) {}
+void QueryContext_ExtensionsEntry_DoNotUse::MergeFrom(const QueryContext_ExtensionsEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::PROTOBUF_NAMESPACE_ID::Metadata QueryContext_ExtensionsEntry_DoNotUse::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[0]);
+}
+
+// ===================================================================
+
+class QueryContext::_Internal {
+ public:
+};
+
+QueryContext::QueryContext(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  if (arena != nullptr && !is_message_owned) {
+    arena->OwnCustomDestructor(this, &QueryContext::ArenaDtor);
+  }
+  // @@protoc_insertion_point(arena_constructor:greptime.v1.region.QueryContext)
+}
+QueryContext::QueryContext(const QueryContext& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  QueryContext* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      /*decltype(_impl_.extensions_)*/{}
+    , decltype(_impl_.current_catalog_){}
+    , decltype(_impl_.current_schema_){}
+    , decltype(_impl_.timezone_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _this->_impl_.extensions_.MergeFrom(from._impl_.extensions_);
+  _impl_.current_catalog_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.current_catalog_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_current_catalog().empty()) {
+    _this->_impl_.current_catalog_.Set(from._internal_current_catalog(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.current_schema_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.current_schema_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_current_schema().empty()) {
+    _this->_impl_.current_schema_.Set(from._internal_current_schema(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.timezone_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.timezone_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_timezone().empty()) {
+    _this->_impl_.timezone_.Set(from._internal_timezone(), 
+      _this->GetArenaForAllocation());
+  }
+  // @@protoc_insertion_point(copy_constructor:greptime.v1.region.QueryContext)
+}
+
+inline void QueryContext::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      /*decltype(_impl_.extensions_)*/{::_pbi::ArenaInitialized(), arena}
+    , decltype(_impl_.current_catalog_){}
+    , decltype(_impl_.current_schema_){}
+    , decltype(_impl_.timezone_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.current_catalog_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.current_catalog_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.current_schema_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.current_schema_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.timezone_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.timezone_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+QueryContext::~QueryContext() {
+  // @@protoc_insertion_point(destructor:greptime.v1.region.QueryContext)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    ArenaDtor(this);
+    return;
+  }
+  SharedDtor();
+}
+
+inline void QueryContext::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.extensions_.Destruct();
+  _impl_.extensions_.~MapField();
+  _impl_.current_catalog_.Destroy();
+  _impl_.current_schema_.Destroy();
+  _impl_.timezone_.Destroy();
+}
+
+void QueryContext::ArenaDtor(void* object) {
+  QueryContext* _this = reinterpret_cast< QueryContext* >(object);
+  _this->_impl_.extensions_.Destruct();
+}
+void QueryContext::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void QueryContext::Clear() {
+// @@protoc_insertion_point(message_clear_start:greptime.v1.region.QueryContext)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.extensions_.Clear();
+  _impl_.current_catalog_.ClearToEmpty();
+  _impl_.current_schema_.ClearToEmpty();
+  _impl_.timezone_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* QueryContext::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // string current_catalog = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_current_catalog();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.QueryContext.current_catalog"));
+        } else
+          goto handle_unusual;
+        continue;
+      // string current_schema = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_current_schema();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.QueryContext.current_schema"));
+        } else
+          goto handle_unusual;
+        continue;
+      // string timezone = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
+          auto str = _internal_mutable_timezone();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.QueryContext.timezone"));
+        } else
+          goto handle_unusual;
+        continue;
+      // map<string, string> extensions = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 42)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(&_impl_.extensions_, ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<42>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* QueryContext::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:greptime.v1.region.QueryContext)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string current_catalog = 1;
+  if (!this->_internal_current_catalog().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_current_catalog().data(), static_cast<int>(this->_internal_current_catalog().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.region.QueryContext.current_catalog");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_current_catalog(), target);
+  }
+
+  // string current_schema = 2;
+  if (!this->_internal_current_schema().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_current_schema().data(), static_cast<int>(this->_internal_current_schema().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.region.QueryContext.current_schema");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_current_schema(), target);
+  }
+
+  // string timezone = 4;
+  if (!this->_internal_timezone().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_timezone().data(), static_cast<int>(this->_internal_timezone().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.region.QueryContext.timezone");
+    target = stream->WriteStringMaybeAliased(
+        4, this->_internal_timezone(), target);
+  }
+
+  // map<string, string> extensions = 5;
+  if (!this->_internal_extensions().empty()) {
+    using MapType = ::_pb::Map<std::string, std::string>;
+    using WireHelper = QueryContext_ExtensionsEntry_DoNotUse::Funcs;
+    const auto& map_field = this->_internal_extensions();
+    auto check_utf8 = [](const MapType::value_type& entry) {
+      (void)entry;
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+        entry.first.data(), static_cast<int>(entry.first.length()),
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+        "greptime.v1.region.QueryContext.ExtensionsEntry.key");
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+        entry.second.data(), static_cast<int>(entry.second.length()),
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+        "greptime.v1.region.QueryContext.ExtensionsEntry.value");
+    };
+
+    if (stream->IsSerializationDeterministic() && map_field.size() > 1) {
+      for (const auto& entry : ::_pbi::MapSorterPtr<MapType>(map_field)) {
+        target = WireHelper::InternalSerialize(5, entry.first, entry.second, target, stream);
+        check_utf8(entry);
+      }
+    } else {
+      for (const auto& entry : map_field) {
+        target = WireHelper::InternalSerialize(5, entry.first, entry.second, target, stream);
+        check_utf8(entry);
+      }
+    }
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:greptime.v1.region.QueryContext)
+  return target;
+}
+
+size_t QueryContext::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:greptime.v1.region.QueryContext)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // map<string, string> extensions = 5;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_extensions_size());
+  for (::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_iterator
+      it = this->_internal_extensions().begin();
+      it != this->_internal_extensions().end(); ++it) {
+    total_size += QueryContext_ExtensionsEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
+  }
+
+  // string current_catalog = 1;
+  if (!this->_internal_current_catalog().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_current_catalog());
+  }
+
+  // string current_schema = 2;
+  if (!this->_internal_current_schema().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_current_schema());
+  }
+
+  // string timezone = 4;
+  if (!this->_internal_timezone().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_timezone());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData QueryContext::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    QueryContext::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*QueryContext::GetClassData() const { return &_class_data_; }
+
+
+void QueryContext::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<QueryContext*>(&to_msg);
+  auto& from = static_cast<const QueryContext&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:greptime.v1.region.QueryContext)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_impl_.extensions_.MergeFrom(from._impl_.extensions_);
+  if (!from._internal_current_catalog().empty()) {
+    _this->_internal_set_current_catalog(from._internal_current_catalog());
+  }
+  if (!from._internal_current_schema().empty()) {
+    _this->_internal_set_current_schema(from._internal_current_schema());
+  }
+  if (!from._internal_timezone().empty()) {
+    _this->_internal_set_timezone(from._internal_timezone());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void QueryContext::CopyFrom(const QueryContext& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:greptime.v1.region.QueryContext)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool QueryContext::IsInitialized() const {
+  return true;
+}
+
+void QueryContext::InternalSwap(QueryContext* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  _impl_.extensions_.InternalSwap(&other->_impl_.extensions_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.current_catalog_, lhs_arena,
+      &other->_impl_.current_catalog_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.current_schema_, lhs_arena,
+      &other->_impl_.current_schema_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.timezone_, lhs_arena,
+      &other->_impl_.timezone_, rhs_arena
+  );
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata QueryContext::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[1]);
+}
+
+// ===================================================================
+
 RegionRequestHeader_TracingContextEntry_DoNotUse::RegionRequestHeader_TracingContextEntry_DoNotUse() {}
 RegionRequestHeader_TracingContextEntry_DoNotUse::RegionRequestHeader_TracingContextEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
     : SuperType(arena) {}
@@ -839,15 +1281,20 @@ void RegionRequestHeader_TracingContextEntry_DoNotUse::MergeFrom(const RegionReq
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionRequestHeader_TracingContextEntry_DoNotUse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[0]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[2]);
 }
 
 // ===================================================================
 
 class RegionRequestHeader::_Internal {
  public:
+  static const ::greptime::v1::region::QueryContext& query_context(const RegionRequestHeader* msg);
 };
 
+const ::greptime::v1::region::QueryContext&
+RegionRequestHeader::_Internal::query_context(const RegionRequestHeader* msg) {
+  return *msg->_impl_.query_context_;
+}
 RegionRequestHeader::RegionRequestHeader(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
@@ -863,7 +1310,7 @@ RegionRequestHeader::RegionRequestHeader(const RegionRequestHeader& from)
   new (&_impl_) Impl_{
       /*decltype(_impl_.tracing_context_)*/{}
     , decltype(_impl_.dbname_){}
-    , decltype(_impl_.timezone_){}
+    , decltype(_impl_.query_context_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
@@ -876,13 +1323,8 @@ RegionRequestHeader::RegionRequestHeader(const RegionRequestHeader& from)
     _this->_impl_.dbname_.Set(from._internal_dbname(), 
       _this->GetArenaForAllocation());
   }
-  _impl_.timezone_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.timezone_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_timezone().empty()) {
-    _this->_impl_.timezone_.Set(from._internal_timezone(), 
-      _this->GetArenaForAllocation());
+  if (from._internal_has_query_context()) {
+    _this->_impl_.query_context_ = new ::greptime::v1::region::QueryContext(*from._impl_.query_context_);
   }
   // @@protoc_insertion_point(copy_constructor:greptime.v1.region.RegionRequestHeader)
 }
@@ -894,16 +1336,12 @@ inline void RegionRequestHeader::SharedCtor(
   new (&_impl_) Impl_{
       /*decltype(_impl_.tracing_context_)*/{::_pbi::ArenaInitialized(), arena}
     , decltype(_impl_.dbname_){}
-    , decltype(_impl_.timezone_){}
+    , decltype(_impl_.query_context_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}
   };
   _impl_.dbname_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
     _impl_.dbname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.timezone_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.timezone_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
@@ -922,7 +1360,7 @@ inline void RegionRequestHeader::SharedDtor() {
   _impl_.tracing_context_.Destruct();
   _impl_.tracing_context_.~MapField();
   _impl_.dbname_.Destroy();
-  _impl_.timezone_.Destroy();
+  if (this != internal_default_instance()) delete _impl_.query_context_;
 }
 
 void RegionRequestHeader::ArenaDtor(void* object) {
@@ -941,7 +1379,10 @@ void RegionRequestHeader::Clear() {
 
   _impl_.tracing_context_.Clear();
   _impl_.dbname_.ClearToEmpty();
-  _impl_.timezone_.ClearToEmpty();
+  if (GetArenaForAllocation() == nullptr && _impl_.query_context_ != nullptr) {
+    delete _impl_.query_context_;
+  }
+  _impl_.query_context_ = nullptr;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -961,16 +1402,6 @@ const char* RegionRequestHeader::_InternalParse(const char* ptr, ::_pbi::ParseCo
         } else
           goto handle_unusual;
         continue;
-      // string timezone = 4;
-      case 4:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
-          auto str = _internal_mutable_timezone();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.region.RegionRequestHeader.timezone"));
-        } else
-          goto handle_unusual;
-        continue;
       // map<string, string> tracing_context = 5;
       case 5:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 42)) {
@@ -981,6 +1412,14 @@ const char* RegionRequestHeader::_InternalParse(const char* ptr, ::_pbi::ParseCo
             CHK_(ptr);
             if (!ctx->DataAvailable(ptr)) break;
           } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<42>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // .greptime.v1.region.QueryContext query_context = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 50)) {
+          ptr = ctx->ParseMessage(_internal_mutable_query_context(), ptr);
+          CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
@@ -1023,16 +1462,6 @@ uint8_t* RegionRequestHeader::_InternalSerialize(
         3, this->_internal_dbname(), target);
   }
 
-  // string timezone = 4;
-  if (!this->_internal_timezone().empty()) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_timezone().data(), static_cast<int>(this->_internal_timezone().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "greptime.v1.region.RegionRequestHeader.timezone");
-    target = stream->WriteStringMaybeAliased(
-        4, this->_internal_timezone(), target);
-  }
-
   // map<string, string> tracing_context = 5;
   if (!this->_internal_tracing_context().empty()) {
     using MapType = ::_pb::Map<std::string, std::string>;
@@ -1061,6 +1490,13 @@ uint8_t* RegionRequestHeader::_InternalSerialize(
         check_utf8(entry);
       }
     }
+  }
+
+  // .greptime.v1.region.QueryContext query_context = 6;
+  if (this->_internal_has_query_context()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(6, _Internal::query_context(this),
+        _Internal::query_context(this).GetCachedSize(), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -1095,11 +1531,11 @@ size_t RegionRequestHeader::ByteSizeLong() const {
         this->_internal_dbname());
   }
 
-  // string timezone = 4;
-  if (!this->_internal_timezone().empty()) {
+  // .greptime.v1.region.QueryContext query_context = 6;
+  if (this->_internal_has_query_context()) {
     total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_timezone());
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.query_context_);
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -1124,8 +1560,9 @@ void RegionRequestHeader::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, co
   if (!from._internal_dbname().empty()) {
     _this->_internal_set_dbname(from._internal_dbname());
   }
-  if (!from._internal_timezone().empty()) {
-    _this->_internal_set_timezone(from._internal_timezone());
+  if (from._internal_has_query_context()) {
+    _this->_internal_mutable_query_context()->::greptime::v1::region::QueryContext::MergeFrom(
+        from._internal_query_context());
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -1151,16 +1588,13 @@ void RegionRequestHeader::InternalSwap(RegionRequestHeader* other) {
       &_impl_.dbname_, lhs_arena,
       &other->_impl_.dbname_, rhs_arena
   );
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.timezone_, lhs_arena,
-      &other->_impl_.timezone_, rhs_arena
-  );
+  swap(_impl_.query_context_, other->_impl_.query_context_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionRequestHeader::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[1]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[3]);
 }
 
 // ===================================================================
@@ -2145,7 +2579,7 @@ void RegionRequest::InternalSwap(RegionRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[2]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[4]);
 }
 
 // ===================================================================
@@ -2159,7 +2593,7 @@ void RegionResponse_ExtensionEntry_DoNotUse::MergeFrom(const RegionResponse_Exte
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionResponse_ExtensionEntry_DoNotUse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[3]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[5]);
 }
 
 // ===================================================================
@@ -2453,7 +2887,7 @@ void RegionResponse::InternalSwap(RegionResponse* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionResponse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[4]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[6]);
 }
 
 // ===================================================================
@@ -2638,7 +3072,7 @@ void InsertRequests::InternalSwap(InsertRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InsertRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[5]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[7]);
 }
 
 // ===================================================================
@@ -2823,7 +3257,7 @@ void DeleteRequests::InternalSwap(DeleteRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DeleteRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[6]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[8]);
 }
 
 // ===================================================================
@@ -3053,7 +3487,7 @@ void InsertRequest::InternalSwap(InsertRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InsertRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[7]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[9]);
 }
 
 // ===================================================================
@@ -3283,7 +3717,7 @@ void DeleteRequest::InternalSwap(DeleteRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DeleteRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[8]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[10]);
 }
 
 // ===================================================================
@@ -3554,7 +3988,7 @@ void QueryRequest::InternalSwap(QueryRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata QueryRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[9]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[11]);
 }
 
 // ===================================================================
@@ -3739,7 +4173,7 @@ void CreateRequests::InternalSwap(CreateRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CreateRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[10]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[12]);
 }
 
 // ===================================================================
@@ -3753,7 +4187,7 @@ void CreateRequest_OptionsEntry_DoNotUse::MergeFrom(const CreateRequest_OptionsE
 ::PROTOBUF_NAMESPACE_ID::Metadata CreateRequest_OptionsEntry_DoNotUse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[11]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[13]);
 }
 
 // ===================================================================
@@ -4177,7 +4611,7 @@ void CreateRequest::InternalSwap(CreateRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CreateRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[12]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[14]);
 }
 
 // ===================================================================
@@ -4362,7 +4796,7 @@ void DropRequests::InternalSwap(DropRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DropRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[13]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[15]);
 }
 
 // ===================================================================
@@ -4540,7 +4974,7 @@ void DropRequest::InternalSwap(DropRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DropRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[14]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[16]);
 }
 
 // ===================================================================
@@ -4554,7 +4988,7 @@ void OpenRequest_OptionsEntry_DoNotUse::MergeFrom(const OpenRequest_OptionsEntry
 ::PROTOBUF_NAMESPACE_ID::Metadata OpenRequest_OptionsEntry_DoNotUse::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[15]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[17]);
 }
 
 // ===================================================================
@@ -4902,7 +5336,7 @@ void OpenRequest::InternalSwap(OpenRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata OpenRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[16]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[18]);
 }
 
 // ===================================================================
@@ -5080,7 +5514,7 @@ void CloseRequest::InternalSwap(CloseRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CloseRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[17]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[19]);
 }
 
 // ===================================================================
@@ -5265,7 +5699,7 @@ void AlterRequests::InternalSwap(AlterRequests* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AlterRequests::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[18]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[20]);
 }
 
 // ===================================================================
@@ -5697,7 +6131,7 @@ void AlterRequest::InternalSwap(AlterRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AlterRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[19]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[21]);
 }
 
 // ===================================================================
@@ -5882,7 +6316,7 @@ void AddColumns::InternalSwap(AddColumns* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AddColumns::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[20]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[22]);
 }
 
 // ===================================================================
@@ -6067,7 +6501,7 @@ void DropColumns::InternalSwap(DropColumns* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DropColumns::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[21]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[23]);
 }
 
 // ===================================================================
@@ -6312,7 +6746,7 @@ void AddColumn::InternalSwap(AddColumn* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AddColumn::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[22]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[24]);
 }
 
 // ===================================================================
@@ -6515,7 +6949,7 @@ void DropColumn::InternalSwap(DropColumn* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DropColumn::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[23]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[25]);
 }
 
 // ===================================================================
@@ -6693,7 +7127,7 @@ void FlushRequest::InternalSwap(FlushRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata FlushRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[24]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[26]);
 }
 
 // ===================================================================
@@ -6871,7 +7305,7 @@ void CompactRequest::InternalSwap(CompactRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CompactRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[25]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[27]);
 }
 
 // ===================================================================
@@ -7049,7 +7483,7 @@ void TruncateRequest::InternalSwap(TruncateRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata TruncateRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[26]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[28]);
 }
 
 // ===================================================================
@@ -7279,7 +7713,7 @@ void RegionColumnDef::InternalSwap(RegionColumnDef* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionColumnDef::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[27]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[29]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -7287,6 +7721,14 @@ void RegionColumnDef::InternalSwap(RegionColumnDef* other) {
 }  // namespace v1
 }  // namespace greptime
 PROTOBUF_NAMESPACE_OPEN
+template<> PROTOBUF_NOINLINE ::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse*
+Arena::CreateMaybeMessage< ::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::greptime::v1::region::QueryContext*
+Arena::CreateMaybeMessage< ::greptime::v1::region::QueryContext >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::region::QueryContext >(arena);
+}
 template<> PROTOBUF_NOINLINE ::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse*
 Arena::CreateMaybeMessage< ::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse >(arena);

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -113,6 +113,12 @@ extern OpenRequestDefaultTypeInternal _OpenRequest_default_instance_;
 class OpenRequest_OptionsEntry_DoNotUse;
 struct OpenRequest_OptionsEntry_DoNotUseDefaultTypeInternal;
 extern OpenRequest_OptionsEntry_DoNotUseDefaultTypeInternal _OpenRequest_OptionsEntry_DoNotUse_default_instance_;
+class QueryContext;
+struct QueryContextDefaultTypeInternal;
+extern QueryContextDefaultTypeInternal _QueryContext_default_instance_;
+class QueryContext_ExtensionsEntry_DoNotUse;
+struct QueryContext_ExtensionsEntry_DoNotUseDefaultTypeInternal;
+extern QueryContext_ExtensionsEntry_DoNotUseDefaultTypeInternal _QueryContext_ExtensionsEntry_DoNotUse_default_instance_;
 class QueryRequest;
 struct QueryRequestDefaultTypeInternal;
 extern QueryRequestDefaultTypeInternal _QueryRequest_default_instance_;
@@ -161,6 +167,8 @@ template<> ::greptime::v1::region::InsertRequest* Arena::CreateMaybeMessage<::gr
 template<> ::greptime::v1::region::InsertRequests* Arena::CreateMaybeMessage<::greptime::v1::region::InsertRequests>(Arena*);
 template<> ::greptime::v1::region::OpenRequest* Arena::CreateMaybeMessage<::greptime::v1::region::OpenRequest>(Arena*);
 template<> ::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse* Arena::CreateMaybeMessage<::greptime::v1::region::OpenRequest_OptionsEntry_DoNotUse>(Arena*);
+template<> ::greptime::v1::region::QueryContext* Arena::CreateMaybeMessage<::greptime::v1::region::QueryContext>(Arena*);
+template<> ::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse* Arena::CreateMaybeMessage<::greptime::v1::region::QueryContext_ExtensionsEntry_DoNotUse>(Arena*);
 template<> ::greptime::v1::region::QueryRequest* Arena::CreateMaybeMessage<::greptime::v1::region::QueryRequest>(Arena*);
 template<> ::greptime::v1::region::RegionColumnDef* Arena::CreateMaybeMessage<::greptime::v1::region::RegionColumnDef>(Arena*);
 template<> ::greptime::v1::region::RegionRequest* Arena::CreateMaybeMessage<::greptime::v1::region::RegionRequest>(Arena*);
@@ -175,6 +183,245 @@ namespace v1 {
 namespace region {
 
 // ===================================================================
+
+class QueryContext_ExtensionsEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<QueryContext_ExtensionsEntry_DoNotUse, 
+    std::string, std::string,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING> {
+public:
+  typedef ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<QueryContext_ExtensionsEntry_DoNotUse, 
+    std::string, std::string,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING> SuperType;
+  QueryContext_ExtensionsEntry_DoNotUse();
+  explicit PROTOBUF_CONSTEXPR QueryContext_ExtensionsEntry_DoNotUse(
+      ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  explicit QueryContext_ExtensionsEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  void MergeFrom(const QueryContext_ExtensionsEntry_DoNotUse& other);
+  static const QueryContext_ExtensionsEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const QueryContext_ExtensionsEntry_DoNotUse*>(&_QueryContext_ExtensionsEntry_DoNotUse_default_instance_); }
+  static bool ValidateKey(std::string* s) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(s->data(), static_cast<int>(s->size()), ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::PARSE, "greptime.v1.region.QueryContext.ExtensionsEntry.key");
+ }
+  static bool ValidateValue(std::string* s) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(s->data(), static_cast<int>(s->size()), ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::PARSE, "greptime.v1.region.QueryContext.ExtensionsEntry.value");
+ }
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  friend struct ::TableStruct_greptime_2fv1_2fregion_2fserver_2eproto;
+};
+
+// -------------------------------------------------------------------
+
+class QueryContext final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.region.QueryContext) */ {
+ public:
+  inline QueryContext() : QueryContext(nullptr) {}
+  ~QueryContext() override;
+  explicit PROTOBUF_CONSTEXPR QueryContext(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  QueryContext(const QueryContext& from);
+  QueryContext(QueryContext&& from) noexcept
+    : QueryContext() {
+    *this = ::std::move(from);
+  }
+
+  inline QueryContext& operator=(const QueryContext& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline QueryContext& operator=(QueryContext&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const QueryContext& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const QueryContext* internal_default_instance() {
+    return reinterpret_cast<const QueryContext*>(
+               &_QueryContext_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    1;
+
+  friend void swap(QueryContext& a, QueryContext& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(QueryContext* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(QueryContext* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  QueryContext* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<QueryContext>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const QueryContext& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const QueryContext& from) {
+    QueryContext::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(QueryContext* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "greptime.v1.region.QueryContext";
+  }
+  protected:
+  explicit QueryContext(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  private:
+  static void ArenaDtor(void* object);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kExtensionsFieldNumber = 5,
+    kCurrentCatalogFieldNumber = 1,
+    kCurrentSchemaFieldNumber = 2,
+    kTimezoneFieldNumber = 4,
+  };
+  // map<string, string> extensions = 5;
+  int extensions_size() const;
+  private:
+  int _internal_extensions_size() const;
+  public:
+  void clear_extensions();
+  private:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+      _internal_extensions() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+      _internal_mutable_extensions();
+  public:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+      extensions() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+      mutable_extensions();
+
+  // string current_catalog = 1;
+  void clear_current_catalog();
+  const std::string& current_catalog() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_current_catalog(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_current_catalog();
+  PROTOBUF_NODISCARD std::string* release_current_catalog();
+  void set_allocated_current_catalog(std::string* current_catalog);
+  private:
+  const std::string& _internal_current_catalog() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_current_catalog(const std::string& value);
+  std::string* _internal_mutable_current_catalog();
+  public:
+
+  // string current_schema = 2;
+  void clear_current_schema();
+  const std::string& current_schema() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_current_schema(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_current_schema();
+  PROTOBUF_NODISCARD std::string* release_current_schema();
+  void set_allocated_current_schema(std::string* current_schema);
+  private:
+  const std::string& _internal_current_schema() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_current_schema(const std::string& value);
+  std::string* _internal_mutable_current_schema();
+  public:
+
+  // string timezone = 4;
+  void clear_timezone();
+  const std::string& timezone() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_timezone(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_timezone();
+  PROTOBUF_NODISCARD std::string* release_timezone();
+  void set_allocated_timezone(std::string* timezone);
+  private:
+  const std::string& _internal_timezone() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_timezone(const std::string& value);
+  std::string* _internal_mutable_timezone();
+  public:
+
+  // @@protoc_insertion_point(class_scope:greptime.v1.region.QueryContext)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::MapField<
+        QueryContext_ExtensionsEntry_DoNotUse,
+        std::string, std::string,
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING> extensions_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr current_catalog_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr current_schema_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr timezone_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_greptime_2fv1_2fregion_2fserver_2eproto;
+};
+// -------------------------------------------------------------------
 
 class RegionRequestHeader_TracingContextEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<RegionRequestHeader_TracingContextEntry_DoNotUse, 
     std::string, std::string,
@@ -252,7 +499,7 @@ class RegionRequestHeader final :
                &_RegionRequestHeader_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    1;
+    3;
 
   friend void swap(RegionRequestHeader& a, RegionRequestHeader& b) {
     a.Swap(&b);
@@ -330,7 +577,7 @@ class RegionRequestHeader final :
   enum : int {
     kTracingContextFieldNumber = 5,
     kDbnameFieldNumber = 3,
-    kTimezoneFieldNumber = 4,
+    kQueryContextFieldNumber = 6,
   };
   // map<string, string> tracing_context = 5;
   int tracing_context_size() const;
@@ -363,19 +610,23 @@ class RegionRequestHeader final :
   std::string* _internal_mutable_dbname();
   public:
 
-  // string timezone = 4;
-  void clear_timezone();
-  const std::string& timezone() const;
-  template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_timezone(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_timezone();
-  PROTOBUF_NODISCARD std::string* release_timezone();
-  void set_allocated_timezone(std::string* timezone);
+  // .greptime.v1.region.QueryContext query_context = 6;
+  bool has_query_context() const;
   private:
-  const std::string& _internal_timezone() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_timezone(const std::string& value);
-  std::string* _internal_mutable_timezone();
+  bool _internal_has_query_context() const;
   public:
+  void clear_query_context();
+  const ::greptime::v1::region::QueryContext& query_context() const;
+  PROTOBUF_NODISCARD ::greptime::v1::region::QueryContext* release_query_context();
+  ::greptime::v1::region::QueryContext* mutable_query_context();
+  void set_allocated_query_context(::greptime::v1::region::QueryContext* query_context);
+  private:
+  const ::greptime::v1::region::QueryContext& _internal_query_context() const;
+  ::greptime::v1::region::QueryContext* _internal_mutable_query_context();
+  public:
+  void unsafe_arena_set_allocated_query_context(
+      ::greptime::v1::region::QueryContext* query_context);
+  ::greptime::v1::region::QueryContext* unsafe_arena_release_query_context();
 
   // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionRequestHeader)
  private:
@@ -391,7 +642,7 @@ class RegionRequestHeader final :
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING> tracing_context_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr dbname_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr timezone_;
+    ::greptime::v1::region::QueryContext* query_context_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -464,7 +715,7 @@ class RegionRequest final :
                &_RegionRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   friend void swap(RegionRequest& a, RegionRequest& b) {
     a.Swap(&b);
@@ -931,7 +1182,7 @@ class RegionResponse final :
                &_RegionResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    6;
 
   friend void swap(RegionResponse& a, RegionResponse& b) {
     a.Swap(&b);
@@ -1125,7 +1376,7 @@ class InsertRequests final :
                &_InsertRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    7;
 
   friend void swap(InsertRequests& a, InsertRequests& b) {
     a.Swap(&b);
@@ -1282,7 +1533,7 @@ class DeleteRequests final :
                &_DeleteRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(DeleteRequests& a, DeleteRequests& b) {
     a.Swap(&b);
@@ -1439,7 +1690,7 @@ class InsertRequest final :
                &_InsertRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    9;
 
   friend void swap(InsertRequest& a, InsertRequest& b) {
     a.Swap(&b);
@@ -1607,7 +1858,7 @@ class DeleteRequest final :
                &_DeleteRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    10;
 
   friend void swap(DeleteRequest& a, DeleteRequest& b) {
     a.Swap(&b);
@@ -1775,7 +2026,7 @@ class QueryRequest final :
                &_QueryRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    11;
 
   friend void swap(QueryRequest& a, QueryRequest& b) {
     a.Swap(&b);
@@ -1959,7 +2210,7 @@ class CreateRequests final :
                &_CreateRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    12;
 
   friend void swap(CreateRequests& a, CreateRequests& b) {
     a.Swap(&b);
@@ -2144,7 +2395,7 @@ class CreateRequest final :
                &_CreateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    14;
 
   friend void swap(CreateRequest& a, CreateRequest& b) {
     a.Swap(&b);
@@ -2395,7 +2646,7 @@ class DropRequests final :
                &_DropRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    15;
 
   friend void swap(DropRequests& a, DropRequests& b) {
     a.Swap(&b);
@@ -2552,7 +2803,7 @@ class DropRequest final :
                &_DropRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    16;
 
   friend void swap(DropRequest& a, DropRequest& b) {
     a.Swap(&b);
@@ -2728,7 +2979,7 @@ class OpenRequest final :
                &_OpenRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    16;
+    18;
 
   friend void swap(OpenRequest& a, OpenRequest& b) {
     a.Swap(&b);
@@ -2934,7 +3185,7 @@ class CloseRequest final :
                &_CloseRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    17;
+    19;
 
   friend void swap(CloseRequest& a, CloseRequest& b) {
     a.Swap(&b);
@@ -3082,7 +3333,7 @@ class AlterRequests final :
                &_AlterRequests_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    18;
+    20;
 
   friend void swap(AlterRequests& a, AlterRequests& b) {
     a.Swap(&b);
@@ -3246,7 +3497,7 @@ class AlterRequest final :
                &_AlterRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    19;
+    21;
 
   friend void swap(AlterRequest& a, AlterRequest& b) {
     a.Swap(&b);
@@ -3479,7 +3730,7 @@ class AddColumns final :
                &_AddColumns_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    20;
+    22;
 
   friend void swap(AddColumns& a, AddColumns& b) {
     a.Swap(&b);
@@ -3636,7 +3887,7 @@ class DropColumns final :
                &_DropColumns_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    21;
+    23;
 
   friend void swap(DropColumns& a, DropColumns& b) {
     a.Swap(&b);
@@ -3793,7 +4044,7 @@ class AddColumn final :
                &_AddColumn_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    22;
+    24;
 
   friend void swap(AddColumn& a, AddColumn& b) {
     a.Swap(&b);
@@ -3970,7 +4221,7 @@ class DropColumn final :
                &_DropColumn_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    25;
 
   friend void swap(DropColumn& a, DropColumn& b) {
     a.Swap(&b);
@@ -4123,7 +4374,7 @@ class FlushRequest final :
                &_FlushRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    26;
 
   friend void swap(FlushRequest& a, FlushRequest& b) {
     a.Swap(&b);
@@ -4271,7 +4522,7 @@ class CompactRequest final :
                &_CompactRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    27;
 
   friend void swap(CompactRequest& a, CompactRequest& b) {
     a.Swap(&b);
@@ -4419,7 +4670,7 @@ class TruncateRequest final :
                &_TruncateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    28;
 
   friend void swap(TruncateRequest& a, TruncateRequest& b) {
     a.Swap(&b);
@@ -4567,7 +4818,7 @@ class RegionColumnDef final :
                &_RegionColumnDef_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    29;
 
   friend void swap(RegionColumnDef& a, RegionColumnDef& b) {
     a.Swap(&b);
@@ -4696,6 +4947,191 @@ class RegionColumnDef final :
 #endif  // __GNUC__
 // -------------------------------------------------------------------
 
+// QueryContext
+
+// string current_catalog = 1;
+inline void QueryContext::clear_current_catalog() {
+  _impl_.current_catalog_.ClearToEmpty();
+}
+inline const std::string& QueryContext::current_catalog() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.QueryContext.current_catalog)
+  return _internal_current_catalog();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void QueryContext::set_current_catalog(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.current_catalog_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.QueryContext.current_catalog)
+}
+inline std::string* QueryContext::mutable_current_catalog() {
+  std::string* _s = _internal_mutable_current_catalog();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.QueryContext.current_catalog)
+  return _s;
+}
+inline const std::string& QueryContext::_internal_current_catalog() const {
+  return _impl_.current_catalog_.Get();
+}
+inline void QueryContext::_internal_set_current_catalog(const std::string& value) {
+  
+  _impl_.current_catalog_.Set(value, GetArenaForAllocation());
+}
+inline std::string* QueryContext::_internal_mutable_current_catalog() {
+  
+  return _impl_.current_catalog_.Mutable(GetArenaForAllocation());
+}
+inline std::string* QueryContext::release_current_catalog() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.QueryContext.current_catalog)
+  return _impl_.current_catalog_.Release();
+}
+inline void QueryContext::set_allocated_current_catalog(std::string* current_catalog) {
+  if (current_catalog != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.current_catalog_.SetAllocated(current_catalog, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.current_catalog_.IsDefault()) {
+    _impl_.current_catalog_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.QueryContext.current_catalog)
+}
+
+// string current_schema = 2;
+inline void QueryContext::clear_current_schema() {
+  _impl_.current_schema_.ClearToEmpty();
+}
+inline const std::string& QueryContext::current_schema() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.QueryContext.current_schema)
+  return _internal_current_schema();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void QueryContext::set_current_schema(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.current_schema_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.QueryContext.current_schema)
+}
+inline std::string* QueryContext::mutable_current_schema() {
+  std::string* _s = _internal_mutable_current_schema();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.QueryContext.current_schema)
+  return _s;
+}
+inline const std::string& QueryContext::_internal_current_schema() const {
+  return _impl_.current_schema_.Get();
+}
+inline void QueryContext::_internal_set_current_schema(const std::string& value) {
+  
+  _impl_.current_schema_.Set(value, GetArenaForAllocation());
+}
+inline std::string* QueryContext::_internal_mutable_current_schema() {
+  
+  return _impl_.current_schema_.Mutable(GetArenaForAllocation());
+}
+inline std::string* QueryContext::release_current_schema() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.QueryContext.current_schema)
+  return _impl_.current_schema_.Release();
+}
+inline void QueryContext::set_allocated_current_schema(std::string* current_schema) {
+  if (current_schema != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.current_schema_.SetAllocated(current_schema, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.current_schema_.IsDefault()) {
+    _impl_.current_schema_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.QueryContext.current_schema)
+}
+
+// string timezone = 4;
+inline void QueryContext::clear_timezone() {
+  _impl_.timezone_.ClearToEmpty();
+}
+inline const std::string& QueryContext::timezone() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.QueryContext.timezone)
+  return _internal_timezone();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void QueryContext::set_timezone(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.timezone_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.QueryContext.timezone)
+}
+inline std::string* QueryContext::mutable_timezone() {
+  std::string* _s = _internal_mutable_timezone();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.QueryContext.timezone)
+  return _s;
+}
+inline const std::string& QueryContext::_internal_timezone() const {
+  return _impl_.timezone_.Get();
+}
+inline void QueryContext::_internal_set_timezone(const std::string& value) {
+  
+  _impl_.timezone_.Set(value, GetArenaForAllocation());
+}
+inline std::string* QueryContext::_internal_mutable_timezone() {
+  
+  return _impl_.timezone_.Mutable(GetArenaForAllocation());
+}
+inline std::string* QueryContext::release_timezone() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.QueryContext.timezone)
+  return _impl_.timezone_.Release();
+}
+inline void QueryContext::set_allocated_timezone(std::string* timezone) {
+  if (timezone != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.timezone_.SetAllocated(timezone, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.timezone_.IsDefault()) {
+    _impl_.timezone_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.QueryContext.timezone)
+}
+
+// map<string, string> extensions = 5;
+inline int QueryContext::_internal_extensions_size() const {
+  return _impl_.extensions_.size();
+}
+inline int QueryContext::extensions_size() const {
+  return _internal_extensions_size();
+}
+inline void QueryContext::clear_extensions() {
+  _impl_.extensions_.Clear();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+QueryContext::_internal_extensions() const {
+  return _impl_.extensions_.GetMap();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+QueryContext::extensions() const {
+  // @@protoc_insertion_point(field_map:greptime.v1.region.QueryContext.extensions)
+  return _internal_extensions();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+QueryContext::_internal_mutable_extensions() {
+  return _impl_.extensions_.MutableMap();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+QueryContext::mutable_extensions() {
+  // @@protoc_insertion_point(field_mutable_map:greptime.v1.region.QueryContext.extensions)
+  return _internal_mutable_extensions();
+}
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // RegionRequestHeader
 
 // map<string, string> tracing_context = 5;
@@ -4777,54 +5213,94 @@ inline void RegionRequestHeader::set_allocated_dbname(std::string* dbname) {
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequestHeader.dbname)
 }
 
-// string timezone = 4;
-inline void RegionRequestHeader::clear_timezone() {
-  _impl_.timezone_.ClearToEmpty();
+// .greptime.v1.region.QueryContext query_context = 6;
+inline bool RegionRequestHeader::_internal_has_query_context() const {
+  return this != internal_default_instance() && _impl_.query_context_ != nullptr;
 }
-inline const std::string& RegionRequestHeader::timezone() const {
-  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionRequestHeader.timezone)
-  return _internal_timezone();
+inline bool RegionRequestHeader::has_query_context() const {
+  return _internal_has_query_context();
 }
-template <typename ArgT0, typename... ArgT>
-inline PROTOBUF_ALWAYS_INLINE
-void RegionRequestHeader::set_timezone(ArgT0&& arg0, ArgT... args) {
- 
- _impl_.timezone_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:greptime.v1.region.RegionRequestHeader.timezone)
+inline void RegionRequestHeader::clear_query_context() {
+  if (GetArenaForAllocation() == nullptr && _impl_.query_context_ != nullptr) {
+    delete _impl_.query_context_;
+  }
+  _impl_.query_context_ = nullptr;
 }
-inline std::string* RegionRequestHeader::mutable_timezone() {
-  std::string* _s = _internal_mutable_timezone();
-  // @@protoc_insertion_point(field_mutable:greptime.v1.region.RegionRequestHeader.timezone)
-  return _s;
+inline const ::greptime::v1::region::QueryContext& RegionRequestHeader::_internal_query_context() const {
+  const ::greptime::v1::region::QueryContext* p = _impl_.query_context_;
+  return p != nullptr ? *p : reinterpret_cast<const ::greptime::v1::region::QueryContext&>(
+      ::greptime::v1::region::_QueryContext_default_instance_);
 }
-inline const std::string& RegionRequestHeader::_internal_timezone() const {
-  return _impl_.timezone_.Get();
+inline const ::greptime::v1::region::QueryContext& RegionRequestHeader::query_context() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionRequestHeader.query_context)
+  return _internal_query_context();
 }
-inline void RegionRequestHeader::_internal_set_timezone(const std::string& value) {
-  
-  _impl_.timezone_.Set(value, GetArenaForAllocation());
-}
-inline std::string* RegionRequestHeader::_internal_mutable_timezone() {
-  
-  return _impl_.timezone_.Mutable(GetArenaForAllocation());
-}
-inline std::string* RegionRequestHeader::release_timezone() {
-  // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequestHeader.timezone)
-  return _impl_.timezone_.Release();
-}
-inline void RegionRequestHeader::set_allocated_timezone(std::string* timezone) {
-  if (timezone != nullptr) {
+inline void RegionRequestHeader::unsafe_arena_set_allocated_query_context(
+    ::greptime::v1::region::QueryContext* query_context) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.query_context_);
+  }
+  _impl_.query_context_ = query_context;
+  if (query_context) {
     
   } else {
     
   }
-  _impl_.timezone_.SetAllocated(timezone, GetArenaForAllocation());
-#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.timezone_.IsDefault()) {
-    _impl_.timezone_.Set("", GetArenaForAllocation());
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.RegionRequestHeader.query_context)
+}
+inline ::greptime::v1::region::QueryContext* RegionRequestHeader::release_query_context() {
+  
+  ::greptime::v1::region::QueryContext* temp = _impl_.query_context_;
+  _impl_.query_context_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
   }
-#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequestHeader.timezone)
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::greptime::v1::region::QueryContext* RegionRequestHeader::unsafe_arena_release_query_context() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.RegionRequestHeader.query_context)
+  
+  ::greptime::v1::region::QueryContext* temp = _impl_.query_context_;
+  _impl_.query_context_ = nullptr;
+  return temp;
+}
+inline ::greptime::v1::region::QueryContext* RegionRequestHeader::_internal_mutable_query_context() {
+  
+  if (_impl_.query_context_ == nullptr) {
+    auto* p = CreateMaybeMessage<::greptime::v1::region::QueryContext>(GetArenaForAllocation());
+    _impl_.query_context_ = p;
+  }
+  return _impl_.query_context_;
+}
+inline ::greptime::v1::region::QueryContext* RegionRequestHeader::mutable_query_context() {
+  ::greptime::v1::region::QueryContext* _msg = _internal_mutable_query_context();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.RegionRequestHeader.query_context)
+  return _msg;
+}
+inline void RegionRequestHeader::set_allocated_query_context(::greptime::v1::region::QueryContext* query_context) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.query_context_;
+  }
+  if (query_context) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(query_context);
+    if (message_arena != submessage_arena) {
+      query_context = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, query_context, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.query_context_ = query_context;
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionRequestHeader.query_context)
 }
 
 // -------------------------------------------------------------------
@@ -7851,6 +8327,10 @@ inline void RegionColumnDef::set_column_id(uint32_t value) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -14,6 +14,1201 @@ public final class Server {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
+  public interface QueryContextOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:greptime.v1.region.QueryContext)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string current_catalog = 1;</code>
+     * @return The currentCatalog.
+     */
+    java.lang.String getCurrentCatalog();
+    /**
+     * <code>string current_catalog = 1;</code>
+     * @return The bytes for currentCatalog.
+     */
+    com.google.protobuf.ByteString
+        getCurrentCatalogBytes();
+
+    /**
+     * <code>string current_schema = 2;</code>
+     * @return The currentSchema.
+     */
+    java.lang.String getCurrentSchema();
+    /**
+     * <code>string current_schema = 2;</code>
+     * @return The bytes for currentSchema.
+     */
+    com.google.protobuf.ByteString
+        getCurrentSchemaBytes();
+
+    /**
+     * <code>string timezone = 4;</code>
+     * @return The timezone.
+     */
+    java.lang.String getTimezone();
+    /**
+     * <code>string timezone = 4;</code>
+     * @return The bytes for timezone.
+     */
+    com.google.protobuf.ByteString
+        getTimezoneBytes();
+
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+    int getExtensionsCount();
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+    boolean containsExtensions(
+        java.lang.String key);
+    /**
+     * Use {@link #getExtensionsMap()} instead.
+     */
+    @java.lang.Deprecated
+    java.util.Map<java.lang.String, java.lang.String>
+    getExtensions();
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+    java.util.Map<java.lang.String, java.lang.String>
+    getExtensionsMap();
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+
+    /* nullable */
+java.lang.String getExtensionsOrDefault(
+        java.lang.String key,
+        /* nullable */
+java.lang.String defaultValue);
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+
+    java.lang.String getExtensionsOrThrow(
+        java.lang.String key);
+  }
+  /**
+   * Protobuf type {@code greptime.v1.region.QueryContext}
+   */
+  public static final class QueryContext extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:greptime.v1.region.QueryContext)
+      QueryContextOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use QueryContext.newBuilder() to construct.
+    private QueryContext(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private QueryContext() {
+      currentCatalog_ = "";
+      currentSchema_ = "";
+      timezone_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new QueryContext();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private QueryContext(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              currentCatalog_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              currentSchema_ = s;
+              break;
+            }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              timezone_ = s;
+              break;
+            }
+            case 42: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                extensions_ = com.google.protobuf.MapField.newMapField(
+                    ExtensionsDefaultEntryHolder.defaultEntry);
+                mutable_bitField0_ |= 0x00000001;
+              }
+              com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
+              extensions__ = input.readMessage(
+                  ExtensionsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
+              extensions_.getMutableMap().put(
+                  extensions__.getKey(), extensions__.getValue());
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_QueryContext_descriptor;
+    }
+
+    @SuppressWarnings({"rawtypes"})
+    @java.lang.Override
+    protected com.google.protobuf.MapField internalGetMapField(
+        int number) {
+      switch (number) {
+        case 5:
+          return internalGetExtensions();
+        default:
+          throw new RuntimeException(
+              "Invalid map field number: " + number);
+      }
+    }
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_QueryContext_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.greptime.v1.region.Server.QueryContext.class, io.greptime.v1.region.Server.QueryContext.Builder.class);
+    }
+
+    public static final int CURRENT_CATALOG_FIELD_NUMBER = 1;
+    private volatile java.lang.Object currentCatalog_;
+    /**
+     * <code>string current_catalog = 1;</code>
+     * @return The currentCatalog.
+     */
+    @java.lang.Override
+    public java.lang.String getCurrentCatalog() {
+      java.lang.Object ref = currentCatalog_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        currentCatalog_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string current_catalog = 1;</code>
+     * @return The bytes for currentCatalog.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCurrentCatalogBytes() {
+      java.lang.Object ref = currentCatalog_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        currentCatalog_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CURRENT_SCHEMA_FIELD_NUMBER = 2;
+    private volatile java.lang.Object currentSchema_;
+    /**
+     * <code>string current_schema = 2;</code>
+     * @return The currentSchema.
+     */
+    @java.lang.Override
+    public java.lang.String getCurrentSchema() {
+      java.lang.Object ref = currentSchema_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        currentSchema_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string current_schema = 2;</code>
+     * @return The bytes for currentSchema.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCurrentSchemaBytes() {
+      java.lang.Object ref = currentSchema_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        currentSchema_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TIMEZONE_FIELD_NUMBER = 4;
+    private volatile java.lang.Object timezone_;
+    /**
+     * <code>string timezone = 4;</code>
+     * @return The timezone.
+     */
+    @java.lang.Override
+    public java.lang.String getTimezone() {
+      java.lang.Object ref = timezone_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        timezone_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string timezone = 4;</code>
+     * @return The bytes for timezone.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTimezoneBytes() {
+      java.lang.Object ref = timezone_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        timezone_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int EXTENSIONS_FIELD_NUMBER = 5;
+    private static final class ExtensionsDefaultEntryHolder {
+      static final com.google.protobuf.MapEntry<
+          java.lang.String, java.lang.String> defaultEntry =
+              com.google.protobuf.MapEntry
+              .<java.lang.String, java.lang.String>newDefaultInstance(
+                  io.greptime.v1.region.Server.internal_static_greptime_v1_region_QueryContext_ExtensionsEntry_descriptor, 
+                  com.google.protobuf.WireFormat.FieldType.STRING,
+                  "",
+                  com.google.protobuf.WireFormat.FieldType.STRING,
+                  "");
+    }
+    private com.google.protobuf.MapField<
+        java.lang.String, java.lang.String> extensions_;
+    private com.google.protobuf.MapField<java.lang.String, java.lang.String>
+    internalGetExtensions() {
+      if (extensions_ == null) {
+        return com.google.protobuf.MapField.emptyMapField(
+            ExtensionsDefaultEntryHolder.defaultEntry);
+      }
+      return extensions_;
+    }
+
+    public int getExtensionsCount() {
+      return internalGetExtensions().getMap().size();
+    }
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+
+    @java.lang.Override
+    public boolean containsExtensions(
+        java.lang.String key) {
+      if (key == null) { throw new NullPointerException("map key"); }
+      return internalGetExtensions().getMap().containsKey(key);
+    }
+    /**
+     * Use {@link #getExtensionsMap()} instead.
+     */
+    @java.lang.Override
+    @java.lang.Deprecated
+    public java.util.Map<java.lang.String, java.lang.String> getExtensions() {
+      return getExtensionsMap();
+    }
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+    @java.lang.Override
+
+    public java.util.Map<java.lang.String, java.lang.String> getExtensionsMap() {
+      return internalGetExtensions().getMap();
+    }
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+    @java.lang.Override
+
+    public java.lang.String getExtensionsOrDefault(
+        java.lang.String key,
+        java.lang.String defaultValue) {
+      if (key == null) { throw new NullPointerException("map key"); }
+      java.util.Map<java.lang.String, java.lang.String> map =
+          internalGetExtensions().getMap();
+      return map.containsKey(key) ? map.get(key) : defaultValue;
+    }
+    /**
+     * <code>map&lt;string, string&gt; extensions = 5;</code>
+     */
+    @java.lang.Override
+
+    public java.lang.String getExtensionsOrThrow(
+        java.lang.String key) {
+      if (key == null) { throw new NullPointerException("map key"); }
+      java.util.Map<java.lang.String, java.lang.String> map =
+          internalGetExtensions().getMap();
+      if (!map.containsKey(key)) {
+        throw new java.lang.IllegalArgumentException();
+      }
+      return map.get(key);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(currentCatalog_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, currentCatalog_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(currentSchema_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, currentSchema_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(timezone_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, timezone_);
+      }
+      com.google.protobuf.GeneratedMessageV3
+        .serializeStringMapTo(
+          output,
+          internalGetExtensions(),
+          ExtensionsDefaultEntryHolder.defaultEntry,
+          5);
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(currentCatalog_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, currentCatalog_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(currentSchema_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, currentSchema_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(timezone_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, timezone_);
+      }
+      for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
+           : internalGetExtensions().getMap().entrySet()) {
+        com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
+        extensions__ = ExtensionsDefaultEntryHolder.defaultEntry.newBuilderForType()
+            .setKey(entry.getKey())
+            .setValue(entry.getValue())
+            .build();
+        size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(5, extensions__);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.greptime.v1.region.Server.QueryContext)) {
+        return super.equals(obj);
+      }
+      io.greptime.v1.region.Server.QueryContext other = (io.greptime.v1.region.Server.QueryContext) obj;
+
+      if (!getCurrentCatalog()
+          .equals(other.getCurrentCatalog())) return false;
+      if (!getCurrentSchema()
+          .equals(other.getCurrentSchema())) return false;
+      if (!getTimezone()
+          .equals(other.getTimezone())) return false;
+      if (!internalGetExtensions().equals(
+          other.internalGetExtensions())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + CURRENT_CATALOG_FIELD_NUMBER;
+      hash = (53 * hash) + getCurrentCatalog().hashCode();
+      hash = (37 * hash) + CURRENT_SCHEMA_FIELD_NUMBER;
+      hash = (53 * hash) + getCurrentSchema().hashCode();
+      hash = (37 * hash) + TIMEZONE_FIELD_NUMBER;
+      hash = (53 * hash) + getTimezone().hashCode();
+      if (!internalGetExtensions().getMap().isEmpty()) {
+        hash = (37 * hash) + EXTENSIONS_FIELD_NUMBER;
+        hash = (53 * hash) + internalGetExtensions().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.QueryContext parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.greptime.v1.region.Server.QueryContext prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code greptime.v1.region.QueryContext}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:greptime.v1.region.QueryContext)
+        io.greptime.v1.region.Server.QueryContextOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_QueryContext_descriptor;
+      }
+
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMapField(
+          int number) {
+        switch (number) {
+          case 5:
+            return internalGetExtensions();
+          default:
+            throw new RuntimeException(
+                "Invalid map field number: " + number);
+        }
+      }
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMutableMapField(
+          int number) {
+        switch (number) {
+          case 5:
+            return internalGetMutableExtensions();
+          default:
+            throw new RuntimeException(
+                "Invalid map field number: " + number);
+        }
+      }
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_QueryContext_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.greptime.v1.region.Server.QueryContext.class, io.greptime.v1.region.Server.QueryContext.Builder.class);
+      }
+
+      // Construct using io.greptime.v1.region.Server.QueryContext.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        currentCatalog_ = "";
+
+        currentSchema_ = "";
+
+        timezone_ = "";
+
+        internalGetMutableExtensions().clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_QueryContext_descriptor;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.QueryContext getDefaultInstanceForType() {
+        return io.greptime.v1.region.Server.QueryContext.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.QueryContext build() {
+        io.greptime.v1.region.Server.QueryContext result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.QueryContext buildPartial() {
+        io.greptime.v1.region.Server.QueryContext result = new io.greptime.v1.region.Server.QueryContext(this);
+        int from_bitField0_ = bitField0_;
+        result.currentCatalog_ = currentCatalog_;
+        result.currentSchema_ = currentSchema_;
+        result.timezone_ = timezone_;
+        result.extensions_ = internalGetExtensions();
+        result.extensions_.makeImmutable();
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.greptime.v1.region.Server.QueryContext) {
+          return mergeFrom((io.greptime.v1.region.Server.QueryContext)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.greptime.v1.region.Server.QueryContext other) {
+        if (other == io.greptime.v1.region.Server.QueryContext.getDefaultInstance()) return this;
+        if (!other.getCurrentCatalog().isEmpty()) {
+          currentCatalog_ = other.currentCatalog_;
+          onChanged();
+        }
+        if (!other.getCurrentSchema().isEmpty()) {
+          currentSchema_ = other.currentSchema_;
+          onChanged();
+        }
+        if (!other.getTimezone().isEmpty()) {
+          timezone_ = other.timezone_;
+          onChanged();
+        }
+        internalGetMutableExtensions().mergeFrom(
+            other.internalGetExtensions());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.greptime.v1.region.Server.QueryContext parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.greptime.v1.region.Server.QueryContext) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object currentCatalog_ = "";
+      /**
+       * <code>string current_catalog = 1;</code>
+       * @return The currentCatalog.
+       */
+      public java.lang.String getCurrentCatalog() {
+        java.lang.Object ref = currentCatalog_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          currentCatalog_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string current_catalog = 1;</code>
+       * @return The bytes for currentCatalog.
+       */
+      public com.google.protobuf.ByteString
+          getCurrentCatalogBytes() {
+        java.lang.Object ref = currentCatalog_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          currentCatalog_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string current_catalog = 1;</code>
+       * @param value The currentCatalog to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCurrentCatalog(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        currentCatalog_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string current_catalog = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCurrentCatalog() {
+        
+        currentCatalog_ = getDefaultInstance().getCurrentCatalog();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string current_catalog = 1;</code>
+       * @param value The bytes for currentCatalog to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCurrentCatalogBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        currentCatalog_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object currentSchema_ = "";
+      /**
+       * <code>string current_schema = 2;</code>
+       * @return The currentSchema.
+       */
+      public java.lang.String getCurrentSchema() {
+        java.lang.Object ref = currentSchema_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          currentSchema_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string current_schema = 2;</code>
+       * @return The bytes for currentSchema.
+       */
+      public com.google.protobuf.ByteString
+          getCurrentSchemaBytes() {
+        java.lang.Object ref = currentSchema_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          currentSchema_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string current_schema = 2;</code>
+       * @param value The currentSchema to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCurrentSchema(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        currentSchema_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string current_schema = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCurrentSchema() {
+        
+        currentSchema_ = getDefaultInstance().getCurrentSchema();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string current_schema = 2;</code>
+       * @param value The bytes for currentSchema to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCurrentSchemaBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        currentSchema_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object timezone_ = "";
+      /**
+       * <code>string timezone = 4;</code>
+       * @return The timezone.
+       */
+      public java.lang.String getTimezone() {
+        java.lang.Object ref = timezone_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          timezone_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string timezone = 4;</code>
+       * @return The bytes for timezone.
+       */
+      public com.google.protobuf.ByteString
+          getTimezoneBytes() {
+        java.lang.Object ref = timezone_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          timezone_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string timezone = 4;</code>
+       * @param value The timezone to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTimezone(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        timezone_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string timezone = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTimezone() {
+        
+        timezone_ = getDefaultInstance().getTimezone();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string timezone = 4;</code>
+       * @param value The bytes for timezone to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTimezoneBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        timezone_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.MapField<
+          java.lang.String, java.lang.String> extensions_;
+      private com.google.protobuf.MapField<java.lang.String, java.lang.String>
+      internalGetExtensions() {
+        if (extensions_ == null) {
+          return com.google.protobuf.MapField.emptyMapField(
+              ExtensionsDefaultEntryHolder.defaultEntry);
+        }
+        return extensions_;
+      }
+      private com.google.protobuf.MapField<java.lang.String, java.lang.String>
+      internalGetMutableExtensions() {
+        onChanged();;
+        if (extensions_ == null) {
+          extensions_ = com.google.protobuf.MapField.newMapField(
+              ExtensionsDefaultEntryHolder.defaultEntry);
+        }
+        if (!extensions_.isMutable()) {
+          extensions_ = extensions_.copy();
+        }
+        return extensions_;
+      }
+
+      public int getExtensionsCount() {
+        return internalGetExtensions().getMap().size();
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+
+      @java.lang.Override
+      public boolean containsExtensions(
+          java.lang.String key) {
+        if (key == null) { throw new NullPointerException("map key"); }
+        return internalGetExtensions().getMap().containsKey(key);
+      }
+      /**
+       * Use {@link #getExtensionsMap()} instead.
+       */
+      @java.lang.Override
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, java.lang.String> getExtensions() {
+        return getExtensionsMap();
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+      @java.lang.Override
+
+      public java.util.Map<java.lang.String, java.lang.String> getExtensionsMap() {
+        return internalGetExtensions().getMap();
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+      @java.lang.Override
+
+      public java.lang.String getExtensionsOrDefault(
+          java.lang.String key,
+          java.lang.String defaultValue) {
+        if (key == null) { throw new NullPointerException("map key"); }
+        java.util.Map<java.lang.String, java.lang.String> map =
+            internalGetExtensions().getMap();
+        return map.containsKey(key) ? map.get(key) : defaultValue;
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+      @java.lang.Override
+
+      public java.lang.String getExtensionsOrThrow(
+          java.lang.String key) {
+        if (key == null) { throw new NullPointerException("map key"); }
+        java.util.Map<java.lang.String, java.lang.String> map =
+            internalGetExtensions().getMap();
+        if (!map.containsKey(key)) {
+          throw new java.lang.IllegalArgumentException();
+        }
+        return map.get(key);
+      }
+
+      public Builder clearExtensions() {
+        internalGetMutableExtensions().getMutableMap()
+            .clear();
+        return this;
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+
+      public Builder removeExtensions(
+          java.lang.String key) {
+        if (key == null) { throw new NullPointerException("map key"); }
+        internalGetMutableExtensions().getMutableMap()
+            .remove(key);
+        return this;
+      }
+      /**
+       * Use alternate mutation accessors instead.
+       */
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, java.lang.String>
+      getMutableExtensions() {
+        return internalGetMutableExtensions().getMutableMap();
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+      public Builder putExtensions(
+          java.lang.String key,
+          java.lang.String value) {
+        if (key == null) { throw new NullPointerException("map key"); }
+        if (value == null) {
+  throw new NullPointerException("map value");
+}
+
+        internalGetMutableExtensions().getMutableMap()
+            .put(key, value);
+        return this;
+      }
+      /**
+       * <code>map&lt;string, string&gt; extensions = 5;</code>
+       */
+
+      public Builder putAllExtensions(
+          java.util.Map<java.lang.String, java.lang.String> values) {
+        internalGetMutableExtensions().getMutableMap()
+            .putAll(values);
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:greptime.v1.region.QueryContext)
+    }
+
+    // @@protoc_insertion_point(class_scope:greptime.v1.region.QueryContext)
+    private static final io.greptime.v1.region.Server.QueryContext DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.greptime.v1.region.Server.QueryContext();
+    }
+
+    public static io.greptime.v1.region.Server.QueryContext getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<QueryContext>
+        PARSER = new com.google.protobuf.AbstractParser<QueryContext>() {
+      @java.lang.Override
+      public QueryContext parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new QueryContext(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<QueryContext> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<QueryContext> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.greptime.v1.region.Server.QueryContext getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface RegionRequestHeaderOrBuilder extends
       // @@protoc_insertion_point(interface_extends:greptime.v1.region.RegionRequestHeader)
       com.google.protobuf.MessageOrBuilder {
@@ -101,23 +1296,30 @@ java.lang.String defaultValue);
 
     /**
      * <pre>
-     * The `timezone` for the request
+     * The contextual information of the query
      * </pre>
      *
-     * <code>string timezone = 4;</code>
-     * @return The timezone.
+     * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+     * @return Whether the queryContext field is set.
      */
-    java.lang.String getTimezone();
+    boolean hasQueryContext();
     /**
      * <pre>
-     * The `timezone` for the request
+     * The contextual information of the query
      * </pre>
      *
-     * <code>string timezone = 4;</code>
-     * @return The bytes for timezone.
+     * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+     * @return The queryContext.
      */
-    com.google.protobuf.ByteString
-        getTimezoneBytes();
+    io.greptime.v1.region.Server.QueryContext getQueryContext();
+    /**
+     * <pre>
+     * The contextual information of the query
+     * </pre>
+     *
+     * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+     */
+    io.greptime.v1.region.Server.QueryContextOrBuilder getQueryContextOrBuilder();
   }
   /**
    * Protobuf type {@code greptime.v1.region.RegionRequestHeader}
@@ -133,7 +1335,6 @@ java.lang.String defaultValue);
     }
     private RegionRequestHeader() {
       dbname_ = "";
-      timezone_ = "";
     }
 
     @java.lang.Override
@@ -173,12 +1374,6 @@ java.lang.String defaultValue);
               dbname_ = s;
               break;
             }
-            case 34: {
-              java.lang.String s = input.readStringRequireUtf8();
-
-              timezone_ = s;
-              break;
-            }
             case 42: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 tracingContext_ = com.google.protobuf.MapField.newMapField(
@@ -190,6 +1385,19 @@ java.lang.String defaultValue);
                   TracingContextDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               tracingContext_.getMutableMap().put(
                   tracingContext__.getKey(), tracingContext__.getValue());
+              break;
+            }
+            case 50: {
+              io.greptime.v1.region.Server.QueryContext.Builder subBuilder = null;
+              if (queryContext_ != null) {
+                subBuilder = queryContext_.toBuilder();
+              }
+              queryContext_ = input.readMessage(io.greptime.v1.region.Server.QueryContext.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(queryContext_);
+                queryContext_ = subBuilder.buildPartial();
+              }
+
               break;
             }
             default: {
@@ -385,50 +1593,42 @@ java.lang.String defaultValue);
       }
     }
 
-    public static final int TIMEZONE_FIELD_NUMBER = 4;
-    private volatile java.lang.Object timezone_;
+    public static final int QUERY_CONTEXT_FIELD_NUMBER = 6;
+    private io.greptime.v1.region.Server.QueryContext queryContext_;
     /**
      * <pre>
-     * The `timezone` for the request
+     * The contextual information of the query
      * </pre>
      *
-     * <code>string timezone = 4;</code>
-     * @return The timezone.
+     * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+     * @return Whether the queryContext field is set.
      */
     @java.lang.Override
-    public java.lang.String getTimezone() {
-      java.lang.Object ref = timezone_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        timezone_ = s;
-        return s;
-      }
+    public boolean hasQueryContext() {
+      return queryContext_ != null;
     }
     /**
      * <pre>
-     * The `timezone` for the request
+     * The contextual information of the query
      * </pre>
      *
-     * <code>string timezone = 4;</code>
-     * @return The bytes for timezone.
+     * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+     * @return The queryContext.
      */
     @java.lang.Override
-    public com.google.protobuf.ByteString
-        getTimezoneBytes() {
-      java.lang.Object ref = timezone_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        timezone_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+    public io.greptime.v1.region.Server.QueryContext getQueryContext() {
+      return queryContext_ == null ? io.greptime.v1.region.Server.QueryContext.getDefaultInstance() : queryContext_;
+    }
+    /**
+     * <pre>
+     * The contextual information of the query
+     * </pre>
+     *
+     * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+     */
+    @java.lang.Override
+    public io.greptime.v1.region.Server.QueryContextOrBuilder getQueryContextOrBuilder() {
+      return getQueryContext();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -448,15 +1648,15 @@ java.lang.String defaultValue);
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(dbname_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, dbname_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(timezone_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, timezone_);
-      }
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
           output,
           internalGetTracingContext(),
           TracingContextDefaultEntryHolder.defaultEntry,
           5);
+      if (queryContext_ != null) {
+        output.writeMessage(6, getQueryContext());
+      }
       unknownFields.writeTo(output);
     }
 
@@ -469,9 +1669,6 @@ java.lang.String defaultValue);
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(dbname_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, dbname_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(timezone_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, timezone_);
-      }
       for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
            : internalGetTracingContext().getMap().entrySet()) {
         com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
@@ -481,6 +1678,10 @@ java.lang.String defaultValue);
             .build();
         size += com.google.protobuf.CodedOutputStream
             .computeMessageSize(5, tracingContext__);
+      }
+      if (queryContext_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, getQueryContext());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -501,8 +1702,11 @@ java.lang.String defaultValue);
           other.internalGetTracingContext())) return false;
       if (!getDbname()
           .equals(other.getDbname())) return false;
-      if (!getTimezone()
-          .equals(other.getTimezone())) return false;
+      if (hasQueryContext() != other.hasQueryContext()) return false;
+      if (hasQueryContext()) {
+        if (!getQueryContext()
+            .equals(other.getQueryContext())) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -520,8 +1724,10 @@ java.lang.String defaultValue);
       }
       hash = (37 * hash) + DBNAME_FIELD_NUMBER;
       hash = (53 * hash) + getDbname().hashCode();
-      hash = (37 * hash) + TIMEZONE_FIELD_NUMBER;
-      hash = (53 * hash) + getTimezone().hashCode();
+      if (hasQueryContext()) {
+        hash = (37 * hash) + QUERY_CONTEXT_FIELD_NUMBER;
+        hash = (53 * hash) + getQueryContext().hashCode();
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -680,8 +1886,12 @@ java.lang.String defaultValue);
         internalGetMutableTracingContext().clear();
         dbname_ = "";
 
-        timezone_ = "";
-
+        if (queryContextBuilder_ == null) {
+          queryContext_ = null;
+        } else {
+          queryContext_ = null;
+          queryContextBuilder_ = null;
+        }
         return this;
       }
 
@@ -712,7 +1922,11 @@ java.lang.String defaultValue);
         result.tracingContext_ = internalGetTracingContext();
         result.tracingContext_.makeImmutable();
         result.dbname_ = dbname_;
-        result.timezone_ = timezone_;
+        if (queryContextBuilder_ == null) {
+          result.queryContext_ = queryContext_;
+        } else {
+          result.queryContext_ = queryContextBuilder_.build();
+        }
         onBuilt();
         return result;
       }
@@ -767,9 +1981,8 @@ java.lang.String defaultValue);
           dbname_ = other.dbname_;
           onChanged();
         }
-        if (!other.getTimezone().isEmpty()) {
-          timezone_ = other.timezone_;
-          onChanged();
+        if (other.hasQueryContext()) {
+          mergeQueryContext(other.getQueryContext());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -1063,100 +2276,159 @@ java.lang.String defaultValue);
         return this;
       }
 
-      private java.lang.Object timezone_ = "";
+      private io.greptime.v1.region.Server.QueryContext queryContext_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          io.greptime.v1.region.Server.QueryContext, io.greptime.v1.region.Server.QueryContext.Builder, io.greptime.v1.region.Server.QueryContextOrBuilder> queryContextBuilder_;
       /**
        * <pre>
-       * The `timezone` for the request
+       * The contextual information of the query
        * </pre>
        *
-       * <code>string timezone = 4;</code>
-       * @return The timezone.
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       * @return Whether the queryContext field is set.
        */
-      public java.lang.String getTimezone() {
-        java.lang.Object ref = timezone_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          timezone_ = s;
-          return s;
+      public boolean hasQueryContext() {
+        return queryContextBuilder_ != null || queryContext_ != null;
+      }
+      /**
+       * <pre>
+       * The contextual information of the query
+       * </pre>
+       *
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       * @return The queryContext.
+       */
+      public io.greptime.v1.region.Server.QueryContext getQueryContext() {
+        if (queryContextBuilder_ == null) {
+          return queryContext_ == null ? io.greptime.v1.region.Server.QueryContext.getDefaultInstance() : queryContext_;
         } else {
-          return (java.lang.String) ref;
+          return queryContextBuilder_.getMessage();
         }
       }
       /**
        * <pre>
-       * The `timezone` for the request
+       * The contextual information of the query
        * </pre>
        *
-       * <code>string timezone = 4;</code>
-       * @return The bytes for timezone.
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
        */
-      public com.google.protobuf.ByteString
-          getTimezoneBytes() {
-        java.lang.Object ref = timezone_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          timezone_ = b;
-          return b;
+      public Builder setQueryContext(io.greptime.v1.region.Server.QueryContext value) {
+        if (queryContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          queryContext_ = value;
+          onChanged();
         } else {
-          return (com.google.protobuf.ByteString) ref;
+          queryContextBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The contextual information of the query
+       * </pre>
+       *
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       */
+      public Builder setQueryContext(
+          io.greptime.v1.region.Server.QueryContext.Builder builderForValue) {
+        if (queryContextBuilder_ == null) {
+          queryContext_ = builderForValue.build();
+          onChanged();
+        } else {
+          queryContextBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The contextual information of the query
+       * </pre>
+       *
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       */
+      public Builder mergeQueryContext(io.greptime.v1.region.Server.QueryContext value) {
+        if (queryContextBuilder_ == null) {
+          if (queryContext_ != null) {
+            queryContext_ =
+              io.greptime.v1.region.Server.QueryContext.newBuilder(queryContext_).mergeFrom(value).buildPartial();
+          } else {
+            queryContext_ = value;
+          }
+          onChanged();
+        } else {
+          queryContextBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The contextual information of the query
+       * </pre>
+       *
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       */
+      public Builder clearQueryContext() {
+        if (queryContextBuilder_ == null) {
+          queryContext_ = null;
+          onChanged();
+        } else {
+          queryContext_ = null;
+          queryContextBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The contextual information of the query
+       * </pre>
+       *
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       */
+      public io.greptime.v1.region.Server.QueryContext.Builder getQueryContextBuilder() {
+        
+        onChanged();
+        return getQueryContextFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * The contextual information of the query
+       * </pre>
+       *
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
+       */
+      public io.greptime.v1.region.Server.QueryContextOrBuilder getQueryContextOrBuilder() {
+        if (queryContextBuilder_ != null) {
+          return queryContextBuilder_.getMessageOrBuilder();
+        } else {
+          return queryContext_ == null ?
+              io.greptime.v1.region.Server.QueryContext.getDefaultInstance() : queryContext_;
         }
       }
       /**
        * <pre>
-       * The `timezone` for the request
+       * The contextual information of the query
        * </pre>
        *
-       * <code>string timezone = 4;</code>
-       * @param value The timezone to set.
-       * @return This builder for chaining.
+       * <code>.greptime.v1.region.QueryContext query_context = 6;</code>
        */
-      public Builder setTimezone(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
-        timezone_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * The `timezone` for the request
-       * </pre>
-       *
-       * <code>string timezone = 4;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearTimezone() {
-        
-        timezone_ = getDefaultInstance().getTimezone();
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * The `timezone` for the request
-       * </pre>
-       *
-       * <code>string timezone = 4;</code>
-       * @param value The bytes for timezone to set.
-       * @return This builder for chaining.
-       */
-      public Builder setTimezoneBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
-        timezone_ = value;
-        onChanged();
-        return this;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          io.greptime.v1.region.Server.QueryContext, io.greptime.v1.region.Server.QueryContext.Builder, io.greptime.v1.region.Server.QueryContextOrBuilder> 
+          getQueryContextFieldBuilder() {
+        if (queryContextBuilder_ == null) {
+          queryContextBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              io.greptime.v1.region.Server.QueryContext, io.greptime.v1.region.Server.QueryContext.Builder, io.greptime.v1.region.Server.QueryContextOrBuilder>(
+                  getQueryContext(),
+                  getParentForChildren(),
+                  isClean());
+          queryContext_ = null;
+        }
+        return queryContextBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -22811,6 +24083,16 @@ java.lang.String defaultValue);
   }
 
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_region_QueryContext_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_region_QueryContext_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_region_QueryContext_ExtensionsEntry_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_region_QueryContext_ExtensionsEntry_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_greptime_v1_region_RegionRequestHeader_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -22962,86 +24244,92 @@ java.lang.String defaultValue);
       "\n\037greptime/v1/region/server.proto\022\022grept" +
       "ime.v1.region\032\030greptime/v1/common.proto\032" +
       "\025greptime/v1/row.proto\032\025greptime/v1/ddl." +
-      "proto\"\304\001\n\023RegionRequestHeader\022T\n\017tracing" +
-      "_context\030\005 \003(\0132;.greptime.v1.region.Regi" +
-      "onRequestHeader.TracingContextEntry\022\016\n\006d" +
-      "bname\030\003 \001(\t\022\020\n\010timezone\030\004 \001(\t\0325\n\023Tracing" +
-      "ContextEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t" +
-      ":\0028\001\"\375\005\n\rRegionRequest\0227\n\006header\030\001 \001(\0132\'" +
-      ".greptime.v1.region.RegionRequestHeader\022" +
-      "5\n\007inserts\030\003 \001(\0132\".greptime.v1.region.In" +
-      "sertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".grepti" +
-      "me.v1.region.DeleteRequestsH\000\0223\n\006create\030" +
-      "\005 \001(\0132!.greptime.v1.region.CreateRequest" +
-      "H\000\022/\n\004drop\030\006 \001(\0132\037.greptime.v1.region.Dr" +
-      "opRequestH\000\022/\n\004open\030\007 \001(\0132\037.greptime.v1." +
-      "region.OpenRequestH\000\0221\n\005close\030\010 \001(\0132 .gr" +
-      "eptime.v1.region.CloseRequestH\000\0221\n\005alter" +
-      "\030\t \001(\0132 .greptime.v1.region.AlterRequest" +
-      "H\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.region.F" +
-      "lushRequestH\000\0225\n\007compact\030\013 \001(\0132\".greptim" +
-      "e.v1.region.CompactRequestH\000\0227\n\010truncate" +
-      "\030\014 \001(\0132#.greptime.v1.region.TruncateRequ" +
-      "estH\000\0225\n\007creates\030\r \001(\0132\".greptime.v1.reg" +
-      "ion.CreateRequestsH\000\0221\n\005drops\030\016 \001(\0132 .gr" +
-      "eptime.v1.region.DropRequestsH\000\0223\n\006alter" +
-      "s\030\017 \001(\0132!.greptime.v1.region.AlterReques" +
-      "tsH\000B\006\n\004body\"\314\001\n\016RegionResponse\022+\n\006heade" +
-      "r\030\001 \001(\0132\033.greptime.v1.ResponseHeader\022\025\n\r" +
-      "affected_rows\030\002 \001(\004\022D\n\textension\030\003 \003(\01321" +
-      ".greptime.v1.region.RegionResponse.Exten" +
-      "sionEntry\0320\n\016ExtensionEntry\022\013\n\003key\030\001 \001(\t" +
-      "\022\r\n\005value\030\002 \001(\014:\0028\001\"E\n\016InsertRequests\0223\n" +
-      "\010requests\030\001 \003(\0132!.greptime.v1.region.Ins" +
-      "ertRequest\"E\n\016DeleteRequests\0223\n\010requests" +
-      "\030\001 \003(\0132!.greptime.v1.region.DeleteReques" +
-      "t\"C\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(\004\022\037\n" +
-      "\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"C\n\rDelete" +
-      "Request\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002 \001(\013" +
-      "2\021.greptime.v1.Rows\"h\n\014QueryRequest\0227\n\006h" +
-      "eader\030\001 \001(\0132\'.greptime.v1.region.RegionR" +
-      "equestHeader\022\021\n\tregion_id\030\002 \001(\004\022\014\n\004plan\030" +
-      "\003 \001(\014\"E\n\016CreateRequests\0223\n\010requests\030\001 \003(" +
-      "\0132!.greptime.v1.region.CreateRequest\"\200\002\n" +
-      "\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006eng" +
-      "ine\030\002 \001(\t\0228\n\013column_defs\030\003 \003(\0132#.greptim" +
-      "e.v1.region.RegionColumnDef\022\023\n\013primary_k" +
-      "ey\030\004 \003(\r\022\014\n\004path\030\005 \001(\t\022?\n\007options\030\006 \003(\0132" +
-      "..greptime.v1.region.CreateRequest.Optio" +
-      "nsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005" +
-      "value\030\002 \001(\t:\0028\001\"A\n\014DropRequests\0221\n\010reque" +
-      "sts\030\001 \003(\0132\037.greptime.v1.region.DropReque" +
-      "st\" \n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004\"\255\001\n" +
-      "\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006engin" +
-      "e\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=\n\007options\030\004 \003(\0132," +
-      ".greptime.v1.region.OpenRequest.OptionsE" +
-      "ntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005val" +
-      "ue\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregion_i" +
-      "d\030\001 \001(\004\"C\n\rAlterRequests\0222\n\010requests\030\001 \003" +
-      "(\0132 .greptime.v1.region.AlterRequest\"\360\001\n" +
-      "\014AlterRequest\022\021\n\tregion_id\030\001 \001(\004\0225\n\013add_" +
-      "columns\030\002 \001(\0132\036.greptime.v1.region.AddCo" +
-      "lumnsH\000\0227\n\014drop_columns\030\003 \001(\0132\037.greptime" +
-      ".v1.region.DropColumnsH\000\022=\n\023change_colum" +
-      "n_types\030\005 \001(\0132\036.greptime.v1.ChangeColumn" +
-      "TypesH\000\022\026\n\016schema_version\030\004 \001(\004B\006\n\004kind\"" +
-      "@\n\nAddColumns\0222\n\013add_columns\030\001 \003(\0132\035.gre" +
-      "ptime.v1.region.AddColumn\"C\n\013DropColumns" +
-      "\0224\n\014drop_columns\030\001 \003(\0132\036.greptime.v1.reg" +
-      "ion.DropColumn\"v\n\tAddColumn\0227\n\ncolumn_de" +
-      "f\030\001 \001(\0132#.greptime.v1.region.RegionColum" +
-      "nDef\0220\n\010location\030\003 \001(\0132\036.greptime.v1.Add" +
-      "ColumnLocation\"\032\n\nDropColumn\022\014\n\004name\030\001 \001" +
-      "(\t\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(\004\"#\n" +
-      "\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"$\n\017Tr" +
-      "uncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n\017Regi" +
-      "onColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.grepti" +
-      "me.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2Y\n\006Re" +
-      "gion\022O\n\006Handle\022!.greptime.v1.region.Regi" +
-      "onRequest\032\".greptime.v1.region.RegionRes" +
-      "ponseB]\n\025io.greptime.v1.regionB\006ServerZ<" +
-      "github.com/GreptimeTeam/greptime-proto/g" +
-      "o/greptime/v1/regionb\006proto3"
+      "proto\"\312\001\n\014QueryContext\022\027\n\017current_catalo" +
+      "g\030\001 \001(\t\022\026\n\016current_schema\030\002 \001(\t\022\020\n\010timez" +
+      "one\030\004 \001(\t\022D\n\nextensions\030\005 \003(\01320.greptime" +
+      ".v1.region.QueryContext.ExtensionsEntry\032" +
+      "1\n\017ExtensionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value" +
+      "\030\002 \001(\t:\0028\001\"\353\001\n\023RegionRequestHeader\022T\n\017tr" +
+      "acing_context\030\005 \003(\0132;.greptime.v1.region" +
+      ".RegionRequestHeader.TracingContextEntry" +
+      "\022\016\n\006dbname\030\003 \001(\t\0227\n\rquery_context\030\006 \001(\0132" +
+      " .greptime.v1.region.QueryContext\0325\n\023Tra" +
+      "cingContextEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002" +
+      " \001(\t:\0028\001\"\375\005\n\rRegionRequest\0227\n\006header\030\001 \001" +
+      "(\0132\'.greptime.v1.region.RegionRequestHea" +
+      "der\0225\n\007inserts\030\003 \001(\0132\".greptime.v1.regio" +
+      "n.InsertRequestsH\000\0225\n\007deletes\030\004 \001(\0132\".gr" +
+      "eptime.v1.region.DeleteRequestsH\000\0223\n\006cre" +
+      "ate\030\005 \001(\0132!.greptime.v1.region.CreateReq" +
+      "uestH\000\022/\n\004drop\030\006 \001(\0132\037.greptime.v1.regio" +
+      "n.DropRequestH\000\022/\n\004open\030\007 \001(\0132\037.greptime" +
+      ".v1.region.OpenRequestH\000\0221\n\005close\030\010 \001(\0132" +
+      " .greptime.v1.region.CloseRequestH\000\0221\n\005a" +
+      "lter\030\t \001(\0132 .greptime.v1.region.AlterReq" +
+      "uestH\000\0221\n\005flush\030\n \001(\0132 .greptime.v1.regi" +
+      "on.FlushRequestH\000\0225\n\007compact\030\013 \001(\0132\".gre" +
+      "ptime.v1.region.CompactRequestH\000\0227\n\010trun" +
+      "cate\030\014 \001(\0132#.greptime.v1.region.Truncate" +
+      "RequestH\000\0225\n\007creates\030\r \001(\0132\".greptime.v1" +
+      ".region.CreateRequestsH\000\0221\n\005drops\030\016 \001(\0132" +
+      " .greptime.v1.region.DropRequestsH\000\0223\n\006a" +
+      "lters\030\017 \001(\0132!.greptime.v1.region.AlterRe" +
+      "questsH\000B\006\n\004body\"\314\001\n\016RegionResponse\022+\n\006h" +
+      "eader\030\001 \001(\0132\033.greptime.v1.ResponseHeader" +
+      "\022\025\n\raffected_rows\030\002 \001(\004\022D\n\textension\030\003 \003" +
+      "(\01321.greptime.v1.region.RegionResponse.E" +
+      "xtensionEntry\0320\n\016ExtensionEntry\022\013\n\003key\030\001" +
+      " \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"E\n\016InsertRequest" +
+      "s\0223\n\010requests\030\001 \003(\0132!.greptime.v1.region" +
+      ".InsertRequest\"E\n\016DeleteRequests\0223\n\010requ" +
+      "ests\030\001 \003(\0132!.greptime.v1.region.DeleteRe" +
+      "quest\"C\n\rInsertRequest\022\021\n\tregion_id\030\001 \001(" +
+      "\004\022\037\n\004rows\030\002 \001(\0132\021.greptime.v1.Rows\"C\n\rDe" +
+      "leteRequest\022\021\n\tregion_id\030\001 \001(\004\022\037\n\004rows\030\002" +
+      " \001(\0132\021.greptime.v1.Rows\"h\n\014QueryRequest\022" +
+      "7\n\006header\030\001 \001(\0132\'.greptime.v1.region.Reg" +
+      "ionRequestHeader\022\021\n\tregion_id\030\002 \001(\004\022\014\n\004p" +
+      "lan\030\003 \001(\014\"E\n\016CreateRequests\0223\n\010requests\030" +
+      "\001 \003(\0132!.greptime.v1.region.CreateRequest" +
+      "\"\200\002\n\rCreateRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n" +
+      "\006engine\030\002 \001(\t\0228\n\013column_defs\030\003 \003(\0132#.gre" +
+      "ptime.v1.region.RegionColumnDef\022\023\n\013prima" +
+      "ry_key\030\004 \003(\r\022\014\n\004path\030\005 \001(\t\022?\n\007options\030\006 " +
+      "\003(\0132..greptime.v1.region.CreateRequest.O" +
+      "ptionsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t" +
+      "\022\r\n\005value\030\002 \001(\t:\0028\001\"A\n\014DropRequests\0221\n\010r" +
+      "equests\030\001 \003(\0132\037.greptime.v1.region.DropR" +
+      "equest\" \n\013DropRequest\022\021\n\tregion_id\030\001 \001(\004" +
+      "\"\255\001\n\013OpenRequest\022\021\n\tregion_id\030\001 \001(\004\022\016\n\006e" +
+      "ngine\030\002 \001(\t\022\014\n\004path\030\003 \001(\t\022=\n\007options\030\004 \003" +
+      "(\0132,.greptime.v1.region.OpenRequest.Opti" +
+      "onsEntry\032.\n\014OptionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
+      "\005value\030\002 \001(\t:\0028\001\"!\n\014CloseRequest\022\021\n\tregi" +
+      "on_id\030\001 \001(\004\"C\n\rAlterRequests\0222\n\010requests" +
+      "\030\001 \003(\0132 .greptime.v1.region.AlterRequest" +
+      "\"\360\001\n\014AlterRequest\022\021\n\tregion_id\030\001 \001(\004\0225\n\013" +
+      "add_columns\030\002 \001(\0132\036.greptime.v1.region.A" +
+      "ddColumnsH\000\0227\n\014drop_columns\030\003 \001(\0132\037.grep" +
+      "time.v1.region.DropColumnsH\000\022=\n\023change_c" +
+      "olumn_types\030\005 \001(\0132\036.greptime.v1.ChangeCo" +
+      "lumnTypesH\000\022\026\n\016schema_version\030\004 \001(\004B\006\n\004k" +
+      "ind\"@\n\nAddColumns\0222\n\013add_columns\030\001 \003(\0132\035" +
+      ".greptime.v1.region.AddColumn\"C\n\013DropCol" +
+      "umns\0224\n\014drop_columns\030\001 \003(\0132\036.greptime.v1" +
+      ".region.DropColumn\"v\n\tAddColumn\0227\n\ncolum" +
+      "n_def\030\001 \001(\0132#.greptime.v1.region.RegionC" +
+      "olumnDef\0220\n\010location\030\003 \001(\0132\036.greptime.v1" +
+      ".AddColumnLocation\"\032\n\nDropColumn\022\014\n\004name" +
+      "\030\001 \001(\t\"!\n\014FlushRequest\022\021\n\tregion_id\030\001 \001(" +
+      "\004\"#\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\"$" +
+      "\n\017TruncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n\017" +
+      "RegionColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.gr" +
+      "eptime.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2Y" +
+      "\n\006Region\022O\n\006Handle\022!.greptime.v1.region." +
+      "RegionRequest\032\".greptime.v1.region.Regio" +
+      "nResponseB]\n\025io.greptime.v1.regionB\006Serv" +
+      "erZ<github.com/GreptimeTeam/greptime-pro" +
+      "to/go/greptime/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -23050,12 +24338,24 @@ java.lang.String defaultValue);
           io.greptime.v1.RowData.getDescriptor(),
           io.greptime.v1.Ddl.getDescriptor(),
         });
-    internal_static_greptime_v1_region_RegionRequestHeader_descriptor =
+    internal_static_greptime_v1_region_QueryContext_descriptor =
       getDescriptor().getMessageTypes().get(0);
+    internal_static_greptime_v1_region_QueryContext_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_region_QueryContext_descriptor,
+        new java.lang.String[] { "CurrentCatalog", "CurrentSchema", "Timezone", "Extensions", });
+    internal_static_greptime_v1_region_QueryContext_ExtensionsEntry_descriptor =
+      internal_static_greptime_v1_region_QueryContext_descriptor.getNestedTypes().get(0);
+    internal_static_greptime_v1_region_QueryContext_ExtensionsEntry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_region_QueryContext_ExtensionsEntry_descriptor,
+        new java.lang.String[] { "Key", "Value", });
+    internal_static_greptime_v1_region_RegionRequestHeader_descriptor =
+      getDescriptor().getMessageTypes().get(1);
     internal_static_greptime_v1_region_RegionRequestHeader_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequestHeader_descriptor,
-        new java.lang.String[] { "TracingContext", "Dbname", "Timezone", });
+        new java.lang.String[] { "TracingContext", "Dbname", "QueryContext", });
     internal_static_greptime_v1_region_RegionRequestHeader_TracingContextEntry_descriptor =
       internal_static_greptime_v1_region_RegionRequestHeader_descriptor.getNestedTypes().get(0);
     internal_static_greptime_v1_region_RegionRequestHeader_TracingContextEntry_fieldAccessorTable = new
@@ -23063,13 +24363,13 @@ java.lang.String defaultValue);
         internal_static_greptime_v1_region_RegionRequestHeader_TracingContextEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_greptime_v1_region_RegionRequest_descriptor =
-      getDescriptor().getMessageTypes().get(1);
+      getDescriptor().getMessageTypes().get(2);
     internal_static_greptime_v1_region_RegionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionRequest_descriptor,
         new java.lang.String[] { "Header", "Inserts", "Deletes", "Create", "Drop", "Open", "Close", "Alter", "Flush", "Compact", "Truncate", "Creates", "Drops", "Alters", "Body", });
     internal_static_greptime_v1_region_RegionResponse_descriptor =
-      getDescriptor().getMessageTypes().get(2);
+      getDescriptor().getMessageTypes().get(3);
     internal_static_greptime_v1_region_RegionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionResponse_descriptor,
@@ -23081,43 +24381,43 @@ java.lang.String defaultValue);
         internal_static_greptime_v1_region_RegionResponse_ExtensionEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_greptime_v1_region_InsertRequests_descriptor =
-      getDescriptor().getMessageTypes().get(3);
+      getDescriptor().getMessageTypes().get(4);
     internal_static_greptime_v1_region_InsertRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_InsertRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_DeleteRequests_descriptor =
-      getDescriptor().getMessageTypes().get(4);
+      getDescriptor().getMessageTypes().get(5);
     internal_static_greptime_v1_region_DeleteRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DeleteRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_InsertRequest_descriptor =
-      getDescriptor().getMessageTypes().get(5);
+      getDescriptor().getMessageTypes().get(6);
     internal_static_greptime_v1_region_InsertRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_InsertRequest_descriptor,
         new java.lang.String[] { "RegionId", "Rows", });
     internal_static_greptime_v1_region_DeleteRequest_descriptor =
-      getDescriptor().getMessageTypes().get(6);
+      getDescriptor().getMessageTypes().get(7);
     internal_static_greptime_v1_region_DeleteRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DeleteRequest_descriptor,
         new java.lang.String[] { "RegionId", "Rows", });
     internal_static_greptime_v1_region_QueryRequest_descriptor =
-      getDescriptor().getMessageTypes().get(7);
+      getDescriptor().getMessageTypes().get(8);
     internal_static_greptime_v1_region_QueryRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_QueryRequest_descriptor,
         new java.lang.String[] { "Header", "RegionId", "Plan", });
     internal_static_greptime_v1_region_CreateRequests_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_greptime_v1_region_CreateRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CreateRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_CreateRequest_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_greptime_v1_region_CreateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CreateRequest_descriptor,
@@ -23129,19 +24429,19 @@ java.lang.String defaultValue);
         internal_static_greptime_v1_region_CreateRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_greptime_v1_region_DropRequests_descriptor =
-      getDescriptor().getMessageTypes().get(10);
+      getDescriptor().getMessageTypes().get(11);
     internal_static_greptime_v1_region_DropRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DropRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_DropRequest_descriptor =
-      getDescriptor().getMessageTypes().get(11);
+      getDescriptor().getMessageTypes().get(12);
     internal_static_greptime_v1_region_DropRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DropRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_OpenRequest_descriptor =
-      getDescriptor().getMessageTypes().get(12);
+      getDescriptor().getMessageTypes().get(13);
     internal_static_greptime_v1_region_OpenRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_OpenRequest_descriptor,
@@ -23153,67 +24453,67 @@ java.lang.String defaultValue);
         internal_static_greptime_v1_region_OpenRequest_OptionsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_greptime_v1_region_CloseRequest_descriptor =
-      getDescriptor().getMessageTypes().get(13);
+      getDescriptor().getMessageTypes().get(14);
     internal_static_greptime_v1_region_CloseRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CloseRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_AlterRequests_descriptor =
-      getDescriptor().getMessageTypes().get(14);
+      getDescriptor().getMessageTypes().get(15);
     internal_static_greptime_v1_region_AlterRequests_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_AlterRequests_descriptor,
         new java.lang.String[] { "Requests", });
     internal_static_greptime_v1_region_AlterRequest_descriptor =
-      getDescriptor().getMessageTypes().get(15);
+      getDescriptor().getMessageTypes().get(16);
     internal_static_greptime_v1_region_AlterRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_AlterRequest_descriptor,
         new java.lang.String[] { "RegionId", "AddColumns", "DropColumns", "ChangeColumnTypes", "SchemaVersion", "Kind", });
     internal_static_greptime_v1_region_AddColumns_descriptor =
-      getDescriptor().getMessageTypes().get(16);
+      getDescriptor().getMessageTypes().get(17);
     internal_static_greptime_v1_region_AddColumns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_AddColumns_descriptor,
         new java.lang.String[] { "AddColumns", });
     internal_static_greptime_v1_region_DropColumns_descriptor =
-      getDescriptor().getMessageTypes().get(17);
+      getDescriptor().getMessageTypes().get(18);
     internal_static_greptime_v1_region_DropColumns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DropColumns_descriptor,
         new java.lang.String[] { "DropColumns", });
     internal_static_greptime_v1_region_AddColumn_descriptor =
-      getDescriptor().getMessageTypes().get(18);
+      getDescriptor().getMessageTypes().get(19);
     internal_static_greptime_v1_region_AddColumn_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_AddColumn_descriptor,
         new java.lang.String[] { "ColumnDef", "Location", });
     internal_static_greptime_v1_region_DropColumn_descriptor =
-      getDescriptor().getMessageTypes().get(19);
+      getDescriptor().getMessageTypes().get(20);
     internal_static_greptime_v1_region_DropColumn_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_DropColumn_descriptor,
         new java.lang.String[] { "Name", });
     internal_static_greptime_v1_region_FlushRequest_descriptor =
-      getDescriptor().getMessageTypes().get(20);
+      getDescriptor().getMessageTypes().get(21);
     internal_static_greptime_v1_region_FlushRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_FlushRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_CompactRequest_descriptor =
-      getDescriptor().getMessageTypes().get(21);
+      getDescriptor().getMessageTypes().get(22);
     internal_static_greptime_v1_region_CompactRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CompactRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_TruncateRequest_descriptor =
-      getDescriptor().getMessageTypes().get(22);
+      getDescriptor().getMessageTypes().get(23);
     internal_static_greptime_v1_region_TruncateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_TruncateRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_RegionColumnDef_descriptor =
-      getDescriptor().getMessageTypes().get(23);
+      getDescriptor().getMessageTypes().get(24);
     internal_static_greptime_v1_region_RegionColumnDef_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionColumnDef_descriptor,

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -26,14 +26,21 @@ import "greptime/v1/ddl.proto";
 
 service Region { rpc Handle(RegionRequest) returns (RegionResponse); }
 
+message QueryContext {
+  string current_catalog = 1;
+  string current_schema = 2;
+  string timezone = 4;
+  map<string, string> extensions = 5;
+}
+
 message RegionRequestHeader {
   // Encoded trace_id & span_id, follow the w3c Trace Context
   // https://www.w3.org/TR/trace-context/#header-name
   map<string, string> tracing_context = 5;
   // DB Name of request, tracking only
   string dbname = 3;
-  // The `timezone` for the request
-  string timezone = 4;
+  // The contextual information of the query
+  QueryContext query_context = 6;
 }
 
 message RegionRequest {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This refers to the issue "Pass query context down to region server service in Datanode".

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/3752