### PR TITLE
refactor: genetate protobuf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -5,8 +7,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-
-name: CI
 
 env:
   RUST_TOOLCHAIN: stable
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.18.4"
+          go-version: "1.24.3"
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,10 +40,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run cargo check
         run: cargo check --workspace --all-targets
-      - name: Check Go protbuf generation
+      - name: Generate protbuf
         run: |
-          make go
-          test $(git status --porcelain=v1 | wc -l) -eq 0 || (echo "Fail: generated go protobuf in github action is different from pushed ones" ; exit 1)
+          make all  
+      - name: Check protobuf generation
+        run: |
+          git diff --quiet || (echo "Fail: generated go protobuf in github action is different from pushed ones, please run 'make all'"; exit 1)
 
   proto-fmt:
     name: Protobuf Format
@@ -96,3 +98,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings -D clippy::print_stdout -D clippy::print_stderr
+

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -2,17 +2,8 @@
 
 set -e
 
+PROTO_ROOT=./proto
 GO_OUTPUT=./go
 
-# TODO(zyy17): Can we make the following commands as one command?
-protoc --go_out=${GO_OUTPUT} --go_opt=paths=source_relative \
-       --go-grpc_out=${GO_OUTPUT}  --go-grpc_opt=paths=source_relative \
-       -Iproto proto/greptime/v1/**/*.proto
+protoc -I=${PROTO_ROOT} --go_out=paths=source_relative:${GO_OUTPUT} $(find  ./proto/  -type f  -iname "*.proto")
 
-protoc --go_out=${GO_OUTPUT}  --go_opt=paths=source_relative \
-       --go-grpc_out=${GO_OUTPUT}  --go-grpc_opt=paths=source_relative \
-       -Iproto proto/prometheus/**/*.proto
-
-protoc --go_out=${GO_OUTPUT}  --go_opt=paths=source_relative \
-       --go-grpc_out=${GO_OUTPUT}  --go-grpc_opt=paths=source_relative \
-       -Iproto proto/substrait_extension/*.proto


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Bump setup-go action to 1.24.3
- Rename `main.yml` to `ci.yml`
- Use `*.proto` to generate go protobuf more easily in `generate-go.sh`.
- Add check generate protbuf step in ci workflow.

## Checklist

- [ ]  I have written the necessary comments.
- [ ]  I have added the necessary unit tests and integration tests.
