### PR TITLE
feat: kill process rpc service

### DIFF
--- a/c++/greptime/v1/frontend/server.grpc.pb.cc
+++ b/c++/greptime/v1/frontend/server.grpc.pb.cc
@@ -25,6 +25,7 @@ namespace frontend {
 
 static const char* Frontend_method_names[] = {
   "/greptime.v1.frontend.Frontend/ListProcess",
+  "/greptime.v1.frontend.Frontend/KillProcess",
 };
 
 std::unique_ptr< Frontend::Stub> Frontend::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -35,6 +36,7 @@ std::unique_ptr< Frontend::Stub> Frontend::NewStub(const std::shared_ptr< ::grpc
 
 Frontend::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options)
   : channel_(channel), rpcmethod_ListProcess_(Frontend_method_names[0], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_KillProcess_(Frontend_method_names[1], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status Frontend::Stub::ListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::greptime::v1::frontend::ListProcessResponse* response) {
@@ -60,6 +62,29 @@ void Frontend::Stub::async::ListProcess(::grpc::ClientContext* context, const ::
   return result;
 }
 
+::grpc::Status Frontend::Stub::KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::greptime::v1::frontend::KillProcessResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_KillProcess_, context, request, response);
+}
+
+void Frontend::Stub::async::KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_KillProcess_, context, request, response, std::move(f));
+}
+
+void Frontend::Stub::async::KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_KillProcess_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>* Frontend::Stub::PrepareAsyncKillProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::greptime::v1::frontend::KillProcessResponse, ::greptime::v1::frontend::KillProcessRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_KillProcess_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>* Frontend::Stub::AsyncKillProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncKillProcessRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 Frontend::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       Frontend_method_names[0],
@@ -71,12 +96,29 @@ Frontend::Service::Service() {
              ::greptime::v1::frontend::ListProcessResponse* resp) {
                return service->ListProcess(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      Frontend_method_names[1],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< Frontend::Service, ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](Frontend::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::greptime::v1::frontend::KillProcessRequest* req,
+             ::greptime::v1::frontend::KillProcessResponse* resp) {
+               return service->KillProcess(ctx, req, resp);
+             }, this)));
 }
 
 Frontend::Service::~Service() {
 }
 
 ::grpc::Status Frontend::Service::ListProcess(::grpc::ServerContext* context, const ::greptime::v1::frontend::ListProcessRequest* request, ::greptime::v1::frontend::ListProcessResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status Frontend::Service::KillProcess(::grpc::ServerContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/c++/greptime/v1/frontend/server.grpc.pb.h
+++ b/c++/greptime/v1/frontend/server.grpc.pb.h
@@ -60,12 +60,23 @@ class Frontend final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::ListProcessResponse>> PrepareAsyncListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::ListProcessResponse>>(PrepareAsyncListProcessRaw(context, request, cq));
     }
+    // Kill a running process on frontend.
+    virtual ::grpc::Status KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::greptime::v1::frontend::KillProcessResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::KillProcessResponse>> AsyncKillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::KillProcessResponse>>(AsyncKillProcessRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::KillProcessResponse>> PrepareAsyncKillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::KillProcessResponse>>(PrepareAsyncKillProcessRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
       // List all running processes on frontend.
       virtual void ListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest* request, ::greptime::v1::frontend::ListProcessResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void ListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest* request, ::greptime::v1::frontend::ListProcessResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Kill a running process on frontend.
+      virtual void KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -73,6 +84,8 @@ class Frontend final {
    private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::ListProcessResponse>* AsyncListProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::ListProcessResponse>* PrepareAsyncListProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::KillProcessResponse>* AsyncKillProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::greptime::v1::frontend::KillProcessResponse>* PrepareAsyncKillProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -84,11 +97,20 @@ class Frontend final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::ListProcessResponse>> PrepareAsyncListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::ListProcessResponse>>(PrepareAsyncListProcessRaw(context, request, cq));
     }
+    ::grpc::Status KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::greptime::v1::frontend::KillProcessResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>> AsyncKillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>>(AsyncKillProcessRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>> PrepareAsyncKillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>>(PrepareAsyncKillProcessRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
       void ListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest* request, ::greptime::v1::frontend::ListProcessResponse* response, std::function<void(::grpc::Status)>) override;
       void ListProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest* request, ::greptime::v1::frontend::ListProcessResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response, std::function<void(::grpc::Status)>) override;
+      void KillProcess(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -102,7 +124,10 @@ class Frontend final {
     class async async_stub_{this};
     ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::ListProcessResponse>* AsyncListProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::ListProcessResponse>* PrepareAsyncListProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::ListProcessRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>* AsyncKillProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::greptime::v1::frontend::KillProcessResponse>* PrepareAsyncKillProcessRaw(::grpc::ClientContext* context, const ::greptime::v1::frontend::KillProcessRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_ListProcess_;
+    const ::grpc::internal::RpcMethod rpcmethod_KillProcess_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -112,6 +137,8 @@ class Frontend final {
     virtual ~Service();
     // List all running processes on frontend.
     virtual ::grpc::Status ListProcess(::grpc::ServerContext* context, const ::greptime::v1::frontend::ListProcessRequest* request, ::greptime::v1::frontend::ListProcessResponse* response);
+    // Kill a running process on frontend.
+    virtual ::grpc::Status KillProcess(::grpc::ServerContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_ListProcess : public BaseClass {
@@ -133,7 +160,27 @@ class Frontend final {
       ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_ListProcess<Service > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_KillProcess : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_KillProcess() {
+      ::grpc::Service::MarkMethodAsync(1);
+    }
+    ~WithAsyncMethod_KillProcess() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status KillProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestKillProcess(::grpc::ServerContext* context, ::greptime::v1::frontend::KillProcessRequest* request, ::grpc::ServerAsyncResponseWriter< ::greptime::v1::frontend::KillProcessResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_ListProcess<WithAsyncMethod_KillProcess<Service > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_ListProcess : public BaseClass {
    private:
@@ -161,7 +208,34 @@ class Frontend final {
     virtual ::grpc::ServerUnaryReactor* ListProcess(
       ::grpc::CallbackServerContext* /*context*/, const ::greptime::v1::frontend::ListProcessRequest* /*request*/, ::greptime::v1::frontend::ListProcessResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_ListProcess<Service > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_KillProcess : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_KillProcess() {
+      ::grpc::Service::MarkMethodCallback(1,
+          new ::grpc::internal::CallbackUnaryHandler< ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::greptime::v1::frontend::KillProcessRequest* request, ::greptime::v1::frontend::KillProcessResponse* response) { return this->KillProcess(context, request, response); }));}
+    void SetMessageAllocatorFor_KillProcess(
+        ::grpc::MessageAllocator< ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(1);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_KillProcess() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status KillProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* KillProcess(
+      ::grpc::CallbackServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_ListProcess<WithCallbackMethod_KillProcess<Service > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_ListProcess : public BaseClass {
@@ -176,6 +250,23 @@ class Frontend final {
     }
     // disable synchronous version of this method
     ::grpc::Status ListProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::ListProcessRequest* /*request*/, ::greptime::v1::frontend::ListProcessResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_KillProcess : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_KillProcess() {
+      ::grpc::Service::MarkMethodGeneric(1);
+    }
+    ~WithGenericMethod_KillProcess() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status KillProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -201,6 +292,26 @@ class Frontend final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_KillProcess : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_KillProcess() {
+      ::grpc::Service::MarkMethodRaw(1);
+    }
+    ~WithRawMethod_KillProcess() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status KillProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestKillProcess(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_ListProcess : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -220,6 +331,28 @@ class Frontend final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     virtual ::grpc::ServerUnaryReactor* ListProcess(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_KillProcess : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_KillProcess() {
+      ::grpc::Service::MarkMethodRawCallback(1,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->KillProcess(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_KillProcess() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status KillProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* KillProcess(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -249,9 +382,36 @@ class Frontend final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedListProcess(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::greptime::v1::frontend::ListProcessRequest,::greptime::v1::frontend::ListProcessResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_ListProcess<Service > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_KillProcess : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_KillProcess() {
+      ::grpc::Service::MarkMethodStreamed(1,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::greptime::v1::frontend::KillProcessRequest, ::greptime::v1::frontend::KillProcessResponse>* streamer) {
+                       return this->StreamedKillProcess(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_KillProcess() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status KillProcess(::grpc::ServerContext* /*context*/, const ::greptime::v1::frontend::KillProcessRequest* /*request*/, ::greptime::v1::frontend::KillProcessResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedKillProcess(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::greptime::v1::frontend::KillProcessRequest,::greptime::v1::frontend::KillProcessResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_ListProcess<WithStreamedUnaryMethod_KillProcess<Service > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_ListProcess<Service > StreamedService;
+  typedef WithStreamedUnaryMethod_ListProcess<WithStreamedUnaryMethod_KillProcess<Service > > StreamedService;
 };
 
 }  // namespace frontend

--- a/c++/greptime/v1/frontend/server.pb.cc
+++ b/c++/greptime/v1/frontend/server.pb.cc
@@ -49,6 +49,31 @@ struct ListProcessResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ListProcessResponseDefaultTypeInternal _ListProcessResponse_default_instance_;
+PROTOBUF_CONSTEXPR KillProcessRequest::KillProcessRequest(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.catalog_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.process_id_)*/uint64_t{0u}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct KillProcessRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR KillProcessRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~KillProcessRequestDefaultTypeInternal() {}
+  union {
+    KillProcessRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 KillProcessRequestDefaultTypeInternal _KillProcessRequest_default_instance_;
+PROTOBUF_CONSTEXPR KillProcessResponse::KillProcessResponse(
+    ::_pbi::ConstantInitialized) {}
+struct KillProcessResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR KillProcessResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~KillProcessResponseDefaultTypeInternal() {}
+  union {
+    KillProcessResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 KillProcessResponseDefaultTypeInternal _KillProcessResponse_default_instance_;
 PROTOBUF_CONSTEXPR ProcessInfo::ProcessInfo(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.schemas_)*/{}
@@ -71,7 +96,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace frontend
 }  // namespace v1
 }  // namespace greptime
-static ::_pb::Metadata file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[3];
+static ::_pb::Metadata file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[5];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_greptime_2fv1_2ffrontend_2fserver_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_greptime_2fv1_2ffrontend_2fserver_2eproto = nullptr;
 
@@ -91,6 +116,20 @@ const uint32_t TableStruct_greptime_2fv1_2ffrontend_2fserver_2eproto::offsets[] 
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::frontend::ListProcessResponse, _impl_.processes_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::frontend::KillProcessRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::frontend::KillProcessRequest, _impl_.catalog_),
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::frontend::KillProcessRequest, _impl_.process_id_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::greptime::v1::frontend::KillProcessResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::greptime::v1::frontend::ProcessInfo, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -107,12 +146,16 @@ const uint32_t TableStruct_greptime_2fv1_2ffrontend_2fserver_2eproto::offsets[] 
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, -1, sizeof(::greptime::v1::frontend::ListProcessRequest)},
   { 7, -1, -1, sizeof(::greptime::v1::frontend::ListProcessResponse)},
-  { 14, -1, -1, sizeof(::greptime::v1::frontend::ProcessInfo)},
+  { 14, -1, -1, sizeof(::greptime::v1::frontend::KillProcessRequest)},
+  { 22, -1, -1, sizeof(::greptime::v1::frontend::KillProcessResponse)},
+  { 28, -1, -1, sizeof(::greptime::v1::frontend::ProcessInfo)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
   &::greptime::v1::frontend::_ListProcessRequest_default_instance_._instance,
   &::greptime::v1::frontend::_ListProcessResponse_default_instance_._instance,
+  &::greptime::v1::frontend::_KillProcessRequest_default_instance_._instance,
+  &::greptime::v1::frontend::_KillProcessResponse_default_instance_._instance,
   &::greptime::v1::frontend::_ProcessInfo_default_instance_._instance,
 };
 
@@ -121,22 +164,26 @@ const char descriptor_table_protodef_greptime_2fv1_2ffrontend_2fserver_2eproto[]
   "ptime.v1.frontend\"%\n\022ListProcessRequest\022"
   "\017\n\007catalog\030\001 \001(\t\"K\n\023ListProcessResponse\022"
   "4\n\tprocesses\030\001 \003(\0132!.greptime.v1.fronten"
-  "d.ProcessInfo\"\205\001\n\013ProcessInfo\022\n\n\002id\030\001 \001("
-  "\004\022\017\n\007catalog\030\002 \001(\t\022\017\n\007schemas\030\003 \003(\t\022\r\n\005q"
-  "uery\030\004 \001(\t\022\027\n\017start_timestamp\030\005 \001(\003\022\016\n\006c"
-  "lient\030\006 \001(\t\022\020\n\010frontend\030\007 \001(\t2n\n\010Fronten"
-  "d\022b\n\013ListProcess\022(.greptime.v1.frontend."
-  "ListProcessRequest\032).greptime.v1.fronten"
-  "d.ListProcessResponseBa\n\027io.greptime.v1."
-  "frontendB\006ServerZ>github.com/GreptimeTea"
-  "m/greptime-proto/go/greptime/v1/frontend"
-  "b\006proto3"
+  "d.ProcessInfo\"9\n\022KillProcessRequest\022\017\n\007c"
+  "atalog\030\001 \001(\t\022\022\n\nprocess_id\030\002 \001(\004\"\025\n\023Kill"
+  "ProcessResponse\"\205\001\n\013ProcessInfo\022\n\n\002id\030\001 "
+  "\001(\004\022\017\n\007catalog\030\002 \001(\t\022\017\n\007schemas\030\003 \003(\t\022\r\n"
+  "\005query\030\004 \001(\t\022\027\n\017start_timestamp\030\005 \001(\003\022\016\n"
+  "\006client\030\006 \001(\t\022\020\n\010frontend\030\007 \001(\t2\322\001\n\010Fron"
+  "tend\022b\n\013ListProcess\022(.greptime.v1.fronte"
+  "nd.ListProcessRequest\032).greptime.v1.fron"
+  "tend.ListProcessResponse\022b\n\013KillProcess\022"
+  "(.greptime.v1.frontend.KillProcessReques"
+  "t\032).greptime.v1.frontend.KillProcessResp"
+  "onseBa\n\027io.greptime.v1.frontendB\006ServerZ"
+  ">github.com/GreptimeTeam/greptime-proto/"
+  "go/greptime/v1/frontendb\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto = {
-    false, false, 528, descriptor_table_protodef_greptime_2fv1_2ffrontend_2fserver_2eproto,
+    false, false, 711, descriptor_table_protodef_greptime_2fv1_2ffrontend_2fserver_2eproto,
     "greptime/v1/frontend/server.proto",
-    &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once, nullptr, 0, 3,
+    &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once, nullptr, 0, 5,
     schemas, file_default_instances, TableStruct_greptime_2fv1_2ffrontend_2fserver_2eproto::offsets,
     file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto, file_level_enum_descriptors_greptime_2fv1_2ffrontend_2fserver_2eproto,
     file_level_service_descriptors_greptime_2fv1_2ffrontend_2fserver_2eproto,
@@ -537,6 +584,276 @@ void ListProcessResponse::InternalSwap(ListProcessResponse* other) {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once,
       file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[1]);
+}
+
+// ===================================================================
+
+class KillProcessRequest::_Internal {
+ public:
+};
+
+KillProcessRequest::KillProcessRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:greptime.v1.frontend.KillProcessRequest)
+}
+KillProcessRequest::KillProcessRequest(const KillProcessRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  KillProcessRequest* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.catalog_){}
+    , decltype(_impl_.process_id_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.catalog_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.catalog_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_catalog().empty()) {
+    _this->_impl_.catalog_.Set(from._internal_catalog(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.process_id_ = from._impl_.process_id_;
+  // @@protoc_insertion_point(copy_constructor:greptime.v1.frontend.KillProcessRequest)
+}
+
+inline void KillProcessRequest::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.catalog_){}
+    , decltype(_impl_.process_id_){uint64_t{0u}}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.catalog_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.catalog_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+KillProcessRequest::~KillProcessRequest() {
+  // @@protoc_insertion_point(destructor:greptime.v1.frontend.KillProcessRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void KillProcessRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.catalog_.Destroy();
+}
+
+void KillProcessRequest::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void KillProcessRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:greptime.v1.frontend.KillProcessRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.catalog_.ClearToEmpty();
+  _impl_.process_id_ = uint64_t{0u};
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* KillProcessRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // string catalog = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_catalog();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "greptime.v1.frontend.KillProcessRequest.catalog"));
+        } else
+          goto handle_unusual;
+        continue;
+      // uint64 process_id = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _impl_.process_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* KillProcessRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:greptime.v1.frontend.KillProcessRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string catalog = 1;
+  if (!this->_internal_catalog().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_catalog().data(), static_cast<int>(this->_internal_catalog().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "greptime.v1.frontend.KillProcessRequest.catalog");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_catalog(), target);
+  }
+
+  // uint64 process_id = 2;
+  if (this->_internal_process_id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(2, this->_internal_process_id(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:greptime.v1.frontend.KillProcessRequest)
+  return target;
+}
+
+size_t KillProcessRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:greptime.v1.frontend.KillProcessRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string catalog = 1;
+  if (!this->_internal_catalog().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_catalog());
+  }
+
+  // uint64 process_id = 2;
+  if (this->_internal_process_id() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_process_id());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData KillProcessRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    KillProcessRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*KillProcessRequest::GetClassData() const { return &_class_data_; }
+
+
+void KillProcessRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<KillProcessRequest*>(&to_msg);
+  auto& from = static_cast<const KillProcessRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:greptime.v1.frontend.KillProcessRequest)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_catalog().empty()) {
+    _this->_internal_set_catalog(from._internal_catalog());
+  }
+  if (from._internal_process_id() != 0) {
+    _this->_internal_set_process_id(from._internal_process_id());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void KillProcessRequest::CopyFrom(const KillProcessRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:greptime.v1.frontend.KillProcessRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool KillProcessRequest::IsInitialized() const {
+  return true;
+}
+
+void KillProcessRequest::InternalSwap(KillProcessRequest* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.catalog_, lhs_arena,
+      &other->_impl_.catalog_, rhs_arena
+  );
+  swap(_impl_.process_id_, other->_impl_.process_id_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata KillProcessRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[2]);
+}
+
+// ===================================================================
+
+class KillProcessResponse::_Internal {
+ public:
+};
+
+KillProcessResponse::KillProcessResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase(arena, is_message_owned) {
+  // @@protoc_insertion_point(arena_constructor:greptime.v1.frontend.KillProcessResponse)
+}
+KillProcessResponse::KillProcessResponse(const KillProcessResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase() {
+  KillProcessResponse* const _this = this; (void)_this;
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:greptime.v1.frontend.KillProcessResponse)
+}
+
+
+
+
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData KillProcessResponse::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::CopyImpl,
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::MergeImpl,
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*KillProcessResponse::GetClassData() const { return &_class_data_; }
+
+
+
+
+
+
+
+::PROTOBUF_NAMESPACE_ID::Metadata KillProcessResponse::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once,
+      file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[3]);
 }
 
 // ===================================================================
@@ -988,7 +1305,7 @@ void ProcessInfo::InternalSwap(ProcessInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ProcessInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_getter, &descriptor_table_greptime_2fv1_2ffrontend_2fserver_2eproto_once,
-      file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[2]);
+      file_level_metadata_greptime_2fv1_2ffrontend_2fserver_2eproto[4]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -1003,6 +1320,14 @@ Arena::CreateMaybeMessage< ::greptime::v1::frontend::ListProcessRequest >(Arena*
 template<> PROTOBUF_NOINLINE ::greptime::v1::frontend::ListProcessResponse*
 Arena::CreateMaybeMessage< ::greptime::v1::frontend::ListProcessResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::greptime::v1::frontend::ListProcessResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::greptime::v1::frontend::KillProcessRequest*
+Arena::CreateMaybeMessage< ::greptime::v1::frontend::KillProcessRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::frontend::KillProcessRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::greptime::v1::frontend::KillProcessResponse*
+Arena::CreateMaybeMessage< ::greptime::v1::frontend::KillProcessResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::greptime::v1::frontend::KillProcessResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::greptime::v1::frontend::ProcessInfo*
 Arena::CreateMaybeMessage< ::greptime::v1::frontend::ProcessInfo >(Arena* arena) {

--- a/c++/greptime/v1/frontend/server.pb.h
+++ b/c++/greptime/v1/frontend/server.pb.h
@@ -23,6 +23,7 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/arena.h>
 #include <google/protobuf/arenastring.h>
+#include <google/protobuf/generated_message_bases.h>
 #include <google/protobuf/generated_message_util.h>
 #include <google/protobuf/metadata_lite.h>
 #include <google/protobuf/generated_message_reflection.h>
@@ -47,6 +48,12 @@ extern const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table
 namespace greptime {
 namespace v1 {
 namespace frontend {
+class KillProcessRequest;
+struct KillProcessRequestDefaultTypeInternal;
+extern KillProcessRequestDefaultTypeInternal _KillProcessRequest_default_instance_;
+class KillProcessResponse;
+struct KillProcessResponseDefaultTypeInternal;
+extern KillProcessResponseDefaultTypeInternal _KillProcessResponse_default_instance_;
 class ListProcessRequest;
 struct ListProcessRequestDefaultTypeInternal;
 extern ListProcessRequestDefaultTypeInternal _ListProcessRequest_default_instance_;
@@ -60,6 +67,8 @@ extern ProcessInfoDefaultTypeInternal _ProcessInfo_default_instance_;
 }  // namespace v1
 }  // namespace greptime
 PROTOBUF_NAMESPACE_OPEN
+template<> ::greptime::v1::frontend::KillProcessRequest* Arena::CreateMaybeMessage<::greptime::v1::frontend::KillProcessRequest>(Arena*);
+template<> ::greptime::v1::frontend::KillProcessResponse* Arena::CreateMaybeMessage<::greptime::v1::frontend::KillProcessResponse>(Arena*);
 template<> ::greptime::v1::frontend::ListProcessRequest* Arena::CreateMaybeMessage<::greptime::v1::frontend::ListProcessRequest>(Arena*);
 template<> ::greptime::v1::frontend::ListProcessResponse* Arena::CreateMaybeMessage<::greptime::v1::frontend::ListProcessResponse>(Arena*);
 template<> ::greptime::v1::frontend::ProcessInfo* Arena::CreateMaybeMessage<::greptime::v1::frontend::ProcessInfo>(Arena*);
@@ -380,6 +389,288 @@ class ListProcessResponse final :
 };
 // -------------------------------------------------------------------
 
+class KillProcessRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.frontend.KillProcessRequest) */ {
+ public:
+  inline KillProcessRequest() : KillProcessRequest(nullptr) {}
+  ~KillProcessRequest() override;
+  explicit PROTOBUF_CONSTEXPR KillProcessRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  KillProcessRequest(const KillProcessRequest& from);
+  KillProcessRequest(KillProcessRequest&& from) noexcept
+    : KillProcessRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline KillProcessRequest& operator=(const KillProcessRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline KillProcessRequest& operator=(KillProcessRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const KillProcessRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const KillProcessRequest* internal_default_instance() {
+    return reinterpret_cast<const KillProcessRequest*>(
+               &_KillProcessRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    2;
+
+  friend void swap(KillProcessRequest& a, KillProcessRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(KillProcessRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(KillProcessRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  KillProcessRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<KillProcessRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const KillProcessRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const KillProcessRequest& from) {
+    KillProcessRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(KillProcessRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "greptime.v1.frontend.KillProcessRequest";
+  }
+  protected:
+  explicit KillProcessRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCatalogFieldNumber = 1,
+    kProcessIdFieldNumber = 2,
+  };
+  // string catalog = 1;
+  void clear_catalog();
+  const std::string& catalog() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_catalog(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_catalog();
+  PROTOBUF_NODISCARD std::string* release_catalog();
+  void set_allocated_catalog(std::string* catalog);
+  private:
+  const std::string& _internal_catalog() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_catalog(const std::string& value);
+  std::string* _internal_mutable_catalog();
+  public:
+
+  // uint64 process_id = 2;
+  void clear_process_id();
+  uint64_t process_id() const;
+  void set_process_id(uint64_t value);
+  private:
+  uint64_t _internal_process_id() const;
+  void _internal_set_process_id(uint64_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:greptime.v1.frontend.KillProcessRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr catalog_;
+    uint64_t process_id_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_greptime_2fv1_2ffrontend_2fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class KillProcessResponse final :
+    public ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase /* @@protoc_insertion_point(class_definition:greptime.v1.frontend.KillProcessResponse) */ {
+ public:
+  inline KillProcessResponse() : KillProcessResponse(nullptr) {}
+  explicit PROTOBUF_CONSTEXPR KillProcessResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  KillProcessResponse(const KillProcessResponse& from);
+  KillProcessResponse(KillProcessResponse&& from) noexcept
+    : KillProcessResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline KillProcessResponse& operator=(const KillProcessResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline KillProcessResponse& operator=(KillProcessResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const KillProcessResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const KillProcessResponse* internal_default_instance() {
+    return reinterpret_cast<const KillProcessResponse*>(
+               &_KillProcessResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    3;
+
+  friend void swap(KillProcessResponse& a, KillProcessResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(KillProcessResponse* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(KillProcessResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  KillProcessResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<KillProcessResponse>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const KillProcessResponse& from) {
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const KillProcessResponse& from) {
+    ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+  public:
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "greptime.v1.frontend.KillProcessResponse";
+  }
+  protected:
+  explicit KillProcessResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:greptime.v1.frontend.KillProcessResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+  };
+  friend struct ::TableStruct_greptime_2fv1_2ffrontend_2fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ProcessInfo final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:greptime.v1.frontend.ProcessInfo) */ {
  public:
@@ -428,7 +719,7 @@ class ProcessInfo final :
                &_ProcessInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   friend void swap(ProcessInfo& a, ProcessInfo& b) {
     a.Swap(&b);
@@ -731,6 +1022,84 @@ ListProcessResponse::processes() const {
   // @@protoc_insertion_point(field_list:greptime.v1.frontend.ListProcessResponse.processes)
   return _impl_.processes_;
 }
+
+// -------------------------------------------------------------------
+
+// KillProcessRequest
+
+// string catalog = 1;
+inline void KillProcessRequest::clear_catalog() {
+  _impl_.catalog_.ClearToEmpty();
+}
+inline const std::string& KillProcessRequest::catalog() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.frontend.KillProcessRequest.catalog)
+  return _internal_catalog();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void KillProcessRequest::set_catalog(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.catalog_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:greptime.v1.frontend.KillProcessRequest.catalog)
+}
+inline std::string* KillProcessRequest::mutable_catalog() {
+  std::string* _s = _internal_mutable_catalog();
+  // @@protoc_insertion_point(field_mutable:greptime.v1.frontend.KillProcessRequest.catalog)
+  return _s;
+}
+inline const std::string& KillProcessRequest::_internal_catalog() const {
+  return _impl_.catalog_.Get();
+}
+inline void KillProcessRequest::_internal_set_catalog(const std::string& value) {
+  
+  _impl_.catalog_.Set(value, GetArenaForAllocation());
+}
+inline std::string* KillProcessRequest::_internal_mutable_catalog() {
+  
+  return _impl_.catalog_.Mutable(GetArenaForAllocation());
+}
+inline std::string* KillProcessRequest::release_catalog() {
+  // @@protoc_insertion_point(field_release:greptime.v1.frontend.KillProcessRequest.catalog)
+  return _impl_.catalog_.Release();
+}
+inline void KillProcessRequest::set_allocated_catalog(std::string* catalog) {
+  if (catalog != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.catalog_.SetAllocated(catalog, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.catalog_.IsDefault()) {
+    _impl_.catalog_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:greptime.v1.frontend.KillProcessRequest.catalog)
+}
+
+// uint64 process_id = 2;
+inline void KillProcessRequest::clear_process_id() {
+  _impl_.process_id_ = uint64_t{0u};
+}
+inline uint64_t KillProcessRequest::_internal_process_id() const {
+  return _impl_.process_id_;
+}
+inline uint64_t KillProcessRequest::process_id() const {
+  // @@protoc_insertion_point(field_get:greptime.v1.frontend.KillProcessRequest.process_id)
+  return _internal_process_id();
+}
+inline void KillProcessRequest::_internal_set_process_id(uint64_t value) {
+  
+  _impl_.process_id_ = value;
+}
+inline void KillProcessRequest::set_process_id(uint64_t value) {
+  _internal_set_process_id(value);
+  // @@protoc_insertion_point(field_set:greptime.v1.frontend.KillProcessRequest.process_id)
+}
+
+// -------------------------------------------------------------------
+
+// KillProcessResponse
 
 // -------------------------------------------------------------------
 
@@ -1054,6 +1423,10 @@ inline void ProcessInfo::set_allocated_frontend(std::string* frontend) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/java/src/main/java/io/greptime/v1/frontend/Server.java
+++ b/java/src/main/java/io/greptime/v1/frontend/Server.java
@@ -1379,6 +1379,1123 @@ public final class Server {
 
   }
 
+  public interface KillProcessRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:greptime.v1.frontend.KillProcessRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Catalog of process to kill.
+     * </pre>
+     *
+     * <code>string catalog = 1;</code>
+     * @return The catalog.
+     */
+    java.lang.String getCatalog();
+    /**
+     * <pre>
+     * Catalog of process to kill.
+     * </pre>
+     *
+     * <code>string catalog = 1;</code>
+     * @return The bytes for catalog.
+     */
+    com.google.protobuf.ByteString
+        getCatalogBytes();
+
+    /**
+     * <pre>
+     * ID of process to kill.
+     * </pre>
+     *
+     * <code>uint64 process_id = 2;</code>
+     * @return The processId.
+     */
+    long getProcessId();
+  }
+  /**
+   * Protobuf type {@code greptime.v1.frontend.KillProcessRequest}
+   */
+  public static final class KillProcessRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:greptime.v1.frontend.KillProcessRequest)
+      KillProcessRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use KillProcessRequest.newBuilder() to construct.
+    private KillProcessRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private KillProcessRequest() {
+      catalog_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new KillProcessRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private KillProcessRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              catalog_ = s;
+              break;
+            }
+            case 16: {
+
+              processId_ = input.readUInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.greptime.v1.frontend.Server.KillProcessRequest.class, io.greptime.v1.frontend.Server.KillProcessRequest.Builder.class);
+    }
+
+    public static final int CATALOG_FIELD_NUMBER = 1;
+    private volatile java.lang.Object catalog_;
+    /**
+     * <pre>
+     * Catalog of process to kill.
+     * </pre>
+     *
+     * <code>string catalog = 1;</code>
+     * @return The catalog.
+     */
+    @java.lang.Override
+    public java.lang.String getCatalog() {
+      java.lang.Object ref = catalog_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        catalog_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Catalog of process to kill.
+     * </pre>
+     *
+     * <code>string catalog = 1;</code>
+     * @return The bytes for catalog.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCatalogBytes() {
+      java.lang.Object ref = catalog_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        catalog_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PROCESS_ID_FIELD_NUMBER = 2;
+    private long processId_;
+    /**
+     * <pre>
+     * ID of process to kill.
+     * </pre>
+     *
+     * <code>uint64 process_id = 2;</code>
+     * @return The processId.
+     */
+    @java.lang.Override
+    public long getProcessId() {
+      return processId_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, catalog_);
+      }
+      if (processId_ != 0L) {
+        output.writeUInt64(2, processId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, catalog_);
+      }
+      if (processId_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(2, processId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.greptime.v1.frontend.Server.KillProcessRequest)) {
+        return super.equals(obj);
+      }
+      io.greptime.v1.frontend.Server.KillProcessRequest other = (io.greptime.v1.frontend.Server.KillProcessRequest) obj;
+
+      if (!getCatalog()
+          .equals(other.getCatalog())) return false;
+      if (getProcessId()
+          != other.getProcessId()) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + CATALOG_FIELD_NUMBER;
+      hash = (53 * hash) + getCatalog().hashCode();
+      hash = (37 * hash) + PROCESS_ID_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getProcessId());
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.greptime.v1.frontend.Server.KillProcessRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code greptime.v1.frontend.KillProcessRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:greptime.v1.frontend.KillProcessRequest)
+        io.greptime.v1.frontend.Server.KillProcessRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.greptime.v1.frontend.Server.KillProcessRequest.class, io.greptime.v1.frontend.Server.KillProcessRequest.Builder.class);
+      }
+
+      // Construct using io.greptime.v1.frontend.Server.KillProcessRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        catalog_ = "";
+
+        processId_ = 0L;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.frontend.Server.KillProcessRequest getDefaultInstanceForType() {
+        return io.greptime.v1.frontend.Server.KillProcessRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.frontend.Server.KillProcessRequest build() {
+        io.greptime.v1.frontend.Server.KillProcessRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.frontend.Server.KillProcessRequest buildPartial() {
+        io.greptime.v1.frontend.Server.KillProcessRequest result = new io.greptime.v1.frontend.Server.KillProcessRequest(this);
+        result.catalog_ = catalog_;
+        result.processId_ = processId_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.greptime.v1.frontend.Server.KillProcessRequest) {
+          return mergeFrom((io.greptime.v1.frontend.Server.KillProcessRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.greptime.v1.frontend.Server.KillProcessRequest other) {
+        if (other == io.greptime.v1.frontend.Server.KillProcessRequest.getDefaultInstance()) return this;
+        if (!other.getCatalog().isEmpty()) {
+          catalog_ = other.catalog_;
+          onChanged();
+        }
+        if (other.getProcessId() != 0L) {
+          setProcessId(other.getProcessId());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.greptime.v1.frontend.Server.KillProcessRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.greptime.v1.frontend.Server.KillProcessRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object catalog_ = "";
+      /**
+       * <pre>
+       * Catalog of process to kill.
+       * </pre>
+       *
+       * <code>string catalog = 1;</code>
+       * @return The catalog.
+       */
+      public java.lang.String getCatalog() {
+        java.lang.Object ref = catalog_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          catalog_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Catalog of process to kill.
+       * </pre>
+       *
+       * <code>string catalog = 1;</code>
+       * @return The bytes for catalog.
+       */
+      public com.google.protobuf.ByteString
+          getCatalogBytes() {
+        java.lang.Object ref = catalog_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          catalog_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Catalog of process to kill.
+       * </pre>
+       *
+       * <code>string catalog = 1;</code>
+       * @param value The catalog to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCatalog(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        catalog_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Catalog of process to kill.
+       * </pre>
+       *
+       * <code>string catalog = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCatalog() {
+        
+        catalog_ = getDefaultInstance().getCatalog();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Catalog of process to kill.
+       * </pre>
+       *
+       * <code>string catalog = 1;</code>
+       * @param value The bytes for catalog to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCatalogBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        catalog_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long processId_ ;
+      /**
+       * <pre>
+       * ID of process to kill.
+       * </pre>
+       *
+       * <code>uint64 process_id = 2;</code>
+       * @return The processId.
+       */
+      @java.lang.Override
+      public long getProcessId() {
+        return processId_;
+      }
+      /**
+       * <pre>
+       * ID of process to kill.
+       * </pre>
+       *
+       * <code>uint64 process_id = 2;</code>
+       * @param value The processId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setProcessId(long value) {
+        
+        processId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of process to kill.
+       * </pre>
+       *
+       * <code>uint64 process_id = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearProcessId() {
+        
+        processId_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:greptime.v1.frontend.KillProcessRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:greptime.v1.frontend.KillProcessRequest)
+    private static final io.greptime.v1.frontend.Server.KillProcessRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.greptime.v1.frontend.Server.KillProcessRequest();
+    }
+
+    public static io.greptime.v1.frontend.Server.KillProcessRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<KillProcessRequest>
+        PARSER = new com.google.protobuf.AbstractParser<KillProcessRequest>() {
+      @java.lang.Override
+      public KillProcessRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new KillProcessRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<KillProcessRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<KillProcessRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.greptime.v1.frontend.Server.KillProcessRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface KillProcessResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:greptime.v1.frontend.KillProcessResponse)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code greptime.v1.frontend.KillProcessResponse}
+   */
+  public static final class KillProcessResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:greptime.v1.frontend.KillProcessResponse)
+      KillProcessResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use KillProcessResponse.newBuilder() to construct.
+    private KillProcessResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private KillProcessResponse() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new KillProcessResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private KillProcessResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.greptime.v1.frontend.Server.KillProcessResponse.class, io.greptime.v1.frontend.Server.KillProcessResponse.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.greptime.v1.frontend.Server.KillProcessResponse)) {
+        return super.equals(obj);
+      }
+      io.greptime.v1.frontend.Server.KillProcessResponse other = (io.greptime.v1.frontend.Server.KillProcessResponse) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.greptime.v1.frontend.Server.KillProcessResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.greptime.v1.frontend.Server.KillProcessResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code greptime.v1.frontend.KillProcessResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:greptime.v1.frontend.KillProcessResponse)
+        io.greptime.v1.frontend.Server.KillProcessResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.greptime.v1.frontend.Server.KillProcessResponse.class, io.greptime.v1.frontend.Server.KillProcessResponse.Builder.class);
+      }
+
+      // Construct using io.greptime.v1.frontend.Server.KillProcessResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.greptime.v1.frontend.Server.internal_static_greptime_v1_frontend_KillProcessResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.frontend.Server.KillProcessResponse getDefaultInstanceForType() {
+        return io.greptime.v1.frontend.Server.KillProcessResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.frontend.Server.KillProcessResponse build() {
+        io.greptime.v1.frontend.Server.KillProcessResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.greptime.v1.frontend.Server.KillProcessResponse buildPartial() {
+        io.greptime.v1.frontend.Server.KillProcessResponse result = new io.greptime.v1.frontend.Server.KillProcessResponse(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.greptime.v1.frontend.Server.KillProcessResponse) {
+          return mergeFrom((io.greptime.v1.frontend.Server.KillProcessResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.greptime.v1.frontend.Server.KillProcessResponse other) {
+        if (other == io.greptime.v1.frontend.Server.KillProcessResponse.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        io.greptime.v1.frontend.Server.KillProcessResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (io.greptime.v1.frontend.Server.KillProcessResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:greptime.v1.frontend.KillProcessResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:greptime.v1.frontend.KillProcessResponse)
+    private static final io.greptime.v1.frontend.Server.KillProcessResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.greptime.v1.frontend.Server.KillProcessResponse();
+    }
+
+    public static io.greptime.v1.frontend.Server.KillProcessResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<KillProcessResponse>
+        PARSER = new com.google.protobuf.AbstractParser<KillProcessResponse>() {
+      @java.lang.Override
+      public KillProcessResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new KillProcessResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<KillProcessResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<KillProcessResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.greptime.v1.frontend.Server.KillProcessResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface ProcessInfoOrBuilder extends
       // @@protoc_insertion_point(interface_extends:greptime.v1.frontend.ProcessInfo)
       com.google.protobuf.MessageOrBuilder {
@@ -3024,6 +4141,16 @@ public final class Server {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_greptime_v1_frontend_ListProcessResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_frontend_KillProcessRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_frontend_KillProcessRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_greptime_v1_frontend_KillProcessResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_greptime_v1_frontend_KillProcessResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_greptime_v1_frontend_ProcessInfo_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -3041,16 +4168,20 @@ public final class Server {
       "ptime.v1.frontend\"%\n\022ListProcessRequest\022" +
       "\017\n\007catalog\030\001 \001(\t\"K\n\023ListProcessResponse\022" +
       "4\n\tprocesses\030\001 \003(\0132!.greptime.v1.fronten" +
-      "d.ProcessInfo\"\205\001\n\013ProcessInfo\022\n\n\002id\030\001 \001(" +
-      "\004\022\017\n\007catalog\030\002 \001(\t\022\017\n\007schemas\030\003 \003(\t\022\r\n\005q" +
-      "uery\030\004 \001(\t\022\027\n\017start_timestamp\030\005 \001(\003\022\016\n\006c" +
-      "lient\030\006 \001(\t\022\020\n\010frontend\030\007 \001(\t2n\n\010Fronten" +
-      "d\022b\n\013ListProcess\022(.greptime.v1.frontend." +
-      "ListProcessRequest\032).greptime.v1.fronten" +
-      "d.ListProcessResponseBa\n\027io.greptime.v1." +
-      "frontendB\006ServerZ>github.com/GreptimeTea" +
-      "m/greptime-proto/go/greptime/v1/frontend" +
-      "b\006proto3"
+      "d.ProcessInfo\"9\n\022KillProcessRequest\022\017\n\007c" +
+      "atalog\030\001 \001(\t\022\022\n\nprocess_id\030\002 \001(\004\"\025\n\023Kill" +
+      "ProcessResponse\"\205\001\n\013ProcessInfo\022\n\n\002id\030\001 " +
+      "\001(\004\022\017\n\007catalog\030\002 \001(\t\022\017\n\007schemas\030\003 \003(\t\022\r\n" +
+      "\005query\030\004 \001(\t\022\027\n\017start_timestamp\030\005 \001(\003\022\016\n" +
+      "\006client\030\006 \001(\t\022\020\n\010frontend\030\007 \001(\t2\322\001\n\010Fron" +
+      "tend\022b\n\013ListProcess\022(.greptime.v1.fronte" +
+      "nd.ListProcessRequest\032).greptime.v1.fron" +
+      "tend.ListProcessResponse\022b\n\013KillProcess\022" +
+      "(.greptime.v1.frontend.KillProcessReques" +
+      "t\032).greptime.v1.frontend.KillProcessResp" +
+      "onseBa\n\027io.greptime.v1.frontendB\006ServerZ" +
+      ">github.com/GreptimeTeam/greptime-proto/" +
+      "go/greptime/v1/frontendb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -3068,8 +4199,20 @@ public final class Server {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_frontend_ListProcessResponse_descriptor,
         new java.lang.String[] { "Processes", });
-    internal_static_greptime_v1_frontend_ProcessInfo_descriptor =
+    internal_static_greptime_v1_frontend_KillProcessRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
+    internal_static_greptime_v1_frontend_KillProcessRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_frontend_KillProcessRequest_descriptor,
+        new java.lang.String[] { "Catalog", "ProcessId", });
+    internal_static_greptime_v1_frontend_KillProcessResponse_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_greptime_v1_frontend_KillProcessResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_greptime_v1_frontend_KillProcessResponse_descriptor,
+        new java.lang.String[] { });
+    internal_static_greptime_v1_frontend_ProcessInfo_descriptor =
+      getDescriptor().getMessageTypes().get(4);
     internal_static_greptime_v1_frontend_ProcessInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_greptime_v1_frontend_ProcessInfo_descriptor,

--- a/proto/greptime/v1/frontend/server.proto
+++ b/proto/greptime/v1/frontend/server.proto
@@ -23,6 +23,8 @@ option go_package = "github.com/GreptimeTeam/greptime-proto/go/greptime/v1/front
 service Frontend {
   // List all running processes on frontend.
   rpc ListProcess(ListProcessRequest) returns (ListProcessResponse);
+  // Kill a running process on frontend.
+  rpc KillProcess(KillProcessRequest) returns (KillProcessResponse);
 }
 
 message ListProcessRequest {
@@ -32,6 +34,15 @@ message ListProcessRequest {
 message ListProcessResponse {
   repeated ProcessInfo processes = 1;
 }
+
+message KillProcessRequest {
+  // Catalog of process to kill.
+  string catalog = 1;
+  // ID of process to kill.
+  uint64 process_id = 2;
+}
+
+message KillProcessResponse {}
 
 message ProcessInfo {
   // ID.


### PR DESCRIPTION
 ### Add KillProcess RPC Method

 - **Added `KillProcess` RPC Method**: Introduced a new RPC method `KillProcess` in the `Frontend` service to allow killing a running process on the frontend.
   - Updated files: `server.grpc.pb.cc`, `server.grpc.pb.h`, `server.pb.cc`, `server.pb.h`, `server.proto`
   - Added new request and response messages: `KillProcessRequest` and `KillProcessResponse`.

 - **Java Bindings**: Updated Java bindings to include the new `KillProcess` method.
   - Updated file: `Server.java`

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

__!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.
