### PR TITLE
feat: update rustls to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-prost = "0.12"
+prost = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
-tonic = "0.11"
+tonic = "0.12"
 
 [build-dependencies]
 tonic-build = "0.11"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4557

## What's changed and what's your intention?

- Update prost from 0.12 to 0.13.
- Update tonic from 0.11 to 0.12.

## Checklist

- [x]  I have written the necessary comments.
- [x]  I have added the necessary unit tests and integration tests.
