### PR TITLE
chore: change process id from u64 to u32

### DIFF
--- a/c++/greptime/v1/frontend/server.pb.cc
+++ b/c++/greptime/v1/frontend/server.pb.cc
@@ -53,7 +53,7 @@ PROTOBUF_CONSTEXPR KillProcessRequest::KillProcessRequest(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.server_addr_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.catalog_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.process_id_)*/uint64_t{0u}
+  , /*decltype(_impl_.process_id_)*/0u
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct KillProcessRequestDefaultTypeInternal {
   PROTOBUF_CONSTEXPR KillProcessRequestDefaultTypeInternal()
@@ -171,7 +171,7 @@ const char descriptor_table_protodef_greptime_2fv1_2ffrontend_2fserver_2eproto[]
   "4\n\tprocesses\030\001 \003(\0132!.greptime.v1.fronten"
   "d.ProcessInfo\"N\n\022KillProcessRequest\022\023\n\013s"
   "erver_addr\030\001 \001(\t\022\017\n\007catalog\030\002 \001(\t\022\022\n\npro"
-  "cess_id\030\003 \001(\004\"&\n\023KillProcessResponse\022\017\n\007"
+  "cess_id\030\003 \001(\r\"&\n\023KillProcessResponse\022\017\n\007"
   "success\030\001 \001(\010\"\205\001\n\013ProcessInfo\022\n\n\002id\030\001 \001("
   "\r\022\017\n\007catalog\030\002 \001(\t\022\017\n\007schemas\030\003 \003(\t\022\r\n\005q"
   "uery\030\004 \001(\t\022\027\n\017start_timestamp\030\005 \001(\003\022\016\n\006c"
@@ -641,7 +641,7 @@ inline void KillProcessRequest::SharedCtor(
   new (&_impl_) Impl_{
       decltype(_impl_.server_addr_){}
     , decltype(_impl_.catalog_){}
-    , decltype(_impl_.process_id_){uint64_t{0u}}
+    , decltype(_impl_.process_id_){0u}
     , /*decltype(_impl_._cached_size_)*/{}
   };
   _impl_.server_addr_.InitDefault();
@@ -681,7 +681,7 @@ void KillProcessRequest::Clear() {
 
   _impl_.server_addr_.ClearToEmpty();
   _impl_.catalog_.ClearToEmpty();
-  _impl_.process_id_ = uint64_t{0u};
+  _impl_.process_id_ = 0u;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -711,10 +711,10 @@ const char* KillProcessRequest::_InternalParse(const char* ptr, ::_pbi::ParseCon
         } else
           goto handle_unusual;
         continue;
-      // uint64 process_id = 3;
+      // uint32 process_id = 3;
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
-          _impl_.process_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          _impl_.process_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -768,10 +768,10 @@ uint8_t* KillProcessRequest::_InternalSerialize(
         2, this->_internal_catalog(), target);
   }
 
-  // uint64 process_id = 3;
+  // uint32 process_id = 3;
   if (this->_internal_process_id() != 0) {
     target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(3, this->_internal_process_id(), target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(3, this->_internal_process_id(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -804,9 +804,9 @@ size_t KillProcessRequest::ByteSizeLong() const {
         this->_internal_catalog());
   }
 
-  // uint64 process_id = 3;
+  // uint32 process_id = 3;
   if (this->_internal_process_id() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_process_id());
+    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_process_id());
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);

--- a/c++/greptime/v1/frontend/server.pb.h
+++ b/c++/greptime/v1/frontend/server.pb.h
@@ -541,13 +541,13 @@ class KillProcessRequest final :
   std::string* _internal_mutable_catalog();
   public:
 
-  // uint64 process_id = 3;
+  // uint32 process_id = 3;
   void clear_process_id();
-  uint64_t process_id() const;
-  void set_process_id(uint64_t value);
+  uint32_t process_id() const;
+  void set_process_id(uint32_t value);
   private:
-  uint64_t _internal_process_id() const;
-  void _internal_set_process_id(uint64_t value);
+  uint32_t _internal_process_id() const;
+  void _internal_set_process_id(uint32_t value);
   public:
 
   // @@protoc_insertion_point(class_scope:greptime.v1.frontend.KillProcessRequest)
@@ -560,7 +560,7 @@ class KillProcessRequest final :
   struct Impl_ {
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr server_addr_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr catalog_;
-    uint64_t process_id_;
+    uint32_t process_id_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -1172,22 +1172,22 @@ inline void KillProcessRequest::set_allocated_catalog(std::string* catalog) {
   // @@protoc_insertion_point(field_set_allocated:greptime.v1.frontend.KillProcessRequest.catalog)
 }
 
-// uint64 process_id = 3;
+// uint32 process_id = 3;
 inline void KillProcessRequest::clear_process_id() {
-  _impl_.process_id_ = uint64_t{0u};
+  _impl_.process_id_ = 0u;
 }
-inline uint64_t KillProcessRequest::_internal_process_id() const {
+inline uint32_t KillProcessRequest::_internal_process_id() const {
   return _impl_.process_id_;
 }
-inline uint64_t KillProcessRequest::process_id() const {
+inline uint32_t KillProcessRequest::process_id() const {
   // @@protoc_insertion_point(field_get:greptime.v1.frontend.KillProcessRequest.process_id)
   return _internal_process_id();
 }
-inline void KillProcessRequest::_internal_set_process_id(uint64_t value) {
+inline void KillProcessRequest::_internal_set_process_id(uint32_t value) {
   
   _impl_.process_id_ = value;
 }
-inline void KillProcessRequest::set_process_id(uint64_t value) {
+inline void KillProcessRequest::set_process_id(uint32_t value) {
   _internal_set_process_id(value);
   // @@protoc_insertion_point(field_set:greptime.v1.frontend.KillProcessRequest.process_id)
 }

--- a/java/src/main/java/io/greptime/v1/frontend/Server.java
+++ b/java/src/main/java/io/greptime/v1/frontend/Server.java
@@ -1428,10 +1428,10 @@ public final class Server {
      * ID of process to kill.
      * </pre>
      *
-     * <code>uint64 process_id = 3;</code>
+     * <code>uint32 process_id = 3;</code>
      * @return The processId.
      */
-    long getProcessId();
+    int getProcessId();
   }
   /**
    * Protobuf type {@code greptime.v1.frontend.KillProcessRequest}
@@ -1494,7 +1494,7 @@ public final class Server {
             }
             case 24: {
 
-              processId_ = input.readUInt64();
+              processId_ = input.readUInt32();
               break;
             }
             default: {
@@ -1624,17 +1624,17 @@ public final class Server {
     }
 
     public static final int PROCESS_ID_FIELD_NUMBER = 3;
-    private long processId_;
+    private int processId_;
     /**
      * <pre>
      * ID of process to kill.
      * </pre>
      *
-     * <code>uint64 process_id = 3;</code>
+     * <code>uint32 process_id = 3;</code>
      * @return The processId.
      */
     @java.lang.Override
-    public long getProcessId() {
+    public int getProcessId() {
       return processId_;
     }
 
@@ -1658,8 +1658,8 @@ public final class Server {
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, catalog_);
       }
-      if (processId_ != 0L) {
-        output.writeUInt64(3, processId_);
+      if (processId_ != 0) {
+        output.writeUInt32(3, processId_);
       }
       unknownFields.writeTo(output);
     }
@@ -1676,9 +1676,9 @@ public final class Server {
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalog_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, catalog_);
       }
-      if (processId_ != 0L) {
+      if (processId_ != 0) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(3, processId_);
+          .computeUInt32Size(3, processId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1717,8 +1717,7 @@ public final class Server {
       hash = (37 * hash) + CATALOG_FIELD_NUMBER;
       hash = (53 * hash) + getCatalog().hashCode();
       hash = (37 * hash) + PROCESS_ID_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getProcessId());
+      hash = (53 * hash) + getProcessId();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -1856,7 +1855,7 @@ public final class Server {
 
         catalog_ = "";
 
-        processId_ = 0L;
+        processId_ = 0;
 
         return this;
       }
@@ -1943,7 +1942,7 @@ public final class Server {
           catalog_ = other.catalog_;
           onChanged();
         }
-        if (other.getProcessId() != 0L) {
+        if (other.getProcessId() != 0) {
           setProcessId(other.getProcessId());
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -2167,17 +2166,17 @@ public final class Server {
         return this;
       }
 
-      private long processId_ ;
+      private int processId_ ;
       /**
        * <pre>
        * ID of process to kill.
        * </pre>
        *
-       * <code>uint64 process_id = 3;</code>
+       * <code>uint32 process_id = 3;</code>
        * @return The processId.
        */
       @java.lang.Override
-      public long getProcessId() {
+      public int getProcessId() {
         return processId_;
       }
       /**
@@ -2185,11 +2184,11 @@ public final class Server {
        * ID of process to kill.
        * </pre>
        *
-       * <code>uint64 process_id = 3;</code>
+       * <code>uint32 process_id = 3;</code>
        * @param value The processId to set.
        * @return This builder for chaining.
        */
-      public Builder setProcessId(long value) {
+      public Builder setProcessId(int value) {
         
         processId_ = value;
         onChanged();
@@ -2200,12 +2199,12 @@ public final class Server {
        * ID of process to kill.
        * </pre>
        *
-       * <code>uint64 process_id = 3;</code>
+       * <code>uint32 process_id = 3;</code>
        * @return This builder for chaining.
        */
       public Builder clearProcessId() {
         
-        processId_ = 0L;
+        processId_ = 0;
         onChanged();
         return this;
       }
@@ -4446,7 +4445,7 @@ public final class Server {
       "4\n\tprocesses\030\001 \003(\0132!.greptime.v1.fronten" +
       "d.ProcessInfo\"N\n\022KillProcessRequest\022\023\n\013s" +
       "erver_addr\030\001 \001(\t\022\017\n\007catalog\030\002 \001(\t\022\022\n\npro" +
-      "cess_id\030\003 \001(\004\"&\n\023KillProcessResponse\022\017\n\007" +
+      "cess_id\030\003 \001(\r\"&\n\023KillProcessResponse\022\017\n\007" +
       "success\030\001 \001(\010\"\205\001\n\013ProcessInfo\022\n\n\002id\030\001 \001(" +
       "\r\022\017\n\007catalog\030\002 \001(\t\022\017\n\007schemas\030\003 \003(\t\022\r\n\005q" +
       "uery\030\004 \001(\t\022\027\n\017start_timestamp\030\005 \001(\003\022\016\n\006c" +

--- a/proto/greptime/v1/frontend/server.proto
+++ b/proto/greptime/v1/frontend/server.proto
@@ -41,7 +41,7 @@ message KillProcessRequest {
   // Catalog of process to kill.
   string catalog = 2;
   // ID of process to kill.
-  uint64 process_id = 3;
+  uint32 process_id = 3;
 }
 
 message KillProcessResponse {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)


## What's changed and what's your intention?

Add connection id field to Process message.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.
