### PR TITLE
fix: restore region selection to avoid breaking main branch

### DIFF
--- a/c++/greptime/v1/region/server.pb.cc
+++ b/c++/greptime/v1/region/server.pb.cc
@@ -446,9 +446,9 @@ struct BulkInsertRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 BulkInsertRequestDefaultTypeInternal _BulkInsertRequest_default_instance_;
 PROTOBUF_CONSTEXPR ArrowIpc::ArrowIpc(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.schema_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+    /*decltype(_impl_.region_selection_)*/{}
+  , /*decltype(_impl_.schema_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.payload_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.region_id_)*/uint64_t{0u}
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct ArrowIpcDefaultTypeInternal {
   PROTOBUF_CONSTEXPR ArrowIpcDefaultTypeInternal()
@@ -459,6 +459,20 @@ struct ArrowIpcDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ArrowIpcDefaultTypeInternal _ArrowIpc_default_instance_;
+PROTOBUF_CONSTEXPR RegionSelection::RegionSelection(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.selection_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.region_id_)*/uint64_t{0u}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct RegionSelectionDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RegionSelectionDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RegionSelectionDefaultTypeInternal() {}
+  union {
+    RegionSelection _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RegionSelectionDefaultTypeInternal _RegionSelection_default_instance_;
 PROTOBUF_CONSTEXPR MitoManifestInfo::MitoManifestInfo(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.data_manifest_version_)*/uint64_t{0u}
@@ -504,7 +518,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace region
 }  // namespace v1
 }  // namespace greptime
-static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[35];
+static ::_pb::Metadata file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[36];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto = nullptr;
 
@@ -791,9 +805,17 @@ const uint32_t TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets[] PR
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::ArrowIpc, _impl_.region_id_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::ArrowIpc, _impl_.schema_),
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::ArrowIpc, _impl_.payload_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::ArrowIpc, _impl_.region_selection_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionSelection, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionSelection, _impl_.region_id_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::region::RegionSelection, _impl_.selection_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::region::MitoManifestInfo, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -853,9 +875,10 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 260, -1, -1, sizeof(::greptime::v1::region::RegionColumnDef)},
   { 268, -1, -1, sizeof(::greptime::v1::region::BulkInsertRequest)},
   { 276, -1, -1, sizeof(::greptime::v1::region::ArrowIpc)},
-  { 285, -1, -1, sizeof(::greptime::v1::region::MitoManifestInfo)},
-  { 292, -1, -1, sizeof(::greptime::v1::region::MetricManifestInfo)},
-  { 300, -1, -1, sizeof(::greptime::v1::region::SyncRequest)},
+  { 285, -1, -1, sizeof(::greptime::v1::region::RegionSelection)},
+  { 293, -1, -1, sizeof(::greptime::v1::region::MitoManifestInfo)},
+  { 300, -1, -1, sizeof(::greptime::v1::region::MetricManifestInfo)},
+  { 308, -1, -1, sizeof(::greptime::v1::region::SyncRequest)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -891,6 +914,7 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::greptime::v1::region::_RegionColumnDef_default_instance_._instance,
   &::greptime::v1::region::_BulkInsertRequest_default_instance_._instance,
   &::greptime::v1::region::_ArrowIpc_default_instance_._instance,
+  &::greptime::v1::region::_RegionSelection_default_instance_._instance,
   &::greptime::v1::region::_MitoManifestInfo_default_instance_._instance,
   &::greptime::v1::region::_MetricManifestInfo_default_instance_._instance,
   &::greptime::v1::region::_SyncRequest_default_instance_._instance,
@@ -990,22 +1014,24 @@ const char descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto[] P
   "\022*\n\ncolumn_def\030\001 \001(\0132\026.greptime.v1.Colum"
   "nDef\022\021\n\tcolumn_id\030\002 \001(\r\"N\n\021BulkInsertReq"
   "uest\0221\n\tarrow_ipc\030\001 \001(\0132\034.greptime.v1.re"
-  "gion.ArrowIpcH\000B\006\n\004body\">\n\010ArrowIpc\022\021\n\tr"
-  "egion_id\030\001 \001(\004\022\016\n\006schema\030\002 \001(\014\022\017\n\007payloa"
-  "d\030\003 \001(\014\"1\n\020MitoManifestInfo\022\035\n\025data_mani"
-  "fest_version\030\001 \001(\004\"V\n\022MetricManifestInfo"
-  "\022\035\n\025data_manifest_version\030\001 \001(\004\022!\n\031metad"
-  "ata_manifest_version\030\002 \001(\004\"\275\001\n\013SyncReque"
-  "st\022\021\n\tregion_id\030\001 \001(\004\022B\n\022mito_manifest_i"
-  "nfo\030\002 \001(\0132$.greptime.v1.region.MitoManif"
-  "estInfoH\000\022F\n\024metric_manifest_info\030\003 \001(\0132"
-  "&.greptime.v1.region.MetricManifestInfoH"
-  "\000B\017\n\rmanifest_info2Y\n\006Region\022O\n\006Handle\022!"
-  ".greptime.v1.region.RegionRequest\032\".grep"
-  "time.v1.region.RegionResponseB]\n\025io.grep"
-  "time.v1.regionB\006ServerZ<github.com/Grept"
-  "imeTeam/greptime-proto/go/greptime/v1/re"
-  "gionb\006proto3"
+  "gion.ArrowIpcH\000B\006\n\004body\"j\n\010ArrowIpc\022\016\n\006s"
+  "chema\030\001 \001(\014\022\017\n\007payload\030\002 \001(\014\022=\n\020region_s"
+  "election\030\003 \003(\0132#.greptime.v1.region.Regi"
+  "onSelection\"7\n\017RegionSelection\022\021\n\tregion"
+  "_id\030\001 \001(\004\022\021\n\tselection\030\002 \001(\014\"1\n\020MitoMani"
+  "festInfo\022\035\n\025data_manifest_version\030\001 \001(\004\""
+  "V\n\022MetricManifestInfo\022\035\n\025data_manifest_v"
+  "ersion\030\001 \001(\004\022!\n\031metadata_manifest_versio"
+  "n\030\002 \001(\004\"\275\001\n\013SyncRequest\022\021\n\tregion_id\030\001 \001"
+  "(\004\022B\n\022mito_manifest_info\030\002 \001(\0132$.greptim"
+  "e.v1.region.MitoManifestInfoH\000\022F\n\024metric"
+  "_manifest_info\030\003 \001(\0132&.greptime.v1.regio"
+  "n.MetricManifestInfoH\000B\017\n\rmanifest_info2"
+  "Y\n\006Region\022O\n\006Handle\022!.greptime.v1.region"
+  ".RegionRequest\032\".greptime.v1.region.Regi"
+  "onResponseB]\n\025io.greptime.v1.regionB\006Ser"
+  "verZ<github.com/GreptimeTeam/greptime-pr"
+  "oto/go/greptime/v1/regionb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps[3] = {
   &::descriptor_table_greptime_2fv1_2fcommon_2eproto,
@@ -1014,9 +1040,9 @@ static const ::_pbi::DescriptorTable* const descriptor_table_greptime_2fv1_2freg
 };
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto = {
-    false, false, 4332, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
+    false, false, 4433, descriptor_table_protodef_greptime_2fv1_2fregion_2fserver_2eproto,
     "greptime/v1/region/server.proto",
-    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 35,
+    &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once, descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_deps, 3, 36,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2fregion_2fserver_2eproto::offsets,
     file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto, file_level_enum_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
     file_level_service_descriptors_greptime_2fv1_2fregion_2fserver_2eproto,
@@ -8535,9 +8561,9 @@ ArrowIpc::ArrowIpc(const ArrowIpc& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   ArrowIpc* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.schema_){}
+      decltype(_impl_.region_selection_){from._impl_.region_selection_}
+    , decltype(_impl_.schema_){}
     , decltype(_impl_.payload_){}
-    , decltype(_impl_.region_id_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
@@ -8557,7 +8583,6 @@ ArrowIpc::ArrowIpc(const ArrowIpc& from)
     _this->_impl_.payload_.Set(from._internal_payload(), 
       _this->GetArenaForAllocation());
   }
-  _this->_impl_.region_id_ = from._impl_.region_id_;
   // @@protoc_insertion_point(copy_constructor:greptime.v1.region.ArrowIpc)
 }
 
@@ -8566,9 +8591,9 @@ inline void ArrowIpc::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.schema_){}
+      decltype(_impl_.region_selection_){arena}
+    , decltype(_impl_.schema_){}
     , decltype(_impl_.payload_){}
-    , decltype(_impl_.region_id_){uint64_t{0u}}
     , /*decltype(_impl_._cached_size_)*/{}
   };
   _impl_.schema_.InitDefault();
@@ -8592,6 +8617,7 @@ ArrowIpc::~ArrowIpc() {
 
 inline void ArrowIpc::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.region_selection_.~RepeatedPtrField();
   _impl_.schema_.Destroy();
   _impl_.payload_.Destroy();
 }
@@ -8606,9 +8632,9 @@ void ArrowIpc::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  _impl_.region_selection_.Clear();
   _impl_.schema_.ClearToEmpty();
   _impl_.payload_.ClearToEmpty();
-  _impl_.region_id_ = uint64_t{0u};
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -8618,29 +8644,34 @@ const char* ArrowIpc::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx)
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // uint64 region_id = 1;
+      // bytes schema = 1;
       case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _impl_.region_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // bytes schema = 2;
-      case 2:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
           auto str = _internal_mutable_schema();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // bytes payload = 3;
-      case 3:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+      // bytes payload = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
           auto str = _internal_mutable_payload();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .greptime.v1.region.RegionSelection region_selection = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_region_selection(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<26>(ptr));
         } else
           goto handle_unusual;
         continue;
@@ -8673,22 +8704,24 @@ uint8_t* ArrowIpc::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // uint64 region_id = 1;
-  if (this->_internal_region_id() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(1, this->_internal_region_id(), target);
-  }
-
-  // bytes schema = 2;
+  // bytes schema = 1;
   if (!this->_internal_schema().empty()) {
     target = stream->WriteBytesMaybeAliased(
-        2, this->_internal_schema(), target);
+        1, this->_internal_schema(), target);
   }
 
-  // bytes payload = 3;
+  // bytes payload = 2;
   if (!this->_internal_payload().empty()) {
     target = stream->WriteBytesMaybeAliased(
-        3, this->_internal_payload(), target);
+        2, this->_internal_payload(), target);
+  }
+
+  // repeated .greptime.v1.region.RegionSelection region_selection = 3;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_region_selection_size()); i < n; i++) {
+    const auto& repfield = this->_internal_region_selection(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(3, repfield, repfield.GetCachedSize(), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -8707,23 +8740,25 @@ size_t ArrowIpc::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // bytes schema = 2;
+  // repeated .greptime.v1.region.RegionSelection region_selection = 3;
+  total_size += 1UL * this->_internal_region_selection_size();
+  for (const auto& msg : this->_impl_.region_selection_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // bytes schema = 1;
   if (!this->_internal_schema().empty()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
         this->_internal_schema());
   }
 
-  // bytes payload = 3;
+  // bytes payload = 2;
   if (!this->_internal_payload().empty()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
         this->_internal_payload());
-  }
-
-  // uint64 region_id = 1;
-  if (this->_internal_region_id() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_region_id());
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -8744,14 +8779,12 @@ void ArrowIpc::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTO
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
+  _this->_impl_.region_selection_.MergeFrom(from._impl_.region_selection_);
   if (!from._internal_schema().empty()) {
     _this->_internal_set_schema(from._internal_schema());
   }
   if (!from._internal_payload().empty()) {
     _this->_internal_set_payload(from._internal_payload());
-  }
-  if (from._internal_region_id() != 0) {
-    _this->_internal_set_region_id(from._internal_region_id());
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -8772,6 +8805,7 @@ void ArrowIpc::InternalSwap(ArrowIpc* other) {
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  _impl_.region_selection_.InternalSwap(&other->_impl_.region_selection_);
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
       &_impl_.schema_, lhs_arena,
       &other->_impl_.schema_, rhs_arena
@@ -8780,13 +8814,237 @@ void ArrowIpc::InternalSwap(ArrowIpc* other) {
       &_impl_.payload_, lhs_arena,
       &other->_impl_.payload_, rhs_arena
   );
-  swap(_impl_.region_id_, other->_impl_.region_id_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata ArrowIpc::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
       file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[31]);
+}
+
+// ===================================================================
+
+class RegionSelection::_Internal {
+ public:
+};
+
+RegionSelection::RegionSelection(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:greptime.v1.region.RegionSelection)
+}
+RegionSelection::RegionSelection(const RegionSelection& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  RegionSelection* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.selection_){}
+    , decltype(_impl_.region_id_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.selection_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.selection_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_selection().empty()) {
+    _this->_impl_.selection_.Set(from._internal_selection(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.region_id_ = from._impl_.region_id_;
+  // @@protoc_insertion_point(copy_constructor:greptime.v1.region.RegionSelection)
+}
+
+inline void RegionSelection::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.selection_){}
+    , decltype(_impl_.region_id_){uint64_t{0u}}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.selection_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.selection_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+RegionSelection::~RegionSelection() {
+  // @@protoc_insertion_point(destructor:greptime.v1.region.RegionSelection)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void RegionSelection::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.selection_.Destroy();
+}
+
+void RegionSelection::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void RegionSelection::Clear() {
+// @@protoc_insertion_point(message_clear_start:greptime.v1.region.RegionSelection)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.selection_.ClearToEmpty();
+  _impl_.region_id_ = uint64_t{0u};
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RegionSelection::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // uint64 region_id = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _impl_.region_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes selection = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_selection();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* RegionSelection::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:greptime.v1.region.RegionSelection)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint64 region_id = 1;
+  if (this->_internal_region_id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(1, this->_internal_region_id(), target);
+  }
+
+  // bytes selection = 2;
+  if (!this->_internal_selection().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        2, this->_internal_selection(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:greptime.v1.region.RegionSelection)
+  return target;
+}
+
+size_t RegionSelection::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:greptime.v1.region.RegionSelection)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bytes selection = 2;
+  if (!this->_internal_selection().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_selection());
+  }
+
+  // uint64 region_id = 1;
+  if (this->_internal_region_id() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_region_id());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData RegionSelection::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    RegionSelection::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*RegionSelection::GetClassData() const { return &_class_data_; }
+
+
+void RegionSelection::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<RegionSelection*>(&to_msg);
+  auto& from = static_cast<const RegionSelection&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:greptime.v1.region.RegionSelection)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_selection().empty()) {
+    _this->_internal_set_selection(from._internal_selection());
+  }
+  if (from._internal_region_id() != 0) {
+    _this->_internal_set_region_id(from._internal_region_id());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RegionSelection::CopyFrom(const RegionSelection& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:greptime.v1.region.RegionSelection)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RegionSelection::IsInitialized() const {
+  return true;
+}
+
+void RegionSelection::InternalSwap(RegionSelection* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.selection_, lhs_arena,
+      &other->_impl_.selection_, rhs_arena
+  );
+  swap(_impl_.region_id_, other->_impl_.region_id_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RegionSelection::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[32]);
 }
 
 // ===================================================================
@@ -8964,7 +9222,7 @@ void MitoManifestInfo::InternalSwap(MitoManifestInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MitoManifestInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[32]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[33]);
 }
 
 // ===================================================================
@@ -9175,7 +9433,7 @@ void MetricManifestInfo::InternalSwap(MetricManifestInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MetricManifestInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[33]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[34]);
 }
 
 // ===================================================================
@@ -9507,7 +9765,7 @@ void SyncRequest::InternalSwap(SyncRequest* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata SyncRequest::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2fregion_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[34]);
+      file_level_metadata_greptime_2fv1_2fregion_2fserver_2eproto[35]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -9642,6 +9900,10 @@ Arena::CreateMaybeMessage< ::greptime::v1::region::BulkInsertRequest >(Arena* ar
 template<> PROTOBUF_NOINLINE ::greptime::v1::region::ArrowIpc*
 Arena::CreateMaybeMessage< ::greptime::v1::region::ArrowIpc >(Arena* arena) {
   return Arena::CreateMessageInternal< ::greptime::v1::region::ArrowIpc >(arena);
+}
+template<> PROTOBUF_NOINLINE ::greptime::v1::region::RegionSelection*
+Arena::CreateMaybeMessage< ::greptime::v1::region::RegionSelection >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::region::RegionSelection >(arena);
 }
 template<> PROTOBUF_NOINLINE ::greptime::v1::region::MitoManifestInfo*
 Arena::CreateMaybeMessage< ::greptime::v1::region::MitoManifestInfo >(Arena* arena) {

--- a/c++/greptime/v1/region/server.pb.h
+++ b/c++/greptime/v1/region/server.pb.h
@@ -147,6 +147,9 @@ extern RegionResponseDefaultTypeInternal _RegionResponse_default_instance_;
 class RegionResponse_ExtensionsEntry_DoNotUse;
 struct RegionResponse_ExtensionsEntry_DoNotUseDefaultTypeInternal;
 extern RegionResponse_ExtensionsEntry_DoNotUseDefaultTypeInternal _RegionResponse_ExtensionsEntry_DoNotUse_default_instance_;
+class RegionSelection;
+struct RegionSelectionDefaultTypeInternal;
+extern RegionSelectionDefaultTypeInternal _RegionSelection_default_instance_;
 class Regular;
 struct RegularDefaultTypeInternal;
 extern RegularDefaultTypeInternal _Regular_default_instance_;
@@ -194,6 +197,7 @@ template<> ::greptime::v1::region::RegionRequestHeader* Arena::CreateMaybeMessag
 template<> ::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse* Arena::CreateMaybeMessage<::greptime::v1::region::RegionRequestHeader_TracingContextEntry_DoNotUse>(Arena*);
 template<> ::greptime::v1::region::RegionResponse* Arena::CreateMaybeMessage<::greptime::v1::region::RegionResponse>(Arena*);
 template<> ::greptime::v1::region::RegionResponse_ExtensionsEntry_DoNotUse* Arena::CreateMaybeMessage<::greptime::v1::region::RegionResponse_ExtensionsEntry_DoNotUse>(Arena*);
+template<> ::greptime::v1::region::RegionSelection* Arena::CreateMaybeMessage<::greptime::v1::region::RegionSelection>(Arena*);
 template<> ::greptime::v1::region::Regular* Arena::CreateMaybeMessage<::greptime::v1::region::Regular>(Arena*);
 template<> ::greptime::v1::region::StrictWindow* Arena::CreateMaybeMessage<::greptime::v1::region::StrictWindow>(Arena*);
 template<> ::greptime::v1::region::SyncRequest* Arena::CreateMaybeMessage<::greptime::v1::region::SyncRequest>(Arena*);
@@ -5483,11 +5487,29 @@ class ArrowIpc final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kSchemaFieldNumber = 2,
-    kPayloadFieldNumber = 3,
-    kRegionIdFieldNumber = 1,
+    kRegionSelectionFieldNumber = 3,
+    kSchemaFieldNumber = 1,
+    kPayloadFieldNumber = 2,
   };
-  // bytes schema = 2;
+  // repeated .greptime.v1.region.RegionSelection region_selection = 3;
+  int region_selection_size() const;
+  private:
+  int _internal_region_selection_size() const;
+  public:
+  void clear_region_selection();
+  ::greptime::v1::region::RegionSelection* mutable_region_selection(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::greptime::v1::region::RegionSelection >*
+      mutable_region_selection();
+  private:
+  const ::greptime::v1::region::RegionSelection& _internal_region_selection(int index) const;
+  ::greptime::v1::region::RegionSelection* _internal_add_region_selection();
+  public:
+  const ::greptime::v1::region::RegionSelection& region_selection(int index) const;
+  ::greptime::v1::region::RegionSelection* add_region_selection();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::greptime::v1::region::RegionSelection >&
+      region_selection() const;
+
+  // bytes schema = 1;
   void clear_schema();
   const std::string& schema() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -5501,7 +5523,7 @@ class ArrowIpc final :
   std::string* _internal_mutable_schema();
   public:
 
-  // bytes payload = 3;
+  // bytes payload = 2;
   void clear_payload();
   const std::string& payload() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -5515,6 +5537,162 @@ class ArrowIpc final :
   std::string* _internal_mutable_payload();
   public:
 
+  // @@protoc_insertion_point(class_scope:greptime.v1.region.ArrowIpc)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::greptime::v1::region::RegionSelection > region_selection_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr schema_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr payload_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_greptime_2fv1_2fregion_2fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RegionSelection final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.region.RegionSelection) */ {
+ public:
+  inline RegionSelection() : RegionSelection(nullptr) {}
+  ~RegionSelection() override;
+  explicit PROTOBUF_CONSTEXPR RegionSelection(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  RegionSelection(const RegionSelection& from);
+  RegionSelection(RegionSelection&& from) noexcept
+    : RegionSelection() {
+    *this = ::std::move(from);
+  }
+
+  inline RegionSelection& operator=(const RegionSelection& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RegionSelection& operator=(RegionSelection&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RegionSelection& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RegionSelection* internal_default_instance() {
+    return reinterpret_cast<const RegionSelection*>(
+               &_RegionSelection_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    32;
+
+  friend void swap(RegionSelection& a, RegionSelection& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RegionSelection* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RegionSelection* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RegionSelection* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<RegionSelection>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const RegionSelection& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const RegionSelection& from) {
+    RegionSelection::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RegionSelection* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "greptime.v1.region.RegionSelection";
+  }
+  protected:
+  explicit RegionSelection(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kSelectionFieldNumber = 2,
+    kRegionIdFieldNumber = 1,
+  };
+  // bytes selection = 2;
+  void clear_selection();
+  const std::string& selection() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_selection(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_selection();
+  PROTOBUF_NODISCARD std::string* release_selection();
+  void set_allocated_selection(std::string* selection);
+  private:
+  const std::string& _internal_selection() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_selection(const std::string& value);
+  std::string* _internal_mutable_selection();
+  public:
+
   // uint64 region_id = 1;
   void clear_region_id();
   uint64_t region_id() const;
@@ -5524,7 +5702,7 @@ class ArrowIpc final :
   void _internal_set_region_id(uint64_t value);
   public:
 
-  // @@protoc_insertion_point(class_scope:greptime.v1.region.ArrowIpc)
+  // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionSelection)
  private:
   class _Internal;
 
@@ -5532,8 +5710,7 @@ class ArrowIpc final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr schema_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr payload_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr selection_;
     uint64_t region_id_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
@@ -5590,7 +5767,7 @@ class MitoManifestInfo final :
                &_MitoManifestInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    32;
+    33;
 
   friend void swap(MitoManifestInfo& a, MitoManifestInfo& b) {
     a.Swap(&b);
@@ -5738,7 +5915,7 @@ class MetricManifestInfo final :
                &_MetricManifestInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    33;
+    34;
 
   friend void swap(MetricManifestInfo& a, MetricManifestInfo& b) {
     a.Swap(&b);
@@ -5903,7 +6080,7 @@ class SyncRequest final :
                &_SyncRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    34;
+    35;
 
   friend void swap(SyncRequest& a, SyncRequest& b) {
     a.Swap(&b);
@@ -9960,27 +10137,7 @@ inline BulkInsertRequest::BodyCase BulkInsertRequest::body_case() const {
 
 // ArrowIpc
 
-// uint64 region_id = 1;
-inline void ArrowIpc::clear_region_id() {
-  _impl_.region_id_ = uint64_t{0u};
-}
-inline uint64_t ArrowIpc::_internal_region_id() const {
-  return _impl_.region_id_;
-}
-inline uint64_t ArrowIpc::region_id() const {
-  // @@protoc_insertion_point(field_get:greptime.v1.region.ArrowIpc.region_id)
-  return _internal_region_id();
-}
-inline void ArrowIpc::_internal_set_region_id(uint64_t value) {
-  
-  _impl_.region_id_ = value;
-}
-inline void ArrowIpc::set_region_id(uint64_t value) {
-  _internal_set_region_id(value);
-  // @@protoc_insertion_point(field_set:greptime.v1.region.ArrowIpc.region_id)
-}
-
-// bytes schema = 2;
+// bytes schema = 1;
 inline void ArrowIpc::clear_schema() {
   _impl_.schema_.ClearToEmpty();
 }
@@ -10030,7 +10187,7 @@ inline void ArrowIpc::set_allocated_schema(std::string* schema) {
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.ArrowIpc.schema)
 }
 
-// bytes payload = 3;
+// bytes payload = 2;
 inline void ArrowIpc::clear_payload() {
   _impl_.payload_.ClearToEmpty();
 }
@@ -10078,6 +10235,120 @@ inline void ArrowIpc::set_allocated_payload(std::string* payload) {
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.ArrowIpc.payload)
+}
+
+// repeated .greptime.v1.region.RegionSelection region_selection = 3;
+inline int ArrowIpc::_internal_region_selection_size() const {
+  return _impl_.region_selection_.size();
+}
+inline int ArrowIpc::region_selection_size() const {
+  return _internal_region_selection_size();
+}
+inline void ArrowIpc::clear_region_selection() {
+  _impl_.region_selection_.Clear();
+}
+inline ::greptime::v1::region::RegionSelection* ArrowIpc::mutable_region_selection(int index) {
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.ArrowIpc.region_selection)
+  return _impl_.region_selection_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::greptime::v1::region::RegionSelection >*
+ArrowIpc::mutable_region_selection() {
+  // @@protoc_insertion_point(field_mutable_list:greptime.v1.region.ArrowIpc.region_selection)
+  return &_impl_.region_selection_;
+}
+inline const ::greptime::v1::region::RegionSelection& ArrowIpc::_internal_region_selection(int index) const {
+  return _impl_.region_selection_.Get(index);
+}
+inline const ::greptime::v1::region::RegionSelection& ArrowIpc::region_selection(int index) const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.ArrowIpc.region_selection)
+  return _internal_region_selection(index);
+}
+inline ::greptime::v1::region::RegionSelection* ArrowIpc::_internal_add_region_selection() {
+  return _impl_.region_selection_.Add();
+}
+inline ::greptime::v1::region::RegionSelection* ArrowIpc::add_region_selection() {
+  ::greptime::v1::region::RegionSelection* _add = _internal_add_region_selection();
+  // @@protoc_insertion_point(field_add:greptime.v1.region.ArrowIpc.region_selection)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::greptime::v1::region::RegionSelection >&
+ArrowIpc::region_selection() const {
+  // @@protoc_insertion_point(field_list:greptime.v1.region.ArrowIpc.region_selection)
+  return _impl_.region_selection_;
+}
+
+// -------------------------------------------------------------------
+
+// RegionSelection
+
+// uint64 region_id = 1;
+inline void RegionSelection::clear_region_id() {
+  _impl_.region_id_ = uint64_t{0u};
+}
+inline uint64_t RegionSelection::_internal_region_id() const {
+  return _impl_.region_id_;
+}
+inline uint64_t RegionSelection::region_id() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionSelection.region_id)
+  return _internal_region_id();
+}
+inline void RegionSelection::_internal_set_region_id(uint64_t value) {
+  
+  _impl_.region_id_ = value;
+}
+inline void RegionSelection::set_region_id(uint64_t value) {
+  _internal_set_region_id(value);
+  // @@protoc_insertion_point(field_set:greptime.v1.region.RegionSelection.region_id)
+}
+
+// bytes selection = 2;
+inline void RegionSelection::clear_selection() {
+  _impl_.selection_.ClearToEmpty();
+}
+inline const std::string& RegionSelection::selection() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.region.RegionSelection.selection)
+  return _internal_selection();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void RegionSelection::set_selection(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.selection_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.region.RegionSelection.selection)
+}
+inline std::string* RegionSelection::mutable_selection() {
+  std::string* _s = _internal_mutable_selection();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.region.RegionSelection.selection)
+  return _s;
+}
+inline const std::string& RegionSelection::_internal_selection() const {
+  return _impl_.selection_.Get();
+}
+inline void RegionSelection::_internal_set_selection(const std::string& value) {
+  
+  _impl_.selection_.Set(value, GetArenaForAllocation());
+}
+inline std::string* RegionSelection::_internal_mutable_selection() {
+  
+  return _impl_.selection_.Mutable(GetArenaForAllocation());
+}
+inline std::string* RegionSelection::release_selection() {
+  // @@protoc_insertion_point(field_release:greptime.v1.region.RegionSelection.selection)
+  return _impl_.selection_.Release();
+}
+inline void RegionSelection::set_allocated_selection(std::string* selection) {
+  if (selection != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.selection_.SetAllocated(selection, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.selection_.IsDefault()) {
+    _impl_.selection_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.region.RegionSelection.selection)
 }
 
 // -------------------------------------------------------------------
@@ -10332,6 +10603,8 @@ inline SyncRequest::ManifestInfoCase SyncRequest::manifest_info_case() const {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/java/src/main/java/io/greptime/v1/region/Server.java
+++ b/java/src/main/java/io/greptime/v1/region/Server.java
@@ -26560,22 +26560,40 @@ java.lang.String defaultValue);
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>uint64 region_id = 1;</code>
-     * @return The regionId.
-     */
-    long getRegionId();
-
-    /**
-     * <code>bytes schema = 2;</code>
+     * <code>bytes schema = 1;</code>
      * @return The schema.
      */
     com.google.protobuf.ByteString getSchema();
 
     /**
-     * <code>bytes payload = 3;</code>
+     * <code>bytes payload = 2;</code>
      * @return The payload.
      */
     com.google.protobuf.ByteString getPayload();
+
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    java.util.List<io.greptime.v1.region.Server.RegionSelection> 
+        getRegionSelectionList();
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    io.greptime.v1.region.Server.RegionSelection getRegionSelection(int index);
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    int getRegionSelectionCount();
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    java.util.List<? extends io.greptime.v1.region.Server.RegionSelectionOrBuilder> 
+        getRegionSelectionOrBuilderList();
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    io.greptime.v1.region.Server.RegionSelectionOrBuilder getRegionSelectionOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code greptime.v1.region.ArrowIpc}
@@ -26592,6 +26610,7 @@ java.lang.String defaultValue);
     private ArrowIpc() {
       schema_ = com.google.protobuf.ByteString.EMPTY;
       payload_ = com.google.protobuf.ByteString.EMPTY;
+      regionSelection_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -26614,6 +26633,7 @@ java.lang.String defaultValue);
       if (extensionRegistry == null) {
         throw new java.lang.NullPointerException();
       }
+      int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -26624,19 +26644,23 @@ java.lang.String defaultValue);
             case 0:
               done = true;
               break;
-            case 8: {
-
-              regionId_ = input.readUInt64();
-              break;
-            }
-            case 18: {
+            case 10: {
 
               schema_ = input.readBytes();
               break;
             }
-            case 26: {
+            case 18: {
 
               payload_ = input.readBytes();
+              break;
+            }
+            case 26: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                regionSelection_ = new java.util.ArrayList<io.greptime.v1.region.Server.RegionSelection>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              regionSelection_.add(
+                  input.readMessage(io.greptime.v1.region.Server.RegionSelection.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -26656,6 +26680,9 @@ java.lang.String defaultValue);
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          regionSelection_ = java.util.Collections.unmodifiableList(regionSelection_);
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -26673,21 +26700,10 @@ java.lang.String defaultValue);
               io.greptime.v1.region.Server.ArrowIpc.class, io.greptime.v1.region.Server.ArrowIpc.Builder.class);
     }
 
-    public static final int REGION_ID_FIELD_NUMBER = 1;
-    private long regionId_;
-    /**
-     * <code>uint64 region_id = 1;</code>
-     * @return The regionId.
-     */
-    @java.lang.Override
-    public long getRegionId() {
-      return regionId_;
-    }
-
-    public static final int SCHEMA_FIELD_NUMBER = 2;
+    public static final int SCHEMA_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString schema_;
     /**
-     * <code>bytes schema = 2;</code>
+     * <code>bytes schema = 1;</code>
      * @return The schema.
      */
     @java.lang.Override
@@ -26695,15 +26711,55 @@ java.lang.String defaultValue);
       return schema_;
     }
 
-    public static final int PAYLOAD_FIELD_NUMBER = 3;
+    public static final int PAYLOAD_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString payload_;
     /**
-     * <code>bytes payload = 3;</code>
+     * <code>bytes payload = 2;</code>
      * @return The payload.
      */
     @java.lang.Override
     public com.google.protobuf.ByteString getPayload() {
       return payload_;
+    }
+
+    public static final int REGION_SELECTION_FIELD_NUMBER = 3;
+    private java.util.List<io.greptime.v1.region.Server.RegionSelection> regionSelection_;
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    @java.lang.Override
+    public java.util.List<io.greptime.v1.region.Server.RegionSelection> getRegionSelectionList() {
+      return regionSelection_;
+    }
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends io.greptime.v1.region.Server.RegionSelectionOrBuilder> 
+        getRegionSelectionOrBuilderList() {
+      return regionSelection_;
+    }
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    @java.lang.Override
+    public int getRegionSelectionCount() {
+      return regionSelection_.size();
+    }
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    @java.lang.Override
+    public io.greptime.v1.region.Server.RegionSelection getRegionSelection(int index) {
+      return regionSelection_.get(index);
+    }
+    /**
+     * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+     */
+    @java.lang.Override
+    public io.greptime.v1.region.Server.RegionSelectionOrBuilder getRegionSelectionOrBuilder(
+        int index) {
+      return regionSelection_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -26720,14 +26776,14 @@ java.lang.String defaultValue);
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (regionId_ != 0L) {
-        output.writeUInt64(1, regionId_);
-      }
       if (!schema_.isEmpty()) {
-        output.writeBytes(2, schema_);
+        output.writeBytes(1, schema_);
       }
       if (!payload_.isEmpty()) {
-        output.writeBytes(3, payload_);
+        output.writeBytes(2, payload_);
+      }
+      for (int i = 0; i < regionSelection_.size(); i++) {
+        output.writeMessage(3, regionSelection_.get(i));
       }
       unknownFields.writeTo(output);
     }
@@ -26738,17 +26794,17 @@ java.lang.String defaultValue);
       if (size != -1) return size;
 
       size = 0;
-      if (regionId_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(1, regionId_);
-      }
       if (!schema_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, schema_);
+          .computeBytesSize(1, schema_);
       }
       if (!payload_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(3, payload_);
+          .computeBytesSize(2, payload_);
+      }
+      for (int i = 0; i < regionSelection_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, regionSelection_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -26765,12 +26821,12 @@ java.lang.String defaultValue);
       }
       io.greptime.v1.region.Server.ArrowIpc other = (io.greptime.v1.region.Server.ArrowIpc) obj;
 
-      if (getRegionId()
-          != other.getRegionId()) return false;
       if (!getSchema()
           .equals(other.getSchema())) return false;
       if (!getPayload()
           .equals(other.getPayload())) return false;
+      if (!getRegionSelectionList()
+          .equals(other.getRegionSelectionList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -26782,13 +26838,14 @@ java.lang.String defaultValue);
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + REGION_ID_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getRegionId());
       hash = (37 * hash) + SCHEMA_FIELD_NUMBER;
       hash = (53 * hash) + getSchema().hashCode();
       hash = (37 * hash) + PAYLOAD_FIELD_NUMBER;
       hash = (53 * hash) + getPayload().hashCode();
+      if (getRegionSelectionCount() > 0) {
+        hash = (37 * hash) + REGION_SELECTION_FIELD_NUMBER;
+        hash = (53 * hash) + getRegionSelectionList().hashCode();
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -26917,17 +26974,22 @@ java.lang.String defaultValue);
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
+          getRegionSelectionFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        regionId_ = 0L;
-
         schema_ = com.google.protobuf.ByteString.EMPTY;
 
         payload_ = com.google.protobuf.ByteString.EMPTY;
 
+        if (regionSelectionBuilder_ == null) {
+          regionSelection_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          regionSelectionBuilder_.clear();
+        }
         return this;
       }
 
@@ -26954,9 +27016,18 @@ java.lang.String defaultValue);
       @java.lang.Override
       public io.greptime.v1.region.Server.ArrowIpc buildPartial() {
         io.greptime.v1.region.Server.ArrowIpc result = new io.greptime.v1.region.Server.ArrowIpc(this);
-        result.regionId_ = regionId_;
+        int from_bitField0_ = bitField0_;
         result.schema_ = schema_;
         result.payload_ = payload_;
+        if (regionSelectionBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0)) {
+            regionSelection_ = java.util.Collections.unmodifiableList(regionSelection_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.regionSelection_ = regionSelection_;
+        } else {
+          result.regionSelection_ = regionSelectionBuilder_.build();
+        }
         onBuilt();
         return result;
       }
@@ -27005,14 +27076,37 @@ java.lang.String defaultValue);
 
       public Builder mergeFrom(io.greptime.v1.region.Server.ArrowIpc other) {
         if (other == io.greptime.v1.region.Server.ArrowIpc.getDefaultInstance()) return this;
-        if (other.getRegionId() != 0L) {
-          setRegionId(other.getRegionId());
-        }
         if (other.getSchema() != com.google.protobuf.ByteString.EMPTY) {
           setSchema(other.getSchema());
         }
         if (other.getPayload() != com.google.protobuf.ByteString.EMPTY) {
           setPayload(other.getPayload());
+        }
+        if (regionSelectionBuilder_ == null) {
+          if (!other.regionSelection_.isEmpty()) {
+            if (regionSelection_.isEmpty()) {
+              regionSelection_ = other.regionSelection_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureRegionSelectionIsMutable();
+              regionSelection_.addAll(other.regionSelection_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.regionSelection_.isEmpty()) {
+            if (regionSelectionBuilder_.isEmpty()) {
+              regionSelectionBuilder_.dispose();
+              regionSelectionBuilder_ = null;
+              regionSelection_ = other.regionSelection_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              regionSelectionBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getRegionSelectionFieldBuilder() : null;
+            } else {
+              regionSelectionBuilder_.addAllMessages(other.regionSelection_);
+            }
+          }
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -27042,41 +27136,11 @@ java.lang.String defaultValue);
         }
         return this;
       }
-
-      private long regionId_ ;
-      /**
-       * <code>uint64 region_id = 1;</code>
-       * @return The regionId.
-       */
-      @java.lang.Override
-      public long getRegionId() {
-        return regionId_;
-      }
-      /**
-       * <code>uint64 region_id = 1;</code>
-       * @param value The regionId to set.
-       * @return This builder for chaining.
-       */
-      public Builder setRegionId(long value) {
-        
-        regionId_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>uint64 region_id = 1;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearRegionId() {
-        
-        regionId_ = 0L;
-        onChanged();
-        return this;
-      }
+      private int bitField0_;
 
       private com.google.protobuf.ByteString schema_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>bytes schema = 2;</code>
+       * <code>bytes schema = 1;</code>
        * @return The schema.
        */
       @java.lang.Override
@@ -27084,7 +27148,7 @@ java.lang.String defaultValue);
         return schema_;
       }
       /**
-       * <code>bytes schema = 2;</code>
+       * <code>bytes schema = 1;</code>
        * @param value The schema to set.
        * @return This builder for chaining.
        */
@@ -27098,7 +27162,7 @@ java.lang.String defaultValue);
         return this;
       }
       /**
-       * <code>bytes schema = 2;</code>
+       * <code>bytes schema = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearSchema() {
@@ -27110,7 +27174,7 @@ java.lang.String defaultValue);
 
       private com.google.protobuf.ByteString payload_ = com.google.protobuf.ByteString.EMPTY;
       /**
-       * <code>bytes payload = 3;</code>
+       * <code>bytes payload = 2;</code>
        * @return The payload.
        */
       @java.lang.Override
@@ -27118,7 +27182,7 @@ java.lang.String defaultValue);
         return payload_;
       }
       /**
-       * <code>bytes payload = 3;</code>
+       * <code>bytes payload = 2;</code>
        * @param value The payload to set.
        * @return This builder for chaining.
        */
@@ -27132,7 +27196,7 @@ java.lang.String defaultValue);
         return this;
       }
       /**
-       * <code>bytes payload = 3;</code>
+       * <code>bytes payload = 2;</code>
        * @return This builder for chaining.
        */
       public Builder clearPayload() {
@@ -27140,6 +27204,246 @@ java.lang.String defaultValue);
         payload_ = getDefaultInstance().getPayload();
         onChanged();
         return this;
+      }
+
+      private java.util.List<io.greptime.v1.region.Server.RegionSelection> regionSelection_ =
+        java.util.Collections.emptyList();
+      private void ensureRegionSelectionIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          regionSelection_ = new java.util.ArrayList<io.greptime.v1.region.Server.RegionSelection>(regionSelection_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          io.greptime.v1.region.Server.RegionSelection, io.greptime.v1.region.Server.RegionSelection.Builder, io.greptime.v1.region.Server.RegionSelectionOrBuilder> regionSelectionBuilder_;
+
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public java.util.List<io.greptime.v1.region.Server.RegionSelection> getRegionSelectionList() {
+        if (regionSelectionBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(regionSelection_);
+        } else {
+          return regionSelectionBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public int getRegionSelectionCount() {
+        if (regionSelectionBuilder_ == null) {
+          return regionSelection_.size();
+        } else {
+          return regionSelectionBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public io.greptime.v1.region.Server.RegionSelection getRegionSelection(int index) {
+        if (regionSelectionBuilder_ == null) {
+          return regionSelection_.get(index);
+        } else {
+          return regionSelectionBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder setRegionSelection(
+          int index, io.greptime.v1.region.Server.RegionSelection value) {
+        if (regionSelectionBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRegionSelectionIsMutable();
+          regionSelection_.set(index, value);
+          onChanged();
+        } else {
+          regionSelectionBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder setRegionSelection(
+          int index, io.greptime.v1.region.Server.RegionSelection.Builder builderForValue) {
+        if (regionSelectionBuilder_ == null) {
+          ensureRegionSelectionIsMutable();
+          regionSelection_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          regionSelectionBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder addRegionSelection(io.greptime.v1.region.Server.RegionSelection value) {
+        if (regionSelectionBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRegionSelectionIsMutable();
+          regionSelection_.add(value);
+          onChanged();
+        } else {
+          regionSelectionBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder addRegionSelection(
+          int index, io.greptime.v1.region.Server.RegionSelection value) {
+        if (regionSelectionBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRegionSelectionIsMutable();
+          regionSelection_.add(index, value);
+          onChanged();
+        } else {
+          regionSelectionBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder addRegionSelection(
+          io.greptime.v1.region.Server.RegionSelection.Builder builderForValue) {
+        if (regionSelectionBuilder_ == null) {
+          ensureRegionSelectionIsMutable();
+          regionSelection_.add(builderForValue.build());
+          onChanged();
+        } else {
+          regionSelectionBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder addRegionSelection(
+          int index, io.greptime.v1.region.Server.RegionSelection.Builder builderForValue) {
+        if (regionSelectionBuilder_ == null) {
+          ensureRegionSelectionIsMutable();
+          regionSelection_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          regionSelectionBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder addAllRegionSelection(
+          java.lang.Iterable<? extends io.greptime.v1.region.Server.RegionSelection> values) {
+        if (regionSelectionBuilder_ == null) {
+          ensureRegionSelectionIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, regionSelection_);
+          onChanged();
+        } else {
+          regionSelectionBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder clearRegionSelection() {
+        if (regionSelectionBuilder_ == null) {
+          regionSelection_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          regionSelectionBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public Builder removeRegionSelection(int index) {
+        if (regionSelectionBuilder_ == null) {
+          ensureRegionSelectionIsMutable();
+          regionSelection_.remove(index);
+          onChanged();
+        } else {
+          regionSelectionBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public io.greptime.v1.region.Server.RegionSelection.Builder getRegionSelectionBuilder(
+          int index) {
+        return getRegionSelectionFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public io.greptime.v1.region.Server.RegionSelectionOrBuilder getRegionSelectionOrBuilder(
+          int index) {
+        if (regionSelectionBuilder_ == null) {
+          return regionSelection_.get(index);  } else {
+          return regionSelectionBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public java.util.List<? extends io.greptime.v1.region.Server.RegionSelectionOrBuilder> 
+           getRegionSelectionOrBuilderList() {
+        if (regionSelectionBuilder_ != null) {
+          return regionSelectionBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(regionSelection_);
+        }
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public io.greptime.v1.region.Server.RegionSelection.Builder addRegionSelectionBuilder() {
+        return getRegionSelectionFieldBuilder().addBuilder(
+            io.greptime.v1.region.Server.RegionSelection.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public io.greptime.v1.region.Server.RegionSelection.Builder addRegionSelectionBuilder(
+          int index) {
+        return getRegionSelectionFieldBuilder().addBuilder(
+            index, io.greptime.v1.region.Server.RegionSelection.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .greptime.v1.region.RegionSelection region_selection = 3;</code>
+       */
+      public java.util.List<io.greptime.v1.region.Server.RegionSelection.Builder> 
+           getRegionSelectionBuilderList() {
+        return getRegionSelectionFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          io.greptime.v1.region.Server.RegionSelection, io.greptime.v1.region.Server.RegionSelection.Builder, io.greptime.v1.region.Server.RegionSelectionOrBuilder> 
+          getRegionSelectionFieldBuilder() {
+        if (regionSelectionBuilder_ == null) {
+          regionSelectionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              io.greptime.v1.region.Server.RegionSelection, io.greptime.v1.region.Server.RegionSelection.Builder, io.greptime.v1.region.Server.RegionSelectionOrBuilder>(
+                  regionSelection_,
+                  ((bitField0_ & 0x00000001) != 0),
+                  getParentForChildren(),
+                  isClean());
+          regionSelection_ = null;
+        }
+        return regionSelectionBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -27189,6 +27493,571 @@ java.lang.String defaultValue);
 
     @java.lang.Override
     public io.greptime.v1.region.Server.ArrowIpc getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface RegionSelectionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:greptime.v1.region.RegionSelection)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>uint64 region_id = 1;</code>
+     * @return The regionId.
+     */
+    long getRegionId();
+
+    /**
+     * <code>bytes selection = 2;</code>
+     * @return The selection.
+     */
+    com.google.protobuf.ByteString getSelection();
+  }
+  /**
+   * Protobuf type {@code greptime.v1.region.RegionSelection}
+   */
+  public static final class RegionSelection extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:greptime.v1.region.RegionSelection)
+      RegionSelectionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RegionSelection.newBuilder() to construct.
+    private RegionSelection(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RegionSelection() {
+      selection_ = com.google.protobuf.ByteString.EMPTY;
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new RegionSelection();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RegionSelection(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 8: {
+
+              regionId_ = input.readUInt64();
+              break;
+            }
+            case 18: {
+
+              selection_ = input.readBytes();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionSelection_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionSelection_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.greptime.v1.region.Server.RegionSelection.class, io.greptime.v1.region.Server.RegionSelection.Builder.class);
+    }
+
+    public static final int REGION_ID_FIELD_NUMBER = 1;
+    private long regionId_;
+    /**
+     * <code>uint64 region_id = 1;</code>
+     * @return The regionId.
+     */
+    @java.lang.Override
+    public long getRegionId() {
+      return regionId_;
+    }
+
+    public static final int SELECTION_FIELD_NUMBER = 2;
+    private com.google.protobuf.ByteString selection_;
+    /**
+     * <code>bytes selection = 2;</code>
+     * @return The selection.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString getSelection() {
+      return selection_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (regionId_ != 0L) {
+        output.writeUInt64(1, regionId_);
+      }
+      if (!selection_.isEmpty()) {
+        output.writeBytes(2, selection_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (regionId_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(1, regionId_);
+      }
+      if (!selection_.isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, selection_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.greptime.v1.region.Server.RegionSelection)) {
+        return super.equals(obj);
+      }
+      io.greptime.v1.region.Server.RegionSelection other = (io.greptime.v1.region.Server.RegionSelection) obj;
+
+      if (getRegionId()
+          != other.getRegionId()) return false;
+      if (!getSelection()
+          .equals(other.getSelection())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + REGION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getRegionId());
+      hash = (37 * hash) + SELECTION_FIELD_NUMBER;
+      hash = (53 * hash) + getSelection().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.region.Server.RegionSelection parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.greptime.v1.region.Server.RegionSelection prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code greptime.v1.region.RegionSelection}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:greptime.v1.region.RegionSelection)
+        io.greptime.v1.region.Server.RegionSelectionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionSelection_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionSelection_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.greptime.v1.region.Server.RegionSelection.class, io.greptime.v1.region.Server.RegionSelection.Builder.class);
+      }
+
+      // Construct using io.greptime.v1.region.Server.RegionSelection.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        regionId_ = 0L;
+
+        selection_ = com.google.protobuf.ByteString.EMPTY;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.greptime.v1.region.Server.internal_static_greptime_v1_region_RegionSelection_descriptor;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RegionSelection getDefaultInstanceForType() {
+        return io.greptime.v1.region.Server.RegionSelection.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RegionSelection build() {
+        io.greptime.v1.region.Server.RegionSelection result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.region.Server.RegionSelection buildPartial() {
+        io.greptime.v1.region.Server.RegionSelection result = new io.greptime.v1.region.Server.RegionSelection(this);
+        result.regionId_ = regionId_;
+        result.selection_ = selection_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.greptime.v1.region.Server.RegionSelection) {
+          return mergeFrom((io.greptime.v1.region.Server.RegionSelection)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.greptime.v1.region.Server.RegionSelection other) {
+        if (other == io.greptime.v1.region.Server.RegionSelection.getDefaultInstance()) return this;
+        if (other.getRegionId() != 0L) {
+          setRegionId(other.getRegionId());
+        }
+        if (other.getSelection() != com.google.protobuf.ByteString.EMPTY) {
+          setSelection(other.getSelection());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.greptime.v1.region.Server.RegionSelection parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.greptime.v1.region.Server.RegionSelection) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private long regionId_ ;
+      /**
+       * <code>uint64 region_id = 1;</code>
+       * @return The regionId.
+       */
+      @java.lang.Override
+      public long getRegionId() {
+        return regionId_;
+      }
+      /**
+       * <code>uint64 region_id = 1;</code>
+       * @param value The regionId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRegionId(long value) {
+        
+        regionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>uint64 region_id = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRegionId() {
+        
+        regionId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString selection_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>bytes selection = 2;</code>
+       * @return The selection.
+       */
+      @java.lang.Override
+      public com.google.protobuf.ByteString getSelection() {
+        return selection_;
+      }
+      /**
+       * <code>bytes selection = 2;</code>
+       * @param value The selection to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSelection(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        selection_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>bytes selection = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSelection() {
+        
+        selection_ = getDefaultInstance().getSelection();
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:greptime.v1.region.RegionSelection)
+    }
+
+    // @@protoc_insertion_point(class_scope:greptime.v1.region.RegionSelection)
+    private static final io.greptime.v1.region.Server.RegionSelection DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.greptime.v1.region.Server.RegionSelection();
+    }
+
+    public static io.greptime.v1.region.Server.RegionSelection getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<RegionSelection>
+        PARSER = new com.google.protobuf.AbstractParser<RegionSelection>() {
+      @java.lang.Override
+      public RegionSelection parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RegionSelection(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RegionSelection> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RegionSelection> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.greptime.v1.region.Server.RegionSelection getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -29454,6 +30323,11 @@ java.lang.String defaultValue);
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_greptime_v1_region_ArrowIpc_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_region_RegionSelection_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_region_RegionSelection_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_greptime_v1_region_MitoManifestInfo_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -29570,22 +30444,24 @@ java.lang.String defaultValue);
       "\022*\n\ncolumn_def\030\001 \001(\0132\026.greptime.v1.Colum" +
       "nDef\022\021\n\tcolumn_id\030\002 \001(\r\"N\n\021BulkInsertReq" +
       "uest\0221\n\tarrow_ipc\030\001 \001(\0132\034.greptime.v1.re" +
-      "gion.ArrowIpcH\000B\006\n\004body\">\n\010ArrowIpc\022\021\n\tr" +
-      "egion_id\030\001 \001(\004\022\016\n\006schema\030\002 \001(\014\022\017\n\007payloa" +
-      "d\030\003 \001(\014\"1\n\020MitoManifestInfo\022\035\n\025data_mani" +
-      "fest_version\030\001 \001(\004\"V\n\022MetricManifestInfo" +
-      "\022\035\n\025data_manifest_version\030\001 \001(\004\022!\n\031metad" +
-      "ata_manifest_version\030\002 \001(\004\"\275\001\n\013SyncReque" +
-      "st\022\021\n\tregion_id\030\001 \001(\004\022B\n\022mito_manifest_i" +
-      "nfo\030\002 \001(\0132$.greptime.v1.region.MitoManif" +
-      "estInfoH\000\022F\n\024metric_manifest_info\030\003 \001(\0132" +
-      "&.greptime.v1.region.MetricManifestInfoH" +
-      "\000B\017\n\rmanifest_info2Y\n\006Region\022O\n\006Handle\022!" +
-      ".greptime.v1.region.RegionRequest\032\".grep" +
-      "time.v1.region.RegionResponseB]\n\025io.grep" +
-      "time.v1.regionB\006ServerZ<github.com/Grept" +
-      "imeTeam/greptime-proto/go/greptime/v1/re" +
-      "gionb\006proto3"
+      "gion.ArrowIpcH\000B\006\n\004body\"j\n\010ArrowIpc\022\016\n\006s" +
+      "chema\030\001 \001(\014\022\017\n\007payload\030\002 \001(\014\022=\n\020region_s" +
+      "election\030\003 \003(\0132#.greptime.v1.region.Regi" +
+      "onSelection\"7\n\017RegionSelection\022\021\n\tregion" +
+      "_id\030\001 \001(\004\022\021\n\tselection\030\002 \001(\014\"1\n\020MitoMani" +
+      "festInfo\022\035\n\025data_manifest_version\030\001 \001(\004\"" +
+      "V\n\022MetricManifestInfo\022\035\n\025data_manifest_v" +
+      "ersion\030\001 \001(\004\022!\n\031metadata_manifest_versio" +
+      "n\030\002 \001(\004\"\275\001\n\013SyncRequest\022\021\n\tregion_id\030\001 \001" +
+      "(\004\022B\n\022mito_manifest_info\030\002 \001(\0132$.greptim" +
+      "e.v1.region.MitoManifestInfoH\000\022F\n\024metric" +
+      "_manifest_info\030\003 \001(\0132&.greptime.v1.regio" +
+      "n.MetricManifestInfoH\000B\017\n\rmanifest_info2" +
+      "Y\n\006Region\022O\n\006Handle\022!.greptime.v1.region" +
+      ".RegionRequest\032\".greptime.v1.region.Regi" +
+      "onResponseB]\n\025io.greptime.v1.regionB\006Ser" +
+      "verZ<github.com/GreptimeTeam/greptime-pr" +
+      "oto/go/greptime/v1/regionb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -29785,21 +30661,27 @@ java.lang.String defaultValue);
     internal_static_greptime_v1_region_ArrowIpc_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_ArrowIpc_descriptor,
-        new java.lang.String[] { "RegionId", "Schema", "Payload", });
-    internal_static_greptime_v1_region_MitoManifestInfo_descriptor =
+        new java.lang.String[] { "Schema", "Payload", "RegionSelection", });
+    internal_static_greptime_v1_region_RegionSelection_descriptor =
       getDescriptor().getMessageTypes().get(28);
+    internal_static_greptime_v1_region_RegionSelection_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_region_RegionSelection_descriptor,
+        new java.lang.String[] { "RegionId", "Selection", });
+    internal_static_greptime_v1_region_MitoManifestInfo_descriptor =
+      getDescriptor().getMessageTypes().get(29);
     internal_static_greptime_v1_region_MitoManifestInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_MitoManifestInfo_descriptor,
         new java.lang.String[] { "DataManifestVersion", });
     internal_static_greptime_v1_region_MetricManifestInfo_descriptor =
-      getDescriptor().getMessageTypes().get(29);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_greptime_v1_region_MetricManifestInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_MetricManifestInfo_descriptor,
         new java.lang.String[] { "DataManifestVersion", "MetadataManifestVersion", });
     internal_static_greptime_v1_region_SyncRequest_descriptor =
-      getDescriptor().getMessageTypes().get(30);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_greptime_v1_region_SyncRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_region_SyncRequest_descriptor,

--- a/proto/greptime/v1/region/server.proto
+++ b/proto/greptime/v1/region/server.proto
@@ -193,9 +193,14 @@ message BulkInsertRequest {
 }
 
 message ArrowIpc {
+  bytes schema = 1;
+  bytes payload = 2;
+  repeated RegionSelection region_selection = 3;
+}
+
+message RegionSelection {
   uint64 region_id = 1;
-  bytes schema = 2;
-  bytes payload = 3;
+  bytes selection = 2;
 }
 
 // Manifest info for mito engine.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR restores `RegionSelection` related messages in proto to avoid breaking main branch in DB.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.
