### PR TITLE
refactor: add options for remote compaction

### DIFF
--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -387,6 +387,17 @@ struct StrictWindowDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 StrictWindowDefaultTypeInternal _StrictWindow_default_instance_;
+PROTOBUF_CONSTEXPR Remote::Remote(
+    ::_pbi::ConstantInitialized) {}
+struct RemoteDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RemoteDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RemoteDefaultTypeInternal() {}
+  union {
+    Remote _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RemoteDefaultTypeInternal _Remote_default_instance_;
 PROTOBUF_CONSTEXPR CompactRequest::CompactRequest(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.region_id_)*/uint64_t{0u}
@@ -432,7 +443,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace region
 }  // namespace v1
 }  // namespace greptime
-static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[30];
+static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[31];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 
@@ -674,12 +685,19 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::StrictWindow, _impl_.window_seconds_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::Remote, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CompactRequest, _internal_metadata_),
   ~0u,  // no _extensions_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CompactRequest, _impl_._oneof_case_[0]),
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CompactRequest, _impl_.region_id_),
+  ::_pbi::kInvalidFieldOffsetTag,
   ::_pbi::kInvalidFieldOffsetTag,
   ::_pbi::kInvalidFieldOffsetTag,
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::CompactRequest, _impl_.options_),
@@ -727,9 +745,10 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 216, -1, -1, sizeof(::greptime::v1::region::FlushRequest)},
   { 223, -1, -1, sizeof(::greptime::v1::region::Regular)},
   { 229, -1, -1, sizeof(::greptime::v1::region::StrictWindow)},
-  { 236, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
-  { 246, -1, -1, sizeof(::greptime::v1::region::TruncateRequest)},
-  { 253, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
+  { 236, -1, -1, sizeof(::greptime::v1::region::Remote)},
+  { 242, -1, -1, sizeof(::greptime::v1::region::CompactRequest)},
+  { 253, -1, -1, sizeof(::greptime::v1::region::TruncateRequest)},
+  { 260, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -760,6 +779,7 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::greptime::v1::region::_FlushRequest_default_instance_._instance,
   &::greptime::v1::region::_Regular_default_instance_._instance,
   &::greptime::v1::region::_StrictWindow_default_instance_._instance,
+  &::greptime::v1::region::_Remote_default_instance_._instance,
   &::greptime::v1::region::_CompactRequest_default_instance_._instance,
   &::greptime::v1::region::_TruncateRequest_default_instance_._instance,
   &::greptime::v1::region::_RegionColumnDef_default_instance_._instance,
@@ -842,18 +862,20 @@ const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] P
   "cation\"\032\n\nDropColumn\022\014\n\004name\030\001 \001(\t\"!\n\014Fl"
   "ushRequest\022\021\n\tregion_id\030\001 \001(\004\"\t\n\007Regular"
   "\"&\n\014StrictWindow\022\026\n\016window_seconds\030\001 \001(\003"
-  "\"\231\001\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\022."
-  "\n\007regular\030\002 \001(\0132\033.greptime.v1.region.Reg"
-  "ularH\000\0229\n\rstrict_window\030\003 \001(\0132 .greptime"
-  ".v1.region.StrictWindowH\000B\t\n\007options\"$\n\017"
-  "TruncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n\017Re"
-  "gionColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.grep"
-  "time.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2Y\n\006"
-  "Region\022O\n\006Handle\022!.greptime.v1.region.Re"
-  "gionRequest\032\".greptime.v1.region.RegionR"
-  "esponseB]\n\025io.greptime.v1.regionB\006Server"
-  "Z<github.com/GreptimeTeam/greptime-proto"
-  "/go/greptime/v1/regionb\006proto3"
+  "\"\010\n\006Remote\"\307\001\n\016CompactRequest\022\021\n\tregion_"
+  "id\030\001 \001(\004\022.\n\007regular\030\002 \001(\0132\033.greptime.v1."
+  "region.RegularH\000\0229\n\rstrict_window\030\003 \001(\0132"
+  " .greptime.v1.region.StrictWindowH\000\022,\n\006r"
+  "emote\030\004 \001(\0132\032.greptime.v1.region.RemoteH"
+  "\000B\t\n\007options\"$\n\017TruncateRequest\022\021\n\tregio"
+  "n_id\030\001 \001(\004\"P\n\017RegionColumnDef\022*\n\ncolumn_"
+  "def\030\001 \001(\0132\026.greptime.v1.ColumnDef\022\021\n\tcol"
+  "umn_id\030\002 \001(\r2Y\n\006Region\022O\n\006Handle\022!.grept"
+  "ime.v1.region.RegionRequest\032\".greptime.v"
+  "1.region.RegionResponseB]\n\025io.greptime.v"
+  "1.regionB\006ServerZ<github.com/GreptimeTea"
+  "m/greptime-proto/go/greptime/v1/regionb\006"
+  "proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[3] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -862,9 +884,9 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 3510, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 3566, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
-    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 30,
+    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 31,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
     file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto, file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
     file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
@@ -6965,10 +6987,51 @@ void StrictWindow::InternalSwap(StrictWindow* other) {
 
 // ===================================================================
 
+class Remote::_Internal {
+ public:
+};
+
+Remote::Remote(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase(arena, is_message_owned) {
+  // @@protoc_insertion_point(arena_constructor:greptime.v1.region.Remote)
+}
+Remote::Remote(const Remote& from)
+  : ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase() {
+  Remote* const _this = this; (void)_this;
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:greptime.v1.region.Remote)
+}
+
+
+
+
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData Remote::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::CopyImpl,
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::MergeImpl,
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*Remote::GetClassData() const { return &_class_data_; }
+
+
+
+
+
+
+
+::PROTOBUF_NAMESPACE_ID::Metadata Remote::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[27]);
+}
+
+// ===================================================================
+
 class CompactRequest::_Internal {
  public:
   static const ::greptime::v1::region::Regular& regular(const CompactRequest* msg);
   static const ::greptime::v1::region::StrictWindow& strict_window(const CompactRequest* msg);
+  static const ::greptime::v1::region::Remote& remote(const CompactRequest* msg);
 };
 
 const ::greptime::v1::region::Regular&
@@ -6978,6 +7041,10 @@ CompactRequest::_Internal::regular(const CompactRequest* msg) {
 const ::greptime::v1::region::StrictWindow&
 CompactRequest::_Internal::strict_window(const CompactRequest* msg) {
   return *msg->_impl_.options_.strict_window_;
+}
+const ::greptime::v1::region::Remote&
+CompactRequest::_Internal::remote(const CompactRequest* msg) {
+  return *msg->_impl_.options_.remote_;
 }
 void CompactRequest::set_allocated_regular(::greptime::v1::region::Regular* regular) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
@@ -7009,6 +7076,21 @@ void CompactRequest::set_allocated_strict_window(::greptime::v1::region::StrictW
   }
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.CompactRequest.strict_window)
 }
+void CompactRequest::set_allocated_remote(::greptime::v1::region::Remote* remote) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  clear_options();
+  if (remote) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(remote);
+    if (message_arena != submessage_arena) {
+      remote = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, remote, submessage_arena);
+    }
+    set_has_remote();
+    _impl_.options_.remote_ = remote;
+  }
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.CompactRequest.remote)
+}
 CompactRequest::CompactRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
@@ -7036,6 +7118,11 @@ CompactRequest::CompactRequest(const CompactRequest& from)
     case kStrictWindow: {
       _this->_internal_mutable_strict_window()->::greptime::v1::region::StrictWindow::MergeFrom(
           from._internal_strict_window());
+      break;
+    }
+    case kRemote: {
+      _this->_internal_mutable_remote()->::greptime::v1::region::Remote::MergeFrom(
+          from._internal_remote());
       break;
     }
     case OPTIONS_NOT_SET: {
@@ -7093,6 +7180,12 @@ void CompactRequest::clear_options() {
       }
       break;
     }
+    case kRemote: {
+      if (GetArenaForAllocation() == nullptr) {
+        delete _impl_.options_.remote_;
+      }
+      break;
+    }
     case OPTIONS_NOT_SET: {
       break;
     }
@@ -7138,6 +7231,14 @@ const char* CompactRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
           ptr = ctx->ParseMessage(_internal_mutable_strict_window(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // .greptime.v1.region.Remote remote = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_remote(), ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -7191,6 +7292,13 @@ uint8_t* CompactRequest::_InternalSerialize(
         _Internal::strict_window(this).GetCachedSize(), target, stream);
   }
 
+  // .greptime.v1.region.Remote remote = 4;
+  if (_internal_has_remote()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(4, _Internal::remote(this),
+        _Internal::remote(this).GetCachedSize(), target, stream);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -7225,6 +7333,13 @@ size_t CompactRequest::ByteSizeLong() const {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
           *_impl_.options_.strict_window_);
+      break;
+    }
+    // .greptime.v1.region.Remote remote = 4;
+    case kRemote: {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+          *_impl_.options_.remote_);
       break;
     }
     case OPTIONS_NOT_SET: {
@@ -7263,6 +7378,11 @@ void CompactRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const :
           from._internal_strict_window());
       break;
     }
+    case kRemote: {
+      _this->_internal_mutable_remote()->::greptime::v1::region::Remote::MergeFrom(
+          from._internal_remote());
+      break;
+    }
     case OPTIONS_NOT_SET: {
       break;
     }
@@ -7292,7 +7412,7 @@ void CompactRequest::InternalSwap(CompactRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CompactRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[27]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[28]);
 }
 
 // ===================================================================
@@ -7470,7 +7590,7 @@ void TruncateRequest::InternalSwap(TruncateRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata TruncateRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[28]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[29]);
 }
 
 // ===================================================================
@@ -7700,7 +7820,7 @@ void RegionColumnDef::InternalSwap(RegionColumnDef* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata RegionColumnDef::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[29]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[30]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -7815,6 +7935,10 @@ Arena::CreateMaybeMessage< ::greptime::v1::region::Regular >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::greptime::v1::region::StrictWindow*
 Arena::CreateMaybeMessage< ::greptime::v1::region::StrictWindow >(Arena* arena) {
   return Arena::CreateMessageInternal< ::greptime::v1::region::StrictWindow >(arena);
+}
+template<> PROTOBUF_NOINLINE ::greptime::v1::region::Remote*
+Arena::CreateMaybeMessage< ::greptime::v1::region::Remote >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::region::Remote >(arena);
 }
 template<> PROTOBUF_NOINLINE ::greptime::v1::region::CompactRequest*
 Arena::CreateMaybeMessage< ::greptime::v1::region::CompactRequest >(Arena* arena) {

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -138,6 +138,9 @@ extern RegionResponse_ExtensionEntry_DoNotUseDefaultTypeInternal _RegionResponse
 class Regular;
 struct RegularDefaultTypeInternal;
 extern RegularDefaultTypeInternal _Regular_default_instance_;
+class Remote;
+struct RemoteDefaultTypeInternal;
+extern RemoteDefaultTypeInternal _Remote_default_instance_;
 class StrictWindow;
 struct StrictWindowDefaultTypeInternal;
 extern StrictWindowDefaultTypeInternal _StrictWindow_default_instance_;
@@ -176,6 +179,7 @@ template<> ::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNot
 template<> ::greptime::v1::region::RegionResponse* Arena::CreateMaybeMessage<::greptime::v1::region::RegionResponse>(Arena*);
 template<> ::greptime::v1::region::RegionResponse_ExtensionEntry_DoNotUse* Arena::CreateMaybeMessage<::greptime::v1::region::RegionResponse_ExtensionEntry_DoNotUse>(Arena*);
 template<> ::greptime::v1::region::Regular* Arena::CreateMaybeMessage<::greptime::v1::region::Regular>(Arena*);
+template<> ::greptime::v1::region::Remote* Arena::CreateMaybeMessage<::greptime::v1::region::Remote>(Arena*);
 template<> ::greptime::v1::region::StrictWindow* Arena::CreateMaybeMessage<::greptime::v1::region::StrictWindow>(Arena*);
 template<> ::greptime::v1::region::TruncateRequest* Arena::CreateMaybeMessage<::greptime::v1::region::TruncateRequest>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
@@ -4502,6 +4506,124 @@ class StrictWindow final :
 };
 // -------------------------------------------------------------------
 
+class Remote final :
+    public ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase /* @@protoc_insertion_point(class_definition:greptime.v1.region.Remote) */ {
+ public:
+  inline Remote() : Remote(nullptr) {}
+  explicit PROTOBUF_CONSTEXPR Remote(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  Remote(const Remote& from);
+  Remote(Remote&& from) noexcept
+    : Remote() {
+    *this = ::std::move(from);
+  }
+
+  inline Remote& operator=(const Remote& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline Remote& operator=(Remote&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const Remote& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const Remote* internal_default_instance() {
+    return reinterpret_cast<const Remote*>(
+               &_Remote_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    27;
+
+  friend void swap(Remote& a, Remote& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(Remote* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(Remote* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  Remote* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<Remote>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const Remote& from) {
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const Remote& from) {
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+  public:
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "greptime.v1.region.Remote";
+  }
+  protected:
+  explicit Remote(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:greptime.v1.region.Remote)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+  };
+  friend struct ::TableStruct_greptime_2fv1_2fregion_2fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class CompactRequest final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.region.CompactRequest) */ {
  public:
@@ -4548,6 +4670,7 @@ class CompactRequest final :
   enum OptionsCase {
     kRegular = 2,
     kStrictWindow = 3,
+    kRemote = 4,
     OPTIONS_NOT_SET = 0,
   };
 
@@ -4556,7 +4679,7 @@ class CompactRequest final :
                &_CompactRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    28;
 
   friend void swap(CompactRequest& a, CompactRequest& b) {
     a.Swap(&b);
@@ -4632,6 +4755,7 @@ class CompactRequest final :
     kRegionIdFieldNumber = 1,
     kRegularFieldNumber = 2,
     kStrictWindowFieldNumber = 3,
+    kRemoteFieldNumber = 4,
   };
   // uint64 region_id = 1;
   void clear_region_id();
@@ -4678,6 +4802,24 @@ class CompactRequest final :
       ::greptime::v1::region::StrictWindow* strict_window);
   ::greptime::v1::region::StrictWindow* unsafe_arena_release_strict_window();
 
+  // .greptime.v1.region.Remote remote = 4;
+  bool has_remote() const;
+  private:
+  bool _internal_has_remote() const;
+  public:
+  void clear_remote();
+  const ::greptime::v1::region::Remote& remote() const;
+  PROTOBUF_NODISCARD ::greptime::v1::region::Remote* release_remote();
+  ::greptime::v1::region::Remote* mutable_remote();
+  void set_allocated_remote(::greptime::v1::region::Remote* remote);
+  private:
+  const ::greptime::v1::region::Remote& _internal_remote() const;
+  ::greptime::v1::region::Remote* _internal_mutable_remote();
+  public:
+  void unsafe_arena_set_allocated_remote(
+      ::greptime::v1::region::Remote* remote);
+  ::greptime::v1::region::Remote* unsafe_arena_release_remote();
+
   void clear_options();
   OptionsCase options_case() const;
   // @@protoc_insertion_point(class_scope:greptime.v1.region.CompactRequest)
@@ -4685,6 +4827,7 @@ class CompactRequest final :
   class _Internal;
   void set_has_regular();
   void set_has_strict_window();
+  void set_has_remote();
 
   inline bool has_options() const;
   inline void clear_has_options();
@@ -4699,6 +4842,7 @@ class CompactRequest final :
         ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized _constinit_;
       ::greptime::v1::region::Regular* regular_;
       ::greptime::v1::region::StrictWindow* strict_window_;
+      ::greptime::v1::region::Remote* remote_;
     } options_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     uint32_t _oneof_case_[1];
@@ -4757,7 +4901,7 @@ class TruncateRequest final :
                &_TruncateRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    28;
+    29;
 
   friend void swap(TruncateRequest& a, TruncateRequest& b) {
     a.Swap(&b);
@@ -4905,7 +5049,7 @@ class RegionColumnDef final :
                &_RegionColumnDef_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    30;
 
   friend void swap(RegionColumnDef& a, RegionColumnDef& b) {
     a.Swap(&b);
@@ -8094,6 +8238,10 @@ inline void StrictWindow::set_window_seconds(int64_t value) {
 
 // -------------------------------------------------------------------
 
+// Remote
+
+// -------------------------------------------------------------------
+
 // CompactRequest
 
 // uint64 region_id = 1;
@@ -8264,6 +8412,80 @@ inline ::greptime::v1::region::StrictWindow* CompactRequest::mutable_strict_wind
   return _msg;
 }
 
+// .greptime.v1.region.Remote remote = 4;
+inline bool CompactRequest::_internal_has_remote() const {
+  return options_case() == kRemote;
+}
+inline bool CompactRequest::has_remote() const {
+  return _internal_has_remote();
+}
+inline void CompactRequest::set_has_remote() {
+  _impl_._oneof_case_[0] = kRemote;
+}
+inline void CompactRequest::clear_remote() {
+  if (_internal_has_remote()) {
+    if (GetArenaForAllocation() == nullptr) {
+      delete _impl_.options_.remote_;
+    }
+    clear_has_options();
+  }
+}
+inline ::greptime::v1::region::Remote* CompactRequest::release_remote() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.CompactRequest.remote)
+  if (_internal_has_remote()) {
+    clear_has_options();
+    ::greptime::v1::region::Remote* temp = _impl_.options_.remote_;
+    if (GetArenaForAllocation() != nullptr) {
+      temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.options_.remote_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::greptime::v1::region::Remote& CompactRequest::_internal_remote() const {
+  return _internal_has_remote()
+      ? *_impl_.options_.remote_
+      : reinterpret_cast< ::greptime::v1::region::Remote&>(::greptime::v1::region::_Remote_default_instance_);
+}
+inline const ::greptime::v1::region::Remote& CompactRequest::remote() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.CompactRequest.remote)
+  return _internal_remote();
+}
+inline ::greptime::v1::region::Remote* CompactRequest::unsafe_arena_release_remote() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:greptime.v1.region.CompactRequest.remote)
+  if (_internal_has_remote()) {
+    clear_has_options();
+    ::greptime::v1::region::Remote* temp = _impl_.options_.remote_;
+    _impl_.options_.remote_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void CompactRequest::unsafe_arena_set_allocated_remote(::greptime::v1::region::Remote* remote) {
+  clear_options();
+  if (remote) {
+    set_has_remote();
+    _impl_.options_.remote_ = remote;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:greptime.v1.region.CompactRequest.remote)
+}
+inline ::greptime::v1::region::Remote* CompactRequest::_internal_mutable_remote() {
+  if (!_internal_has_remote()) {
+    clear_options();
+    set_has_remote();
+    _impl_.options_.remote_ = CreateMaybeMessage< ::greptime::v1::region::Remote >(GetArenaForAllocation());
+  }
+  return _impl_.options_.remote_;
+}
+inline ::greptime::v1::region::Remote* CompactRequest::mutable_remote() {
+  ::greptime::v1::region::Remote* _msg = _internal_mutable_remote();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.CompactRequest.remote)
+  return _msg;
+}
+
 inline bool CompactRequest::has_options() const {
   return options_case() != OPTIONS_NOT_SET;
 }
@@ -8409,6 +8631,8 @@ inline void RegionColumnDef::set_column_id(uint32_t value) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -22125,6 +22125,434 @@ java.lang.String defaultValue);
 
   }
 
+  public interface RemoteOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:greptime.v1.region.Remote)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * <pre>
+   *&#47; The options for region compaction.
+   * </pre>
+   *
+   * Protobuf type {@code greptime.v1.region.Remote}
+   */
+  public static final class Remote extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:greptime.v1.region.Remote)
+      RemoteOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use Remote.newBuilder() to construct.
+    private Remote(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private Remote() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new Remote();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Remote(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_Remote_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_Remote_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.greptime.v1.region.Server.Remote.class, io.greptime.v1.region.Server.Remote.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.greptime.v1.region.Server.Remote)) {
+        return super.equals(obj);
+      }
+      io.greptime.v1.region.Server.Remote other = (io.greptime.v1.region.Server.Remote) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.Remote parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.Remote parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.Remote parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.greptime.v1.region.Server.Remote prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *&#47; The options for region compaction.
+     * </pre>
+     *
+     * Protobuf type {@code greptime.v1.region.Remote}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:greptime.v1.region.Remote)
+        io.greptime.v1.region.Server.RemoteOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_Remote_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_Remote_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.greptime.v1.region.Server.Remote.class, io.greptime.v1.region.Server.Remote.Builder.class);
+      }
+
+      // Construct using io.greptime.v1.region.Server.Remote.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_Remote_descriptor;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.Remote getDefaultInstanceForType() {
+        return io.greptime.v1.region.Server.Remote.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.Remote build() {
+        io.greptime.v1.region.Server.Remote result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.Remote buildPartial() {
+        io.greptime.v1.region.Server.Remote result = new io.greptime.v1.region.Server.Remote(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.greptime.v1.region.Server.Remote) {
+          return mergeFrom((io.greptime.v1.region.Server.Remote)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.greptime.v1.region.Server.Remote other) {
+        if (other == io.greptime.v1.region.Server.Remote.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.greptime.v1.region.Server.Remote parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.greptime.v1.region.Server.Remote) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:greptime.v1.region.Remote)
+    }
+
+    // @@protoc_insertion_point(class_scope:greptime.v1.region.Remote)
+    private static final io.greptime.v1.region.Server.Remote DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.greptime.v1.region.Server.Remote();
+    }
+
+    public static io.greptime.v1.region.Server.Remote getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<Remote>
+        PARSER = new com.google.protobuf.AbstractParser<Remote>() {
+      @java.lang.Override
+      public Remote parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Remote(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<Remote> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Remote> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.greptime.v1.region.Server.Remote getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface CompactRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:greptime.v1.region.CompactRequest)
       com.google.protobuf.MessageOrBuilder {
@@ -22164,6 +22592,21 @@ java.lang.String defaultValue);
      * <code>.greptime.v1.region.StrictWindow strict_window = 3;</code>
      */
     io.greptime.v1.region.Server.StrictWindowOrBuilder getStrictWindowOrBuilder();
+
+    /**
+     * <code>.greptime.v1.region.Remote remote = 4;</code>
+     * @return Whether the remote field is set.
+     */
+    boolean hasRemote();
+    /**
+     * <code>.greptime.v1.region.Remote remote = 4;</code>
+     * @return The remote.
+     */
+    io.greptime.v1.region.Server.Remote getRemote();
+    /**
+     * <code>.greptime.v1.region.Remote remote = 4;</code>
+     */
+    io.greptime.v1.region.Server.RemoteOrBuilder getRemoteOrBuilder();
 
     public io.greptime.v1.region.Server.CompactRequest.OptionsCase getOptionsCase();
   }
@@ -22245,6 +22688,20 @@ java.lang.String defaultValue);
               optionsCase_ = 3;
               break;
             }
+            case 34: {
+              io.greptime.v1.region.Server.Remote.Builder subBuilder = null;
+              if (optionsCase_ == 4) {
+                subBuilder = ((io.greptime.v1.region.Server.Remote) options_).toBuilder();
+              }
+              options_ =
+                  input.readMessage(io.greptime.v1.region.Server.Remote.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((io.greptime.v1.region.Server.Remote) options_);
+                options_ = subBuilder.buildPartial();
+              }
+              optionsCase_ = 4;
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -22286,6 +22743,7 @@ java.lang.String defaultValue);
             com.google.protobuf.AbstractMessage.InternalOneOfEnum {
       REGULAR(2),
       STRICT_WINDOW(3),
+      REMOTE(4),
       OPTIONS_NOT_SET(0);
       private final int value;
       private OptionsCase(int value) {
@@ -22305,6 +22763,7 @@ java.lang.String defaultValue);
         switch (value) {
           case 2: return REGULAR;
           case 3: return STRICT_WINDOW;
+          case 4: return REMOTE;
           case 0: return OPTIONS_NOT_SET;
           default: return null;
         }
@@ -22393,6 +22852,37 @@ java.lang.String defaultValue);
       return io.greptime.v1.region.Server.StrictWindow.getDefaultInstance();
     }
 
+    public static final int REMOTE_FIELD_NUMBER = 4;
+    /**
+     * <code>.greptime.v1.region.Remote remote = 4;</code>
+     * @return Whether the remote field is set.
+     */
+    @java.lang.Override
+    public boolean hasRemote() {
+      return optionsCase_ == 4;
+    }
+    /**
+     * <code>.greptime.v1.region.Remote remote = 4;</code>
+     * @return The remote.
+     */
+    @java.lang.Override
+    public io.greptime.v1.region.Server.Remote getRemote() {
+      if (optionsCase_ == 4) {
+         return (io.greptime.v1.region.Server.Remote) options_;
+      }
+      return io.greptime.v1.region.Server.Remote.getDefaultInstance();
+    }
+    /**
+     * <code>.greptime.v1.region.Remote remote = 4;</code>
+     */
+    @java.lang.Override
+    public io.greptime.v1.region.Server.RemoteOrBuilder getRemoteOrBuilder() {
+      if (optionsCase_ == 4) {
+         return (io.greptime.v1.region.Server.Remote) options_;
+      }
+      return io.greptime.v1.region.Server.Remote.getDefaultInstance();
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -22416,6 +22906,9 @@ java.lang.String defaultValue);
       if (optionsCase_ == 3) {
         output.writeMessage(3, (io.greptime.v1.region.Server.StrictWindow) options_);
       }
+      if (optionsCase_ == 4) {
+        output.writeMessage(4, (io.greptime.v1.region.Server.Remote) options_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -22436,6 +22929,10 @@ java.lang.String defaultValue);
       if (optionsCase_ == 3) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, (io.greptime.v1.region.Server.StrictWindow) options_);
+      }
+      if (optionsCase_ == 4) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, (io.greptime.v1.region.Server.Remote) options_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -22464,6 +22961,10 @@ java.lang.String defaultValue);
           if (!getStrictWindow()
               .equals(other.getStrictWindow())) return false;
           break;
+        case 4:
+          if (!getRemote()
+              .equals(other.getRemote())) return false;
+          break;
         case 0:
         default:
       }
@@ -22489,6 +22990,10 @@ java.lang.String defaultValue);
         case 3:
           hash = (37 * hash) + STRICT_WINDOW_FIELD_NUMBER;
           hash = (53 * hash) + getStrictWindow().hashCode();
+          break;
+        case 4:
+          hash = (37 * hash) + REMOTE_FIELD_NUMBER;
+          hash = (53 * hash) + getRemote().hashCode();
           break;
         case 0:
         default:
@@ -22671,6 +23176,13 @@ java.lang.String defaultValue);
             result.options_ = strictWindowBuilder_.build();
           }
         }
+        if (optionsCase_ == 4) {
+          if (remoteBuilder_ == null) {
+            result.options_ = options_;
+          } else {
+            result.options_ = remoteBuilder_.build();
+          }
+        }
         result.optionsCase_ = optionsCase_;
         onBuilt();
         return result;
@@ -22730,6 +23242,10 @@ java.lang.String defaultValue);
           }
           case STRICT_WINDOW: {
             mergeStrictWindow(other.getStrictWindow());
+            break;
+          }
+          case REMOTE: {
+            mergeRemote(other.getRemote());
             break;
           }
           case OPTIONS_NOT_SET: {
@@ -23093,6 +23609,148 @@ java.lang.String defaultValue);
         optionsCase_ = 3;
         onChanged();;
         return strictWindowBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          io.greptime.v1.region.Server.Remote, io.greptime.v1.region.Server.Remote.Builder, io.greptime.v1.region.Server.RemoteOrBuilder> remoteBuilder_;
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       * @return Whether the remote field is set.
+       */
+      @java.lang.Override
+      public boolean hasRemote() {
+        return optionsCase_ == 4;
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       * @return The remote.
+       */
+      @java.lang.Override
+      public io.greptime.v1.region.Server.Remote getRemote() {
+        if (remoteBuilder_ == null) {
+          if (optionsCase_ == 4) {
+            return (io.greptime.v1.region.Server.Remote) options_;
+          }
+          return io.greptime.v1.region.Server.Remote.getDefaultInstance();
+        } else {
+          if (optionsCase_ == 4) {
+            return remoteBuilder_.getMessage();
+          }
+          return io.greptime.v1.region.Server.Remote.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      public Builder setRemote(io.greptime.v1.region.Server.Remote value) {
+        if (remoteBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          options_ = value;
+          onChanged();
+        } else {
+          remoteBuilder_.setMessage(value);
+        }
+        optionsCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      public Builder setRemote(
+          io.greptime.v1.region.Server.Remote.Builder builderForValue) {
+        if (remoteBuilder_ == null) {
+          options_ = builderForValue.build();
+          onChanged();
+        } else {
+          remoteBuilder_.setMessage(builderForValue.build());
+        }
+        optionsCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      public Builder mergeRemote(io.greptime.v1.region.Server.Remote value) {
+        if (remoteBuilder_ == null) {
+          if (optionsCase_ == 4 &&
+              options_ != io.greptime.v1.region.Server.Remote.getDefaultInstance()) {
+            options_ = io.greptime.v1.region.Server.Remote.newBuilder((io.greptime.v1.region.Server.Remote) options_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            options_ = value;
+          }
+          onChanged();
+        } else {
+          if (optionsCase_ == 4) {
+            remoteBuilder_.mergeFrom(value);
+          } else {
+            remoteBuilder_.setMessage(value);
+          }
+        }
+        optionsCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      public Builder clearRemote() {
+        if (remoteBuilder_ == null) {
+          if (optionsCase_ == 4) {
+            optionsCase_ = 0;
+            options_ = null;
+            onChanged();
+          }
+        } else {
+          if (optionsCase_ == 4) {
+            optionsCase_ = 0;
+            options_ = null;
+          }
+          remoteBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      public io.greptime.v1.region.Server.Remote.Builder getRemoteBuilder() {
+        return getRemoteFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RemoteOrBuilder getRemoteOrBuilder() {
+        if ((optionsCase_ == 4) && (remoteBuilder_ != null)) {
+          return remoteBuilder_.getMessageOrBuilder();
+        } else {
+          if (optionsCase_ == 4) {
+            return (io.greptime.v1.region.Server.Remote) options_;
+          }
+          return io.greptime.v1.region.Server.Remote.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.greptime.v1.region.Remote remote = 4;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          io.greptime.v1.region.Server.Remote, io.greptime.v1.region.Server.Remote.Builder, io.greptime.v1.region.Server.RemoteOrBuilder> 
+          getRemoteFieldBuilder() {
+        if (remoteBuilder_ == null) {
+          if (!(optionsCase_ == 4)) {
+            options_ = io.greptime.v1.region.Server.Remote.getDefaultInstance();
+          }
+          remoteBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              io.greptime.v1.region.Server.Remote, io.greptime.v1.region.Server.Remote.Builder, io.greptime.v1.region.Server.RemoteOrBuilder>(
+                  (io.greptime.v1.region.Server.Remote) options_,
+                  getParentForChildren(),
+                  isClean());
+          options_ = null;
+        }
+        optionsCase_ = 4;
+        onChanged();;
+        return remoteBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -24481,6 +25139,11 @@ java.lang.String defaultValue);
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_greptime_v1_region_StrictWindow_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_region_Remote_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_region_Remote_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_greptime_v1_region_CompactRequest_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -24580,18 +25243,20 @@ java.lang.String defaultValue);
       "cation\"\032\n\nDropColumn\022\014\n\004name\030\001 \001(\t\"!\n\014Fl" +
       "ushRequest\022\021\n\tregion_id\030\001 \001(\004\"\t\n\007Regular" +
       "\"&\n\014StrictWindow\022\026\n\016window_seconds\030\001 \001(\003" +
-      "\"\231\001\n\016CompactRequest\022\021\n\tregion_id\030\001 \001(\004\022." +
-      "\n\007regular\030\002 \001(\0132\033.greptime.v1.region.Reg" +
-      "ularH\000\0229\n\rstrict_window\030\003 \001(\0132 .greptime" +
-      ".v1.region.StrictWindowH\000B\t\n\007options\"$\n\017" +
-      "TruncateRequest\022\021\n\tregion_id\030\001 \001(\004\"P\n\017Re" +
-      "gionColumnDef\022*\n\ncolumn_def\030\001 \001(\0132\026.grep" +
-      "time.v1.ColumnDef\022\021\n\tcolumn_id\030\002 \001(\r2Y\n\006" +
-      "Region\022O\n\006Handle\022!.greptime.v1.region.Re" +
-      "gionRequest\032\".greptime.v1.region.RegionR" +
-      "esponseB]\n\025io.greptime.v1.regionB\006Server" +
-      "Z<github.com/GreptimeTeam/greptime-proto" +
-      "/go/greptime/v1/regionb\006proto3"
+      "\"\010\n\006Remote\"\307\001\n\016CompactRequest\022\021\n\tregion_" +
+      "id\030\001 \001(\004\022.\n\007regular\030\002 \001(\0132\033.greptime.v1." +
+      "region.RegularH\000\0229\n\rstrict_window\030\003 \001(\0132" +
+      " .greptime.v1.region.StrictWindowH\000\022,\n\006r" +
+      "emote\030\004 \001(\0132\032.greptime.v1.region.RemoteH" +
+      "\000B\t\n\007options\"$\n\017TruncateRequest\022\021\n\tregio" +
+      "n_id\030\001 \001(\004\"P\n\017RegionColumnDef\022*\n\ncolumn_" +
+      "def\030\001 \001(\0132\026.greptime.v1.ColumnDef\022\021\n\tcol" +
+      "umn_id\030\002 \001(\r2Y\n\006Region\022O\n\006Handle\022!.grept" +
+      "ime.v1.region.RegionRequest\032\".greptime.v" +
+      "1.region.RegionResponseB]\n\025io.greptime.v" +
+      "1.regionB\006ServerZ<github.com/GreptimeTea" +
+      "m/greptime-proto/go/greptime/v1/regionb\006" +
+      "proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -24762,20 +25427,26 @@ java.lang.String defaultValue);
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_StrictWindow_descriptor,
         new java.lang.String[] { "WindowSeconds", });
-    internal_static_greptime_v1_region_CompactRequest_descriptor =
+    internal_static_greptime_v1_region_Remote_descriptor =
       getDescriptor().getMessageTypes().get(23);
+    internal_static_greptime_v1_region_Remote_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_region_Remote_descriptor,
+        new java.lang.String[] { });
+    internal_static_greptime_v1_region_CompactRequest_descriptor =
+      getDescriptor().getMessageTypes().get(24);
     internal_static_greptime_v1_region_CompactRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_CompactRequest_descriptor,
-        new java.lang.String[] { "RegionId", "Regular", "StrictWindow", "Options", });
+        new java.lang.String[] { "RegionId", "Regular", "StrictWindow", "Remote", "Options", });
     internal_static_greptime_v1_region_TruncateRequest_descriptor =
-      getDescriptor().getMessageTypes().get(24);
+      getDescriptor().getMessageTypes().get(25);
     internal_static_greptime_v1_region_TruncateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_TruncateRequest_descriptor,
         new java.lang.String[] { "RegionId", });
     internal_static_greptime_v1_region_RegionColumnDef_descriptor =
-      getDescriptor().getMessageTypes().get(25);
+      getDescriptor().getMessageTypes().get(26);
     internal_static_greptime_v1_region_RegionColumnDef_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_RegionColumnDef_descriptor,

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -154,11 +154,15 @@ message StrictWindow {
   int64 window_seconds = 1;
 }
 
+/// The options for region compaction.
+message Remote {}
+
 message CompactRequest {
     uint64 region_id = 1;
     oneof options {
       Regular regular = 2;
       StrictWindow strict_window = 3;
+      Remote remote = 4;
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add the `Remote{}` for remote compaction.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.
