### PR TITLE
fix: protoc-all image build with archived Bullseye sources

### DIFF
--- a/docker/protoc-all/Dockerfile
+++ b/docker/protoc-all/Dockerfile
@@ -9,12 +9,7 @@ ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH=/usr/local/cargo/bin:${PATH}
 
-RUN rm -f /etc/apt/sources.list.d/nodesource.list \
-    && printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/* \
-    && rustc --version \
+RUN rustc --version \
     && cargo --version \
     && protoc --version \
     && chmod -R a+rwX /usr/local/cargo /usr/local/rustup

--- a/docker/protoc-all/Dockerfile
+++ b/docker/protoc-all/Dockerfile
@@ -9,7 +9,12 @@ ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH=/usr/local/cargo/bin:${PATH}
 
-RUN rustc --version \
+RUN rm -f /etc/apt/sources.list.d/nodesource.list \
+    && printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && rustc --version \
     && cargo --version \
     && protoc --version \
     && chmod -R a+rwX /usr/local/cargo /usr/local/rustup

--- a/docker/protoc-all/Dockerfile
+++ b/docker/protoc-all/Dockerfile
@@ -10,6 +10,7 @@ ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH=/usr/local/cargo/bin:${PATH}
 
 RUN rm -f /etc/apt/sources.list.d/nodesource.list \
+    && printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
I hereby agree to the terms of the GreptimeDB CLA.

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

I hint an [error](https://github.com/GreptimeTeam/greptime-proto/actions/runs/34098404290/job/101667062728?pr=336).

Since the `protoc-all` base image uses outdated Debian Bullseye apt sources, which can make `apt-get update` fail. This pr switches apt to archived Bullseye sources before installing it.

## Checklist

- [ ] I have written the necessary comments.
- [ ] I have added the necessary unit tests and integration tests.